### PR TITLE
Fit codex-delegate description under ZCode's 1024-char cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ CLI flag, field, and command in the docs must match the installed `codex` and `r
   `license`, `compatibility`, `metadata.version`, `allowed-tools`. The **`description` is the only
   triggering signal** — keep it to what the skill does and when to use it, phrased to trigger reliably.
   Provenance, status caveats, and how-it-works detail go in the body or here, never in the description.
+  Keep `description` **under 1024 characters** — some orchestrators (e.g. ZCode) hard-cap it and reject
+  the skill otherwise.
 - **Progressive disclosure:** keep `SKILL.md` lean; push depth into `references/*.md` that load only
   when needed.
 - **Executables:** keep them minimal and inspectable. The only one today is

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -4,14 +4,11 @@ description: >-
   Delegate a coding task to the OpenAI Codex CLI as a background implementer, then review its diff and
   land it yourself. Use this whenever the user wants to hand implementation work to Codex — phrasings
   like "have Codex do X", "delegate this to Codex", "run it through Codex", or "use Codex to
-  implement/fix/refactor" — or wants to run a queue of coding tasks through Codex while staying the
-  reviewer. Prefer it over a one-shot Codex forwarder (such as the codex-rescue agent) specifically
-  when the user will review the resulting diff and commit it themselves, or wants the full
-  brief → dispatch → review → commit loop across a single task or a queue. Also reach for it proactively
-  for a separate implementation pass on a bounded, well-specified task (an implementation sweep, a
-  migration, a mechanical refactor, parallel work). Covers writing the Codex brief, dispatching it via
-  the bundled relay.mjs helper, waiting for completion, reviewing the result, and committing. DO NOT USE
-  for tasks small enough to do inline, or when the user wants the code written directly without
+  implement/fix/refactor" — or to run a queue of coding tasks through Codex while staying the reviewer.
+  Prefer it over a one-shot Codex forwarder (such as the codex-rescue agent) when the user will review
+  the resulting diff and commit it themselves. Also reach for it proactively for a separate
+  implementation pass on a bounded task — a migration, a mechanical refactor, a removal sweep. DO NOT
+  USE for tasks small enough to do inline, or when the user wants the code written directly without
   delegating.
 license: MIT
 compatibility: Requires the `codex` CLI (OpenAI Codex) installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).


### PR DESCRIPTION
## What

ZCode rejects the `codex-delegate` skill with:

```
`description` exceeds 1024 chars
Skill description is too long (>1024): codex-delegate
```

Claude Code imposes no such cap, so the long description loaded fine there and the limit went unnoticed until the skill was loaded in ZCode.

## Changes

- **`SKILL.md`** — trim the `description` from **1086 → 794 chars** (230 under the cap). Cut the redundant "Covers writing the Codex brief…" sentence and tighten the proactive/disambiguation clauses. **Every trigger phrase** (`have Codex do X`, `delegate this to Codex`, `run it through Codex`, `use Codex to implement/fix/refactor`) **and the codex-rescue disambiguation are preserved.**
- **`AGENTS.md`** — document the 1024-char limit in the frontmatter conventions so it can't silently regress.

## Why this slipped through

It's a cross-orchestrator compatibility limit that only surfaces on a target that enforces it (ZCode). Same lesson as earlier package fixes: real coverage needs the real target — Claude Code-only validation can't catch a ZCode-only cap.

## Verification

- `description` parses to 794 chars (≤ 1024) ✓
- All trigger phrases + codex-rescue distinction retained ✓
- SKILL.md frontmatter is valid YAML ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #4