### PR TITLE
Prune recap sections from SKILL.md and tighten the description

### DIFF
--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -6,10 +6,8 @@ description: >-
   like "have Codex do X", "delegate this to Codex", "run it through Codex", or "use Codex to
   implement/fix/refactor" — or to run a queue of coding tasks through Codex while staying the reviewer.
   Prefer it over a one-shot Codex forwarder (such as the codex-rescue agent) when the user will review
-  the resulting diff and commit it themselves. Also reach for it proactively for a separate
-  implementation pass on a bounded task — a migration, a mechanical refactor, a removal sweep. DO NOT
-  USE for tasks small enough to do inline, or when the user wants the code written directly without
-  delegating.
+  the diff and commit it themselves. DO NOT USE for tasks small enough to do inline, or when the user
+  wants the code written directly without delegating.
 license: MIT
 compatibility: Requires the `codex` CLI (OpenAI Codex) installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
@@ -113,13 +111,6 @@ orchestrator commits.** Only after the gates pass and the diff holds:
 - If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
   review again.
 
-## Non-negotiables
-
-- **Re-run the gates yourself.** The self-report is a claim, not evidence.
-- **The orchestrator commits, never Codex.** Don't assume Codex committed; it didn't.
-- **One task = one brief = one commit.** Split unrelated work into separate runs.
-- **Trust the working tree and process state** over any progress tracker.
-
 ## Authorization model
 
 Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
@@ -128,13 +119,6 @@ mandate: **surface, don't absorb** (report Codex's design decisions, defensible-
 non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if correct
 completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
 is in [references/review-and-land.md](references/review-and-land.md).
-
-## Trust and safety
-
-`scripts/relay.mjs` itself makes no network calls, reads or writes no credentials, and sends no
-telemetry; it has no dependencies (Node built-ins only) and shells out only to `codex` and `git`. The
-`codex` process it launches does authenticate — exactly as you do at the terminal. Read the script
-before you run it. It is the one executable in this package; everything else is Markdown.
 
 ## References
 
@@ -146,11 +130,3 @@ before you run it. It is the one executable in this package; everything else is 
   boundary, and the rework cycle via `--resume-last`.
 - [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
   carrying constraints forward, progress tracking, and the end-of-run coherence check.
-
-## What this skill does NOT do
-
-- It does not commit for you — that is deliberate (step 5).
-- It does not review the code's quality itself — pair it with guard skills.
-- It does not run your tests — you re-run the project's own gates in step 4.
-- It is not the inverse direction (Codex reviewing your work). For that, use the openai-codex plugin's
-  review command or stop-review gate.


### PR DESCRIPTION
## What

Deletes three SKILL.md sections and one description clause that behavioral testing showed to be no-ops. SKILL.md: 9,137 → 7,851 chars (−26 lines). Description: 794 → 646 chars.

## How this was validated

**Deletion A/B tests** — 30 runs: 5 skill variants (baseline, each section removed, all three removed) × 3 adversarial scenarios × 2 samples. Scenarios were built to hit each section's unique content:

| Behavior probed | baseline | all three sections removed |
|---|---|---|
| Re-runs gates despite user pressure to "just land it now" | 2/2 | 2/2 |
| Checks git state instead of trusting a false "I committed it" claim | 2/2 | 2/2 |
| Commits each queue task before dispatching the next | 2/2 | 2/2 |
| Refuses Codex's gate claim / orchestrator commits | 2/2 | 2/2 |

No behavior flipped in any variant. The loop's steps already carry every rule the recaps restated: re-run gates (step 4), orchestrator commits (step 5), one task per brief (step 1), trust the tree over trackers (step 3).

**Trigger tests** — 8 prompts (explicit, proactive-without-naming-Codex, queue phrasing, and near-misses like "consult Codex then implement yourself") × 3 samples per description: current and trimmed both scored 24/24. The "reach for it proactively" clause is redundant with the background-implementer / stay-the-reviewer framing.

## Removed

- `## Non-negotiables` — all four bullets duplicated in steps 1/3/4/5
- `## Trust and safety` — install-time trust info; remains in the README and the relay.mjs header where humans actually read it
- `## What this skill does NOT do` — duplicated across "When NOT to use", step 4, and step 5
- description: the proactive clause

## Not changed

References, the five-step loop, Authorization model, and all trigger phrasings ("have Codex do X", "delegate this to Codex", the codex-rescue disambiguation) are intact and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)