### PR TITLE
Quote relay's -o path on Windows so spaced temp dirs don't split

### DIFF
--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -159,7 +159,12 @@ function timestamp() {
 function buildArgv(opts, finalPath) {
   const argv = ["exec"];
   if (opts.resumeLast) argv.push("resume", "--last");
-  argv.push("--json", "-o", finalPath);
+  // ponytail: shell:true on win32 (needed for the codex.cmd shim) doesn't quote
+  // args, so a temp path with spaces (C:\Users\First Last\...) splits and the
+  // trailing "-" misparses (issue #3). Quote the only spaceable arg in argv.
+  // Ceiling: if quoting proves too blunt, drop shell:true and resolve the shim.
+  const outPath = process.platform === "win32" ? `"${finalPath}"` : finalPath;
+  argv.push("--json", "-o", outPath);
   // `-s`/`-C` are not accepted by `exec resume`; resume inherits the original
   // session's sandbox and working root, and we set the child process cwd below.
   if (!opts.resumeLast) {


### PR DESCRIPTION
## What

On Windows, `relay.mjs` fails with `error: unexpected argument '-' found` when the default temp out-dir path contains a space (e.g. `C:\Users\Mahmoud Sabry\...`).

## Root cause

`spawn("codex", argv, { shell: true })` — `shell:true` is required on win32 to resolve the npm `codex.cmd` shim, but it does **not** quote args. So `-o C:\Users\Mahmoud Sabry\...\final.txt` splits on the space, and the trailing `-` (stdin marker) becomes a stray argument.

## Fix

Quote the only spaceable arg in `argv` (the `-o` output path) on win32:

```js
const outPath = process.platform === "win32" ? `"${finalPath}"` : finalPath;
argv.push("--json", "-o", outPath);
```

POSIX unchanged. Ceiling noted in a `ponytail:` comment: if quoting ever proves too blunt, drop `shell:true` and resolve the shim explicitly instead.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)