### PR TITLE
Make review-and-land.md catch gate-gamed diffs on its own

### DIFF
--- a/skills/codex-delegate/references/review-and-land.md
+++ b/skills/codex-delegate/references/review-and-land.md
@@ -2,14 +2,28 @@
 
 Codex did the typing; you own the judgment. This is where delegation earns its keep or quietly ships a
 mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
-reality, never against the self-report, then commit it yourself.**
+reality, never against the self-report — and read the diff as generated code, which fails in ways a
+green gate can't see.**
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
 
 ## Re-run the gates yourself
 
 `result.json` carries Codex's own claim that the gates passed. Treat that as a claim, not evidence —
-re-run the project's actual test/lint/build commands in the working tree and read the output. A run
-that "passed" in Codex's report but fails when you run it is exactly the failure this step exists to
-catch, and it happens often enough to be worth the minute every time.
+re-run the project's actual test/lint/build commands in the working tree and read the output. And keep
+the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a gate,
+not just misreport it — that is what the test check above and the sweep below exist to catch.
 
 For changes with their own verification shape, go further:
 
@@ -30,13 +44,38 @@ for:
 - **Quiet judgment calls** — sometimes Codex makes a defensible decision the brief didn't anticipate.
   Don't just accept it because it looks reasonable; understand it and decide.
 
-## Compose with guard skills
+## The implementer sweep
 
-This skill produces the work; it doesn't judge code quality. If you have the `guard-skills` package
-installed, run the relevant guard on Codex's diff before you commit — `clean-code-guard` on production
-code, `test-guard` on any tests it wrote, `docs-guard` on documentation. They catch the systematic
-failure modes of generated code that a quick read misses. The two packages are designed to pair:
-delegate-skills delegates and lands; guard-skills reviews.
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If Codex couldn't implement something,
+  the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to Codex as a delta brief (below) or gets fixed in the tree before
+commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
 
 ## The commit boundary
 
@@ -59,8 +98,8 @@ drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-las
 (`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
 
 `--resume-last` keeps Codex's context from the first run, so a short delta is enough. Then review
-again — rework gets the same gate-rerun and diff-read as the original, no shortcuts. Repeat until it's
-right, then commit.
+again — rework gets the same gate-rerun, test check, diff-read, and sweep as the original, no
+shortcuts. Repeat until it's right, then commit.
 
 ## Surface, don't absorb
 


### PR DESCRIPTION
## What

Rewrites the review half of `references/review-and-land.md` (74 → 115 lines) so the review step catches what a green gate structurally cannot — with no companion skills required.

## The gap

The reference's main defense was "re-run the gates yourself." That defends against a *dishonest report*, not a *gamed gate*: a hardcoded success fallback passes tests by design; a skipped test or loosened assertion makes the suite measure less than it did before the run. All the operational "what to look for in generated code" knowledge lived behind an optional pointer to a separate package — a solo install got no quality lens at all.

## Changes

- **"Check the tests before trusting the gates"** (new, deliberately ordered first): unbriefed edits to existing tests are a contract change, not part of the fix; added skips/disables and loosened assertions are treated as failing until justified.
- **"The implementer sweep"** (new): nine one-line checks for failure shapes gates are blind to — hardcoded success/fixture returns, catch-all handlers returning defaults, unverified imports/APIs, dead weight and comment scaffolding, style forks beside existing patterns, internals-asserting tests, near-duplicate test bodies, speculative surface, impossible-case guards.
- **Gate re-run reframed:** passing is necessary, not sufficient.
- **guard-skills** becomes a one-line "for depth" escalation instead of the review mechanism; the sweep is the built-in floor.
- Commit boundary, delta rework, and surface-don't-absorb sections unchanged (rework now explicitly repeats the test check and sweep).

## Validation

A/B with blinded reviewers (findings graded post-hoc against the seeded-defect list, schema gave no hints) on a gates-genuinely-green diff seeded with 5 defects: a catch-all success fallback, the skipped test masking it, a loosened assertion, near-duplicate test bloat, and dead code + scaffolding.

| Defect | old reference (n=3) | this version (n=3) |
|---|---|---|
| Catch-all success fallback | 3/3 | 3/3 |
| Skipped test masking it | 3/3 | 3/3 |
| Loosened assertion | 3/3 | 3/3 |
| Near-duplicate test bloat | **1/3** | **3/3** |
| Dead code + scaffolding | **2/3** (hedged) | **3/3** (named) |

All three reviewers on this version converged on rework-before-commit verdicts with the fix named per finding.

## Ship gates

Vocabulary grep clean · relative links resolve · file stays lean (115 lines) · SKILL.md untouched (reference loads only at the review step).