### PR TITLE
opencode-delegate: OpenCode implementer backend (supersedes #1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. The first skill is `codex-delegate` (OpenAI Codex); siblings like `gemini-delegate`
-can be added later without renaming the repo.
+and land the result. Two skills ship today: `codex-delegate` (OpenAI Codex) and `opencode-delegate`
+(OpenCode); siblings like `gemini-delegate` can be added later without renaming the repo.
 
 ## Vocabulary
 
@@ -13,19 +13,21 @@ jargon. Use these terms; don't invent synonyms.
 | Use | For | Not |
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
-| **orchestrator** | the driving agent (Claude Code, OpenCode, …) | "controller", "driver" |
-| **implementer** | the worker agent (Codex) | "worker", "sub-agent", "executor" |
+| **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
+| **implementer** | the worker agent (Codex, OpenCode) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
 | **land** | commit the verified work yourself | — |
 | **relay** / `relay.mjs` | the dispatch **script** only | never a *category* of skills |
 | `exec`, `sandbox`, `resume`, `session` | Codex's own terms — use verbatim | don't paraphrase them |
+| `run`, `agent` (`build`/`plan`), `session` | OpenCode's own terms — use verbatim | "sandbox" (OpenCode has no sandbox enum; autonomy is the agent) |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
 version-neutral); and claims that can't be verified ("verified" without a run → hedge or cut). Every
-CLI flag, field, and command in the docs must match the installed `codex` and `relay.mjs`.
+CLI flag, field, and command in the docs must match the installed implementer CLI (`codex` /
+`opencode`) and the skill's `relay.mjs`.
 
 ## Conventions
 
@@ -40,18 +42,19 @@ CLI flag, field, and command in the docs must match the installed `codex` and `r
   the skill otherwise.
 - **Progressive disclosure:** keep `SKILL.md` lean; push depth into `references/*.md` that load only
   when needed.
-- **Executables:** keep them minimal and inspectable. The only one today is
-  `skills/codex-delegate/scripts/relay.mjs` — Node built-ins only, no dependencies, no network calls of
-  its own, no credentials, no telemetry. New scripts must hold the same line, and the README's trust
-  section must stay accurate.
+- **Executables:** keep them minimal and inspectable. Today there is one per skill —
+  `skills/codex-delegate/scripts/relay.mjs` and `skills/opencode-delegate/scripts/relay.mjs` — each
+  Node built-ins only, no dependencies, no network calls of its own, no credentials, no telemetry. New
+  scripts must hold the same line, and the README's trust section must stay accurate.
 
 ## Before publishing a change
 
 - Validate the package locally: `npx skills add . --list`.
-- Smoke-test any changed script directly (e.g. `node skills/codex-delegate/scripts/relay.mjs --help`,
-  and a `--read-only` run against a throwaway repo) before relying on it.
-- If you touch how `relay.mjs` launches `codex`, smoke-test on Windows too (native PowerShell/cmd, not
-  just Git Bash/WSL): the `codex` launch needs `shell:true` on win32 to resolve the `.cmd` shim.
+- Smoke-test any changed script directly (e.g. `node skills/<skill>/scripts/relay.mjs --help`, and a
+  `--read-only` run against a throwaway repo) before relying on it.
+- If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
+  PowerShell/cmd, not just Git Bash/WSL): both the `codex` and `opencode` launches need `shell:true` on
+  win32 to resolve the `.cmd` shim.
 - Keep the README's "Verification status" honest — claim only what's been run.
 
 ## Local Claude Code config

--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ This package is intentionally inspectable:
   before you run it.
 - Neither ever commits — committing is always the orchestrator's job, after review.
 
-**Verification status:** the `codex-delegate` relay's integration (flags, exit codes, `result.json`) is
-verified, and the `opencode-delegate` relay is verified end-to-end against `opencode` v1.17.6 (fresh
-write run, read-only `plan` run, `--resume-last`, session id, cost, and final-message capture). For both,
-the full delegate → review → commit loop is designed for and run on Claude Code but not yet formally
-verified across other orchestrators (Cursor, …), which are designed-for but unproven.
+**Verification status:** each relay's mechanics are verified — argument handling, exit codes,
+`result.json`, resume, and (for `opencode-delegate`) the required-model guard, since OpenCode has no safe
+default. The full delegate → review → commit loop is designed for and run on Claude Code but not yet
+formally verified end-to-end here (OpenCode's cold start is slow in constrained shells, so exercise a
+real run in a normal terminal). Other orchestrators (Cursor, …) are designed-for but unproven. This line
+gets upgraded to "verified end-to-end" with evidence, not assumption.
 
 ## Repository shape
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, hands it to an implementer CLI, then reviews the diff and
 commits — staying the reviewer the whole way.
 
-The first skill, **`codex-delegate`**, drives the OpenAI Codex CLI.
+Two skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, and **`opencode-delegate`**
+drives the OpenCode CLI. Same loop, different implementer.
 
 ## Install
 
@@ -21,6 +22,7 @@ Install the package, or just one skill:
 ```bash
 npx skills add amElnagdy/delegate-skills
 npx skills add amElnagdy/delegate-skills --skill codex-delegate
+npx skills add amElnagdy/delegate-skills --skill opencode-delegate
 ```
 
 Install for a specific agent, or globally:
@@ -76,6 +78,17 @@ land, multi-task queues) loaded only when needed, and one small helper script.
 handed to Codex, comes back as a clean diff with a structured report, and you commit it after re-running
 the gates yourself instead of typing it all by hand.
 
+### opencode-delegate
+
+Drive the OpenCode CLI as a background implementer: write the brief, dispatch via `relay.mjs`, review
+the diff, commit it yourself. Same four references and loop as `codex-delegate`. Autonomy is set by the
+**agent** rather than a sandbox enum — `build` (write-capable) by default, `plan` (read-only) for
+review/diagnosis — and the brief is piped to `opencode run` on stdin so multi-line XML briefs need no
+quoting.
+
+**You'll feel it when:** a bounded task gets handed to OpenCode, comes back as a clean diff with a
+structured report and the run's cost, and you commit it after re-running the gates yourself.
+
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
@@ -83,7 +96,10 @@ Reserved so the umbrella can grow without a rename.
 
 ## Requirements
 
-- The [`codex` CLI](https://github.com/openai/codex) installed and authenticated (`codex login`).
+- For `codex-delegate`: the [`codex` CLI](https://github.com/openai/codex) installed and authenticated
+  (`codex login`).
+- For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai) installed and authenticated
+  (`opencode auth login`).
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -92,22 +108,32 @@ Reserved so the umbrella can grow without a rename.
 
 This package is intentionally inspectable:
 
-- All skill content is Markdown, plus exactly **one** executable: `skills/codex-delegate/scripts/relay.mjs`.
-- `relay.mjs` itself makes no network calls, reads or writes no credentials, sends no telemetry, and
-  has no dependencies (Node built-ins only). It shells out only to `codex` and `git`. The `codex`
-  process it launches authenticates exactly as you do at the terminal. Read the script before you run it.
-- It never commits — committing is always the orchestrator's job, after review.
+- All skill content is Markdown, plus exactly **one** executable per skill — each a `scripts/relay.mjs`.
+- Each `relay.mjs` makes no network calls, reads or writes no credentials, sends no telemetry, and has
+  no dependencies (Node built-ins only). It shells out only to its implementer CLI (`codex` /
+  `opencode`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the script
+  before you run it.
+- Neither ever commits — committing is always the orchestrator's job, after review.
 
-**Verification status:** the relay's `codex` integration (flags, exit codes, `result.json`) is verified;
-the end-to-end loop is designed for and run on Claude Code, but not yet formally verified across a full
-delegate → review → commit cycle. Other orchestrators (OpenCode, Cursor, …) are designed-for but
-unproven. This line gets upgraded to "verified end-to-end" with evidence, not assumption.
+**Verification status:** the `codex-delegate` relay's integration (flags, exit codes, `result.json`) is
+verified, and the `opencode-delegate` relay is verified end-to-end against `opencode` v1.17.6 (fresh
+write run, read-only `plan` run, `--resume-last`, session id, cost, and final-message capture). For both,
+the full delegate → review → commit loop is designed for and run on Claude Code but not yet formally
+verified across other orchestrators (Cursor, …), which are designed-for but unproven.
 
 ## Repository shape
 
 ```text
 skills/
-└── codex-delegate/
+├── codex-delegate/
+│   ├── SKILL.md
+│   ├── scripts/relay.mjs
+│   └── references/
+│       ├── writing-the-brief.md
+│       ├── dispatch-and-poll.md
+│       ├── review-and-land.md
+│       └── multi-task-queues.md
+└── opencode-delegate/
     ├── SKILL.md
     ├── scripts/relay.mjs
     └── references/

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Works with any orchestrating agent the [Skills CLI](https://github.com/vercel-la
 
 ## What it does
 
-The loop, for `codex-delegate`:
+The loop:
 
-1. **Write a brief** — a self-contained task spec; Codex sees only what you send.
-2. **Dispatch** it with the bundled `relay.mjs` (a thin `codex exec` wrapper).
+1. **Write a brief** — a self-contained task spec; the implementer sees only what you send.
+2. **Dispatch** it with the bundled `relay.mjs`.
 3. **Wait** for completion — the helper writes a structured `result.json`.
 4. **Review** the diff — re-run the project's gates yourself; pair with [guard skills](https://github.com/amElnagdy/guard-skills).
-5. **Land** it — *you* commit, because the implementer's sandbox can't reliably write `.git`.
+5. **Land** it — *you* commit, because committing belongs to the reviewer.
 
 ```text
 Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -5,7 +5,8 @@
       "title": "Delegate to CLI agents",
       "description": "Delegate a coding task to a CLI implementer agent, then review the diff and commit it yourself.",
       "skills": [
-        "codex-delegate"
+        "codex-delegate",
+        "opencode-delegate"
       ]
     }
   ]

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -240,7 +240,7 @@ function makeResultWriter(opts, version, run) {
 }
 
 function reportUnavailable(writeResult, resultPath) {
-  const result = writeResult({ status: "codex_unavailable", exitCode: 127, threadId: null, finalMessage: "", touchedFiles: [] });
+  const result = writeResult({ status: "codex_unavailable", exitCode: 127, threadId: null, finalMessage: "", touchedFiles: null });
   printSummary(result, resultPath);
   process.stderr.write("relay: `codex` not found on PATH. Install it (npm i -g @openai/codex) and run `codex login`.\n");
   process.exit(127);

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -5,13 +5,8 @@ description: >-
   land it yourself. Use this whenever the user wants to hand implementation work to OpenCode — phrasings
   like "have OpenCode do X", "delegate this to OpenCode", "run it through OpenCode", or "use OpenCode to
   implement/fix/refactor" — or wants to run a queue of coding tasks through OpenCode while staying the
-  reviewer. Prefer it specifically when the user will review the resulting diff and commit it themselves,
-  or wants the full brief → dispatch → review → commit loop across a single task or a queue. Also reach
-  for it proactively for a separate implementation pass on a bounded, well-specified task (an
-  implementation sweep, a migration, a mechanical refactor, parallel work). Covers writing the OpenCode
-  brief, dispatching it via the bundled relay.mjs helper, waiting for completion, reviewing the result,
-  and committing. DO NOT USE for tasks small enough to do inline, or when the user wants the code written
-  directly without delegating.
+  reviewer. Prefer it when the user will review the diff and commit it themselves. DO NOT USE for tasks
+  small enough to do inline, or when the user wants the code written directly without delegating.
 license: MIT
 compatibility: Requires the `opencode` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
@@ -45,6 +40,21 @@ orchestrators as designed-for, not yet proven.)
 3. A model provider is authenticated — `opencode auth list` shows at least one credential.
 4. You are in (or will point `--cd` at) the target git repository.
 
+## Choose the implementer model
+
+OpenCode has **no safe default** — a bare `opencode run` errors, so the relay requires `--model` on
+every fresh run (a resumed run inherits its session's model). Picking the model is the point of an
+OpenCode backend, and it is yours to make:
+
+- **Match the model to the task** — a cheap, fast model for a mechanical sweep (rename, migration,
+  removal); a strong one for a subtle bug or a money/security path.
+- **Name a model you pay a flat rate for.** `opencode models` is a large catalog where most entries
+  meter you per token and the CLI can't flag which are your subscriptions — so choose deliberately (e.g.
+  an `opencode-go/*` or `zai-coding-plan/*` plan you hold), not the first match in the list.
+- **State your usable set once** in your own `AGENTS.md`/`CLAUDE.md` so the orchestrator picks from what
+  you actually have instead of guessing. More depth:
+  [references/writing-the-brief.md](references/writing-the-brief.md).
+
 ## The loop
 
 Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
@@ -68,9 +78,10 @@ directory — if unsure where it landed, run `find ~ -name relay.mjs -path '*ope
 substitute the directory above it.)
 
 ```bash
-node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --model <provider/model> --cd /path/to/repo
+# --model is required on a fresh run (see "Choose the implementer model" above)
 # read-only (review/diagnosis, no edits):   add --read-only   (uses the plan agent)
-# continue the previous OpenCode session:   add --resume-last  (send only the delta brief)
+# continue the previous OpenCode session:   add --resume-last  (delta brief only; keeps the model)
 # see all options:                          node .../relay.mjs --help
 ```
 
@@ -117,13 +128,6 @@ the party that verified the work. Only after the gates pass and the diff holds:
 - If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
   review again.
 
-## Non-negotiables
-
-- **Re-run the gates yourself.** The self-report is a claim, not evidence.
-- **The orchestrator commits, never the implementer.** Don't assume OpenCode committed; it didn't.
-- **One task = one brief = one commit.** Split unrelated work into separate runs.
-- **Trust the working tree and process state** over any progress tracker.
-
 ## Autonomy model
 
 OpenCode's autonomy is governed by the **agent**, not a sandbox enum:
@@ -145,13 +149,6 @@ and non-blocking nitpicks rather than silently keeping them) and **stop for scop
 completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
 is in [references/review-and-land.md](references/review-and-land.md).
 
-## Trust and safety
-
-`scripts/relay.mjs` itself makes no network calls, reads or writes no credentials, and sends no
-telemetry; it has no dependencies (Node built-ins only) and shells out only to `opencode` and `git`. The
-`opencode` process it launches does authenticate — exactly as you do at the terminal. Read the script
-before you run it. It is the one executable in this package; everything else is Markdown.
-
 ## References
 
 - [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief OpenCode can
@@ -162,11 +159,3 @@ before you run it. It is the one executable in this package; everything else is 
   boundary, and the rework cycle via `--resume-last`.
 - [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
   carrying constraints forward, progress tracking, and the end-of-run coherence check.
-
-## What this skill does NOT do
-
-- It does not commit for you — that is deliberate (step 5).
-- It does not review the code's quality itself — pair it with guard skills.
-- It does not run your tests — you re-run the project's own gates in step 4.
-- It is not the inverse direction (OpenCode reviewing your work). For that, dispatch a `--read-only`
-  review brief, or use OpenCode's own review workflows directly.

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -146,6 +146,8 @@ prompt no one can answer. That is the point of unattended delegation — the orc
 and the implementer sweep (step 4) are the safety net, not a per-action prompt. Pass `--no-auto` to
 honor the agent's own permission config instead (allow/ask/deny per action); pair it with an agent whose
 in-workspace permissions are set to *allow*, or a headless run can hang waiting on an `ask`.
+**Read-only (`plan`) runs never get `--auto`** — auto-approving would let the plan agent's ask-gated
+edit/bash permissions through and defeat "read-only," so a review can't be tricked into touching the tree.
 
 ## Authorization model
 

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -42,18 +42,22 @@ orchestrators as designed-for, not yet proven.)
 
 ## Choose the implementer model
 
-OpenCode has **no safe default** — a bare `opencode run` errors, so the relay requires `--model` on
-every fresh run (a resumed run inherits its session's model). Picking the model is the point of an
-OpenCode backend, and it is yours to make:
+OpenCode has **no safe default** — a bare `opencode run` errors — so the relay requires `--model` on
+every fresh run (a resumed run inherits its session's model). Naming the model is the one decision a
+single-model backend like codex-delegate never had, and it has two owners:
 
-- **Match the model to the task** — a cheap, fast model for a mechanical sweep (rename, migration,
-  removal); a strong one for a subtle bug or a money/security path.
-- **Name a model you pay a flat rate for.** `opencode models` is a large catalog where most entries
-  meter you per token and the CLI can't flag which are your subscriptions — so choose deliberately (e.g.
-  an `opencode-go/*` or `zai-coding-plan/*` plan you hold), not the first match in the list.
-- **State your usable set once** in your own `AGENTS.md`/`CLAUDE.md` so the orchestrator picks from what
-  you actually have instead of guessing. More depth:
-  [references/writing-the-brief.md](references/writing-the-brief.md).
+- **The human owns which models are allowed.** `opencode models` lists hundreds of entries, most billed
+  per token (OpenRouter and the like); only the human knows which are their flat-rate subscriptions, and
+  the CLI can't tell them apart. So the usable set is theirs — ideally stated once in the repo's
+  `AGENTS.md` or their `CLAUDE.md` (e.g. "delegate mechanical work to `opencode-go/…`, hard logic to
+  `…`").
+- **You, the orchestrator, pick per task — from that set.** Match the model to the brief: a cheap, fast
+  model for a mechanical sweep (rename, migration, removal); a strong one for a subtle bug or a
+  money/security path.
+- **If no usable set is stated, ask — don't guess.** Guessing from the catalog risks a metered model and
+  a surprise bill. Name the constraint to the human and let them choose.
+
+More depth: [references/writing-the-brief.md](references/writing-the-brief.md).
 
 ## The loop
 

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: opencode-delegate
+description: >-
+  Delegate a coding task to the OpenCode CLI as a background implementer, then review its diff and
+  land it yourself. Use this whenever the user wants to hand implementation work to OpenCode — phrasings
+  like "have OpenCode do X", "delegate this to OpenCode", "run it through OpenCode", or "use OpenCode to
+  implement/fix/refactor" — or wants to run a queue of coding tasks through OpenCode while staying the
+  reviewer. Prefer it specifically when the user will review the resulting diff and commit it themselves,
+  or wants the full brief → dispatch → review → commit loop across a single task or a queue. Also reach
+  for it proactively for a separate implementation pass on a bounded, well-specified task (an
+  implementation sweep, a migration, a mechanical refactor, parallel work). Covers writing the OpenCode
+  brief, dispatching it via the bundled relay.mjs helper, waiting for completion, reviewing the result,
+  and committing. DO NOT USE for tasks small enough to do inline, or when the user wants the code written
+  directly without delegating.
+license: MIT
+compatibility: Requires the `opencode` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.1.0
+---
+
+# OpenCode Delegate
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the OpenCode CLI — then review what it produced and land it yourself. You write
+the brief and own the judgment; OpenCode does the typing in its own session; you verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so it works the same whether you are Claude Code, OpenCode itself driving a
+sibling session, or any comparable agent. (It is designed for and run on Claude Code; treat other
+orchestrators as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `opencode` CLI is not installed or not authenticated (run `opencode auth login`).
+- You want to write the code yourself, or you only need a review (use the `plan` agent via `--read-only`).
+
+## Prerequisites (check once)
+
+1. `opencode --version` succeeds. If not, install (`npm i -g opencode-ai`, or the native installer from
+   opencode.ai) and `opencode auth login`.
+2. **Confirm which `opencode` is on PATH.** `command -v opencode` shows the active binary and
+   `opencode --version` its version. The relay records the version it ran into `result.json`, so a stale
+   binary is visible after the fact.
+3. A model provider is authenticated — `opencode auth list` shows at least one credential.
+4. You are in (or will point `--cd` at) the target git repository.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+OpenCode sees **only** the text you send plus what it can read from the working tree — no chat history,
+no shared context. Everything the task needs goes in the brief: the goal, the current state, what to
+change, what to leave untouched, the project's **actual** gate commands (discover them from the repo's
+AGENTS.md/CLAUDE.md/Makefile — do not assume), and a report contract. Tell OpenCode it will **not**
+commit (you will). Keep one task per brief. Full guidance and a template:
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to OpenCode with the bundled helper. It wraps `opencode run`, captures the run, and
+writes a structured `result.json` — so your only job is "run a command, read a file." (`<skill-dir>`
+below is this skill's installed directory — the folder containing this `SKILL.md`. Claude Code prints
+it as "Base directory for this skill" when the skill loads; on other orchestrators use that same
+directory — if unsure where it landed, run `find ~ -name relay.mjs -path '*opencode-delegate*'` and
+substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (review/diagnosis, no edits):   add --read-only   (uses the plan agent)
+# continue the previous OpenCode session:   add --resume-last  (send only the delta brief)
+# see all options:                          node .../relay.mjs --help
+```
+
+The helper defaults to the write-capable `build` agent and writes its artifacts to a temp dir, so the
+repo under review stays clean. It **never commits** — see step 5. Mechanics, flags, and the
+`result.json` shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until OpenCode finishes, so back it with whatever your orchestrator offers and resume
+when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job`
+  in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a `status`. (A
+  pre-run usage error — bad args or an empty brief — instead exits with code 2 and writes no result
+  file, so check the exit code too. A missing `opencode` binary exits 127 but *does* write a
+  `result.json` with status `opencode_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line.
+
+### 4. Review — do not trust the self-report
+
+OpenCode's `result.json` includes its own final message and any gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did OpenCode do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Committing should be the act of
+the party that verified the work. Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
+  review again.
+
+## Non-negotiables
+
+- **Re-run the gates yourself.** The self-report is a claim, not evidence.
+- **The orchestrator commits, never the implementer.** Don't assume OpenCode committed; it didn't.
+- **One task = one brief = one commit.** Split unrelated work into separate runs.
+- **Trust the working tree and process state** over any progress tracker.
+
+## Autonomy model
+
+OpenCode's autonomy is governed by the **agent**, not a sandbox enum:
+
+- **`build`** (the relay default) — write-capable; edits files in the working dir headlessly. The
+  equivalent of "let it implement."
+- **`plan`** (via `--read-only`) — read-only; reviews and diagnoses without touching the tree. The
+  equivalent of "let it look but not edit."
+- **`--dangerous`** adds `--dangerously-skip-permissions`, which auto-approves anything not explicitly
+  denied (broad access — e.g. shell reaching outside the workspace). Opt in only when the task genuinely
+  needs it.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report OpenCode's design decisions, defensible-but-unasked turns,
+and non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if correct
+completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
+is in [references/review-and-land.md](references/review-and-land.md).
+
+## Trust and safety
+
+`scripts/relay.mjs` itself makes no network calls, reads or writes no credentials, and sends no
+telemetry; it has no dependencies (Node built-ins only) and shells out only to `opencode` and `git`. The
+`opencode` process it launches does authenticate — exactly as you do at the terminal. Read the script
+before you run it. It is the one executable in this package; everything else is Markdown.
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief OpenCode can
+  execute blind: structure, XML blocks, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the rework cycle via `--resume-last`.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.
+
+## What this skill does NOT do
+
+- It does not commit for you — that is deliberate (step 5).
+- It does not review the code's quality itself — pair it with guard skills.
+- It does not run your tests — you re-run the project's own gates in step 4.
+- It is not the inverse direction (OpenCode reviewing your work). For that, dispatch a `--read-only`
+  review brief, or use OpenCode's own review workflows directly.

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -140,9 +140,6 @@ OpenCode's autonomy is governed by the **agent**, not a sandbox enum:
   equivalent of "let it implement."
 - **`plan`** (via `--read-only`) — read-only; reviews and diagnoses without touching the tree. The
   equivalent of "let it look but not edit."
-- **`--dangerous`** adds `--dangerously-skip-permissions`, which auto-approves anything not explicitly
-  denied (broad access — e.g. shell reaching outside the workspace). Opt in only when the task genuinely
-  needs it.
 
 ## Authorization model
 

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -141,6 +141,12 @@ OpenCode's autonomy is governed by the **agent**, not a sandbox enum:
 - **`plan`** (via `--read-only`) — read-only; reviews and diagnoses without touching the tree. The
   equivalent of "let it look but not edit."
 
+Permissions **auto-approve by default**: the relay passes `--auto` so a headless run never blocks on a
+prompt no one can answer. That is the point of unattended delegation — the orchestrator's diff review
+and the implementer sweep (step 4) are the safety net, not a per-action prompt. Pass `--no-auto` to
+honor the agent's own permission config instead (allow/ask/deny per action); pair it with an agent whose
+in-workspace permissions are set to *allow*, or a headless run can hang waiting on an `ask`.
+
 ## Authorization model
 
 Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -20,9 +20,9 @@ You are the **orchestrator**. This skill lets you hand a bounded coding task to 
 the brief and own the judgment; OpenCode does the typing in its own session; you verify and commit.
 
 Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
-command and read a file, so it works the same whether you are Claude Code, OpenCode itself driving a
-sibling session, or any comparable agent. (It is designed for and run on Claude Code; treat other
-orchestrators as designed-for, not yet proven.)
+command and read a file, so any agent with those two capabilities — Claude Code, OpenCode driving a
+sibling session, or a comparable one — can drive it. (It is designed for and run on Claude Code; treat
+other orchestrators as designed-for, not yet proven.)
 
 ## When NOT to use this
 

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -31,7 +31,7 @@ Options:
 | --- | --- |
 | `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
 | `--cd <dir>` | Working root for OpenCode (default: current directory). |
-| `--model <name>` | Model as `provider/model` (default: OpenCode's configured default). |
+| `--model <name>` | Model as `provider/model`. **Required on a fresh run** — OpenCode has no safe default (a bare `opencode run` errors); a resumed run inherits its session's model. |
 | `--agent <name>` | OpenCode agent (default: `build`, write-capable). |
 | `--read-only` | Shortcut for `--agent plan` — review/diagnosis with no edits. |
 | `--variant <name>` | Provider reasoning effort (e.g. `high`, `max`, `minimal`). |
@@ -108,8 +108,8 @@ process has exited and `result.json` is written — not when a status line says 
 Under the hood the helper runs roughly:
 
 ```bash
-opencode run --format json --agent build [-m provider/model] < brief.txt     # fresh run
-opencode run --format json --continue    < delta-brief.txt                   # resume most recent
+opencode run --format json --agent build -m provider/model < brief.txt       # fresh run (model required)
+opencode run --format json --continue    < delta-brief.txt                   # resume most recent (inherits model)
 opencode run --format json --session ses_… < delta-brief.txt                 # resume a specific session
 ```
 

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -35,7 +35,7 @@ Options:
 | `--agent <name>` | OpenCode agent (default: `build`, write-capable). |
 | `--read-only` | Shortcut for `--agent plan` — review/diagnosis with no edits. |
 | `--variant <name>` | Provider reasoning effort (e.g. `high`, `max`, `minimal`). |
-| `--no-auto` | The relay passes `opencode`'s `--auto` (auto-approve permissions) **by default** so a headless run doesn't hang on a prompt; `--no-auto` drops it and honors the agent's own permission config instead. |
+| `--no-auto` | The relay passes `opencode`'s `--auto` (auto-approve permissions) **by default** so a headless run doesn't hang on a prompt; `--no-auto` drops it and honors the agent's own permission config instead. A `--read-only`/`plan` run never gets `--auto`, so it can't be auto-approved into edits. |
 | `--resume-last` | Continue the most recent OpenCode session; send only the delta brief (see review-and-land). |
 | `--session <id>` | Continue a specific session id (`ses_…`); send only the delta brief. |
 | `--pure` | Run OpenCode without external plugins (cleaner event stream). |

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,127 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `opencode run`, runs the brief under the chosen
+agent, captures everything, and writes a structured `result.json`. Your job collapses to: run one
+command, then read one file. Everything OpenCode-specific lives in the helper, which is what keeps the
+loop portable across orchestrators.
+
+## Before the first run: check the binary
+
+Two gotchas, both worth 30 seconds:
+
+```bash
+command -v opencode    # the active binary on PATH
+opencode --version     # the relay records this in result.json too
+opencode auth list     # at least one provider credential must be present
+```
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for OpenCode (default: current directory). |
+| `--model <name>` | Model as `provider/model` (default: OpenCode's configured default). |
+| `--agent <name>` | OpenCode agent (default: `build`, write-capable). |
+| `--read-only` | Shortcut for `--agent plan` — review/diagnosis with no edits. |
+| `--variant <name>` | Provider reasoning effort (e.g. `high`, `max`, `minimal`). |
+| `--dangerous` | Add `--dangerously-skip-permissions` — broad access; use sparingly. |
+| `--resume-last` | Continue the most recent OpenCode session; send only the delta brief (see review-and-land). |
+| `--session <id>` | Continue a specific session id (`ses_…`); send only the delta brief. |
+| `--pure` | Run OpenCode without external plugins (cleaner event stream). |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only OpenCode's edits and nothing of the helper's own.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `tool` — `opencode`
+- `status` — `completed` | `failed` | `opencode_unavailable`
+- `exitCode` — mirrors OpenCode's exit code; `127` if `opencode` isn't on PATH
+- `opencodeVersion` — the binary that actually ran
+- `agent` — the agent used (`build`, `plan`, …), or a note that it was inherited from a resumed session
+- `sessionId` — feed this to a later `--session <id>` (or use `--resume-last`)
+- `finalMessage` — OpenCode's assembled final text (the `<structured_output_contract>` you asked for).
+  Empty if OpenCode stopped without emitting a closing summary — ask for the report explicitly
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point.
+  `null` (not `[]`) when git can't report — `git` missing, or a non-repo run; `[]` means git ran and
+  the tree is clean
+- `cost` — total run cost in USD, summed from the step events (`null` if none were reported)
+- `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSON event stream, and
+  the final-message file
+- `workdir`, `model`, `dangerous`, `resumeLast`, `startedAt`, `finishedAt`
+- `stderrTail` — last ~20 stderr lines; present **only** on a failed run, absent on `completed`,
+  `opencode_unavailable`, and launch failures
+- `error` — present **only** if OpenCode failed to launch
+
+The helper also prints a summary to stdout and exits with OpenCode's exit code, so a wrapping script can
+branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until OpenCode finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job` in PowerShell,
+  `start /b` in cmd). A run is done when `result.json` exists with a `status`. **But** a pre-run usage
+  error (bad args, empty brief) exits with code 2 *before* writing any file — so check the exit code
+  too, don't only watch for the file. (A missing `opencode` binary exits 127 but *does* write a
+  `result.json` with status `opencode_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: opencode_unavailable` (exit 127):** `opencode` isn't on PATH or isn't found. Install
+  (`npm i -g opencode-ai`) and `opencode auth login`, then re-dispatch.
+- **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
+  Common causes: an auth lapse, an unknown `--model` or `--agent`, or a permission the run needed but
+  the agent didn't grant. Fix the cause and re-dispatch; don't paper over it by doing the work yourself
+  unless that's what the user wants.
+- **Empty `finalMessage`:** OpenCode finished without emitting a closing text summary (common when it
+  completes purely through tool calls). The edits may still be correct — check `touchedFiles` and the
+  diff. To get a report next time, add a `<structured_output_contract>` block (see
+  [writing-the-brief.md](writing-the-brief.md)).
+- **A run hangs:** an agent with an `ask` permission can block waiting for approval that never comes in
+  headless mode. The `build` and `plan` agents don't prompt for in-workspace work; if a custom agent
+  does, either grant the permission in its config or pass `--dangerous` for that run.
+
+## What the helper is doing (and the alternatives)
+
+Under the hood the helper runs roughly:
+
+```bash
+opencode run --format json --agent build [-m provider/model] < brief.txt     # fresh run
+opencode run --format json --continue    < delta-brief.txt                   # resume most recent
+opencode run --format json --session ses_… < delta-brief.txt                 # resume a specific session
+```
+
+The brief is fed on **stdin**, never as an argument — which is why a multi-line, XML-tagged brief needs
+no quoting. The `--format json` stream is newline-delimited JSON events; the relay assembles
+`finalMessage` from the `text` events and pulls `sessionId` from the event stream. A resumed run inherits
+its original session's agent, so the helper sets `--agent` only on a fresh run.
+
+If you ever want it, raw `opencode run` is fine for one-offs — you just give up the captured
+`result.json`, touched-files summary, and session-id extraction the helper does for you.
+
+## The commit boundary
+
+The helper never commits — by design, not omission. The robust contract is: OpenCode edits the working
+tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -35,7 +35,6 @@ Options:
 | `--agent <name>` | OpenCode agent (default: `build`, write-capable). |
 | `--read-only` | Shortcut for `--agent plan` — review/diagnosis with no edits. |
 | `--variant <name>` | Provider reasoning effort (e.g. `high`, `max`, `minimal`). |
-| `--dangerous` | Add `--dangerously-skip-permissions` — broad access; use sparingly. |
 | `--resume-last` | Continue the most recent OpenCode session; send only the delta brief (see review-and-land). |
 | `--session <id>` | Continue a specific session id (`ses_…`); send only the delta brief. |
 | `--pure` | Run OpenCode without external plugins (cleaner event stream). |
@@ -63,7 +62,7 @@ touched-files report shows only OpenCode's edits and nothing of the helper's own
 - `cost` — total run cost in USD, summed from the step events (`null` if none were reported)
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSON event stream, and
   the final-message file
-- `workdir`, `model`, `dangerous`, `resumeLast`, `startedAt`, `finishedAt`
+- `workdir`, `model`, `resumeLast`, `startedAt`, `finishedAt`
 - `stderrTail` — last ~20 stderr lines; present **only** on a failed run, absent on `completed`,
   `opencode_unavailable`, and launch failures
 - `error` — present **only** if OpenCode failed to launch
@@ -101,7 +100,7 @@ process has exited and `result.json` is written — not when a status line says 
   [writing-the-brief.md](writing-the-brief.md)).
 - **A run hangs:** an agent with an `ask` permission can block waiting for approval that never comes in
   headless mode. The `build` and `plan` agents don't prompt for in-workspace work; if a custom agent
-  does, either grant the permission in its config or pass `--dangerous` for that run.
+  does, grant the needed permission in its config, or switch to `build`/`plan`.
 
 ## What the helper is doing (and the alternatives)
 

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -35,6 +35,7 @@ Options:
 | `--agent <name>` | OpenCode agent (default: `build`, write-capable). |
 | `--read-only` | Shortcut for `--agent plan` — review/diagnosis with no edits. |
 | `--variant <name>` | Provider reasoning effort (e.g. `high`, `max`, `minimal`). |
+| `--no-auto` | The relay passes `opencode`'s `--auto` (auto-approve permissions) **by default** so a headless run doesn't hang on a prompt; `--no-auto` drops it and honors the agent's own permission config instead. |
 | `--resume-last` | Continue the most recent OpenCode session; send only the delta brief (see review-and-land). |
 | `--session <id>` | Continue a specific session id (`ses_…`); send only the delta brief. |
 | `--pure` | Run OpenCode without external plugins (cleaner event stream). |
@@ -62,7 +63,7 @@ touched-files report shows only OpenCode's edits and nothing of the helper's own
 - `cost` — total run cost in USD, summed from the step events (`null` if none were reported)
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSON event stream, and
   the final-message file
-- `workdir`, `model`, `resumeLast`, `startedAt`, `finishedAt`
+- `workdir`, `model`, `auto`, `resumeLast`, `startedAt`, `finishedAt`
 - `stderrTail` — last ~20 stderr lines; present **only** on a failed run, absent on `completed`,
   `opencode_unavailable`, and launch failures
 - `error` — present **only** if OpenCode failed to launch
@@ -99,8 +100,9 @@ process has exited and `result.json` is written — not when a status line says 
   diff. To get a report next time, add a `<structured_output_contract>` block (see
   [writing-the-brief.md](writing-the-brief.md)).
 - **A run hangs:** an agent with an `ask` permission can block waiting for approval that never comes in
-  headless mode. The `build` and `plan` agents don't prompt for in-workspace work; if a custom agent
-  does, grant the needed permission in its config, or switch to `build`/`plan`.
+  headless mode. Runs pass `--auto` by default precisely to avoid this — so a hang almost always means
+  you passed `--no-auto`. Either drop it, or set the agent's permissions to *allow* (not ask) the
+  actions the task needs.
 
 ## What the helper is doing (and the alternatives)
 

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -18,7 +18,7 @@ opencode auth list     # at least one provider credential must be present
 ## Dispatching
 
 ```bash
-node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --model <provider/model> --cd /path/to/repo
 ```
 
 (`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude

--- a/skills/opencode-delegate/references/multi-task-queues.md
+++ b/skills/opencode-delegate/references/multi-task-queues.md
@@ -1,0 +1,68 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential. (Each fresh
+`relay.mjs` dispatch starts a new OpenCode session, so independent tasks don't share context — fold any
+shared constraint into each brief, see below.)
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. A fresh OpenCode session has no memory of the earlier run, so a
+constraint that emerged in task 2 must be restated in task 5's brief or it won't hold. This is the queue
+equivalent of keeping briefs self-contained.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions OpenCode made, non-blocking nitpicks, anything you want the
+  human to overrule or confirm. This is the section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/opencode-delegate/references/review-and-land.md
+++ b/skills/opencode-delegate/references/review-and-land.md
@@ -2,14 +2,28 @@
 
 OpenCode did the typing; you own the judgment. This is where delegation earns its keep or quietly ships
 a mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
-reality, never against the self-report, then commit it yourself.**
+reality, never against the self-report — and read the diff as generated code, which fails in ways a
+green gate can't see.**
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
 
 ## Re-run the gates yourself
 
 `result.json` carries OpenCode's own claim that the gates passed. Treat that as a claim, not evidence —
-re-run the project's actual test/lint/build commands in the working tree and read the output. A run
-that "passed" in OpenCode's report but fails when you run it is exactly the failure this step exists to
-catch, and it happens often enough to be worth the minute every time.
+re-run the project's actual test/lint/build commands in the working tree and read the output. And keep
+the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a gate,
+not just misreport it — that is what the test check above and the sweep below exist to catch.
 
 For changes with their own verification shape, go further:
 
@@ -30,19 +44,45 @@ for:
 - **Quiet judgment calls** — sometimes OpenCode makes a defensible decision the brief didn't anticipate.
   Don't just accept it because it looks reasonable; understand it and decide.
 
-## Compose with guard skills
+## The implementer sweep
 
-This skill produces the work; it doesn't judge code quality. If you have the `guard-skills` package
-installed, run the relevant guard on OpenCode's diff before you commit — `clean-code-guard` on
-production code, `test-guard` on any tests it wrote, `docs-guard` on documentation. They catch the
-systematic failure modes of generated code that a quick read misses. The two packages are designed to
-pair: delegate-skills delegates and lands; guard-skills reviews.
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If OpenCode couldn't implement something,
+  the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to OpenCode as a delta brief (below) or gets fixed in the tree
+before commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
 
 ## The commit boundary
 
-When the gates pass and the diff holds, **you commit** — the orchestrator, never OpenCode. This is the
-deliberate boundary: committing should be the act of the party that verified the work. Write a clear
-message describing what landed. If your project attributes co-authorship, that's the place for it.
+When the gates pass and the diff holds, **you commit** — the orchestrator, never the implementer. The
+`build` agent *can* write the working tree, but committing should be the act of the party that verified
+the work, not the one that produced it. Write a clear message describing what landed. If your project
+attributes co-authorship, that's the place for it.
 
 ## Reworking: send the delta, not the whole task
 
@@ -56,10 +96,9 @@ drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-las
 
 (`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
 
-`--resume-last` continues the most recent session, so it keeps OpenCode's context from the first run and
-a short delta is enough. (Use `--session <id>` with the `sessionId` from `result.json` if a newer run
-has since become "the last one.") Then review again — rework gets the same gate-rerun and diff-read as
-the original, no shortcuts. Repeat until it's right, then commit.
+`--resume-last` keeps OpenCode's session context from the first run (and its model), so a short delta is
+enough. Then review again — rework gets the same gate-rerun, test check, diff-read, and sweep as the
+original, no shortcuts. Repeat until it's right, then commit.
 
 ## Surface, don't absorb
 

--- a/skills/opencode-delegate/references/review-and-land.md
+++ b/skills/opencode-delegate/references/review-and-land.md
@@ -1,0 +1,75 @@
+# Review and land
+
+OpenCode did the typing; you own the judgment. This is where delegation earns its keep or quietly ships
+a mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
+reality, never against the self-report, then commit it yourself.**
+
+## Re-run the gates yourself
+
+`result.json` carries OpenCode's own claim that the gates passed. Treat that as a claim, not evidence —
+re-run the project's actual test/lint/build commands in the working tree and read the output. A run
+that "passed" in OpenCode's report but fails when you run it is exactly the failure this step exists to
+catch, and it happens often enough to be worth the minute every time.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Scope creep** — did OpenCode change things the brief said to leave untouched? Unasked refactors,
+  renames, "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version?
+- **Quiet judgment calls** — sometimes OpenCode makes a defensible decision the brief didn't anticipate.
+  Don't just accept it because it looks reasonable; understand it and decide.
+
+## Compose with guard skills
+
+This skill produces the work; it doesn't judge code quality. If you have the `guard-skills` package
+installed, run the relevant guard on OpenCode's diff before you commit — `clean-code-guard` on
+production code, `test-guard` on any tests it wrote, `docs-guard` on documentation. They catch the
+systematic failure modes of generated code that a quick read misses. The two packages are designed to
+pair: delegate-skills delegates and lands; guard-skills reviews.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never OpenCode. This is the
+deliberate boundary: committing should be the act of the party that verified the work. Write a clear
+message describing what landed. If your project attributes co-authorship, that's the place for it.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same OpenCode session with
+just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
+
+`--resume-last` continues the most recent session, so it keeps OpenCode's context from the first run and
+a short delta is enough. (Use `--session <id>` with the `sessionId` from `result.json` if a newer run
+has since become "the last one.") Then review again — rework gets the same gate-rerun and diff-read as
+the original, no shortcuts. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** OpenCode made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or OpenCode's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/opencode-delegate/references/writing-the-brief.md
+++ b/skills/opencode-delegate/references/writing-the-brief.md
@@ -6,6 +6,27 @@ whatever it can read from the working tree (including the repo's own `AGENTS.md`
 automatically). If a constraint isn't in the brief or discoverable in the repo, it doesn't exist for
 OpenCode. The single most common failure is a brief that assumes context OpenCode doesn't have.
 
+## Match the model to the brief
+
+OpenCode has no default model, so every fresh dispatch names one with `--model provider/model`. That is
+not friction — it is the lever an OpenCode backend gives you that a single-model implementer can't: you
+choose which model does *this* job.
+
+- **Read the task's difficulty off the brief you just wrote.** A mechanical, well-bounded brief — a
+  rename sweep, a `moment`→`date-fns` migration, a dead-code removal — is safe to send to a cheap, fast
+  model. A brief whose risk lives in judgment — a concurrency fix, a money or auth path, an ambiguous
+  spec — wants a strong model, because the sweep's failure modes (plausible-but-wrong logic, swallowed
+  errors) are exactly what a weaker model produces more of.
+- **Pick from what you actually pay a flat rate for.** `opencode models` lists a few hundred models, but
+  most bill per token (OpenRouter and the like) and the CLI does not mark which are your subscriptions.
+  Name a plan model you hold — e.g. `opencode-go/…`, `zai-coding-plan/…`, `minimax-coding-plan/…` —
+  rather than the first match, or a routine sweep quietly runs up a metered bill.
+- **Encode your defaults once.** List your go-to delegation models in the target repo's `AGENTS.md` or
+  your `CLAUDE.md` (e.g. "delegate mechanical work to X, hard logic to Y") so the orchestrator picks from
+  your real, paid set instead of guessing — and the choice stays consistent across runs.
+- **A resumed run keeps the first run's model.** `--resume-last` / `--session` don't take `--model`; the
+  session already has one. Send only the delta brief.
+
 ## The shape that works
 
 OpenCode responds well to compact, block-structured prompts with XML tags rather than long prose. State

--- a/skills/opencode-delegate/references/writing-the-brief.md
+++ b/skills/opencode-delegate/references/writing-the-brief.md
@@ -8,22 +8,20 @@ OpenCode. The single most common failure is a brief that assumes context OpenCod
 
 ## Match the model to the brief
 
-OpenCode has no default model, so every fresh dispatch names one with `--model provider/model`. That is
-not friction — it is the lever an OpenCode backend gives you that a single-model implementer can't: you
-choose which model does *this* job.
+OpenCode has no default model, so every fresh dispatch names one with `--model provider/model`. Which
+model is a two-owner decision: the **human** owns which models are allowed to run; **you, the
+orchestrator**, pick one of them to fit the task in front of you.
 
-- **Read the task's difficulty off the brief you just wrote.** A mechanical, well-bounded brief — a
-  rename sweep, a `moment`→`date-fns` migration, a dead-code removal — is safe to send to a cheap, fast
-  model. A brief whose risk lives in judgment — a concurrency fix, a money or auth path, an ambiguous
-  spec — wants a strong model, because the sweep's failure modes (plausible-but-wrong logic, swallowed
-  errors) are exactly what a weaker model produces more of.
-- **Pick from what you actually pay a flat rate for.** `opencode models` lists a few hundred models, but
-  most bill per token (OpenRouter and the like) and the CLI does not mark which are your subscriptions.
-  Name a plan model you hold — e.g. `opencode-go/…`, `zai-coding-plan/…`, `minimax-coding-plan/…` —
-  rather than the first match, or a routine sweep quietly runs up a metered bill.
-- **Encode your defaults once.** List your go-to delegation models in the target repo's `AGENTS.md` or
-  your `CLAUDE.md` (e.g. "delegate mechanical work to X, hard logic to Y") so the orchestrator picks from
-  your real, paid set instead of guessing — and the choice stays consistent across runs.
+- **The allowed set is the human's to state.** `opencode models` lists a few hundred models, but most
+  bill per token (OpenRouter and the like) and the CLI does not mark which are the human's
+  subscriptions. So they name their usable models — ideally once, in the target repo's `AGENTS.md` or
+  their `CLAUDE.md` (e.g. `opencode-go/…`, `zai-coding-plan/…`, `minimax-coding-plan/…`). If they
+  haven't, ask before dispatching rather than guessing a model and risking a metered bill.
+- **Read the task's difficulty off the brief you just wrote, and match within that set.** A mechanical,
+  well-bounded brief — a rename sweep, a `moment`→`date-fns` migration, a dead-code removal — is safe on
+  a cheap, fast model. A brief whose risk lives in judgment — a concurrency fix, a money or auth path,
+  an ambiguous spec — wants a strong one, because the sweep's failure modes (plausible-but-wrong logic,
+  swallowed errors) are exactly what a weaker model produces more of.
 - **A resumed run keeps the first run's model.** `--resume-last` / `--session` don't take `--model`; the
   session already has one. Send only the delta brief.
 

--- a/skills/opencode-delegate/references/writing-the-brief.md
+++ b/skills/opencode-delegate/references/writing-the-brief.md
@@ -1,0 +1,114 @@
+# Writing the brief
+
+A brief is the entire task as OpenCode will see it. OpenCode runs in a fresh session with **no memory of
+your conversation, no access to your prior notes, and no shared context** — only the text you send and
+whatever it can read from the working tree (including the repo's own `AGENTS.md`, which it picks up
+automatically). If a constraint isn't in the brief or discoverable in the repo, it doesn't exist for
+OpenCode. The single most common failure is a brief that assumes context OpenCode doesn't have.
+
+## The shape that works
+
+OpenCode responds well to compact, block-structured prompts with XML tags rather than long prose. State
+the task, what "done" looks like, how to behave by default, and the few constraints that actually
+matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps OpenCode from
+wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences) and dispatch with `--read-only` so OpenCode runs as the `plan` agent and can't edit.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Always ask for the report explicitly
+
+The relay assembles OpenCode's final message from the text it emits when it stops. If the agent finishes
+a task purely through tool calls and stops without a closing summary, `finalMessage` comes back empty —
+not a relay defect, just nothing said. The `<structured_output_contract>` block is what guarantees a
+report you can read: it tells OpenCode to end with a written summary, so the result file carries one.
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you an OpenCode that guesses — or skips.
+
+## Honor the repo's conventions
+
+OpenCode reads the repo's `AGENTS.md` automatically, so house rules there (style, forbidden patterns,
+commit conventions) already apply. If the project forbids certain things in code — say, spec/ticket IDs
+in comments, process language like "MVP"/"for now"/"phase N", or specific test conventions, whatever the
+repo's own conventions ban — restate the load-bearing ones in the brief too, because OpenCode's
+compliance is only as reliable as what's in front of it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and suggest
+a roadmap" produces a muddled run; split it into separate dispatches. One brief → one OpenCode run →
+one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -168,6 +168,11 @@ function timestamp() {
 
 function buildArgv(opts) {
   const argv = ["run", "--format", "json"];
+  // Pin the working root explicitly. spawn() below sets the child's cwd, but
+  // OpenCode can resolve its project root from the inherited PWD env (which spawn
+  // does NOT rewrite), so without --dir a run may operate on the orchestrator's
+  // directory instead of opts.cd — and with --auto on, edit it unattended.
+  argv.push("--dir", opts.cd);
   if (opts.pure) argv.push("--pure");
   // Resume continues an existing session; --session pins a specific id, otherwise
   // --continue picks up the most recent one. A resumed run inherits its original
@@ -228,14 +233,19 @@ function makeEventScanner(onObject) {
       }
     }
     // Retain only an in-progress object (if any) so the buffer can't grow without
-    // bound on a long run; everything already emitted or skipped is dropped.
-    if (depth > 0 && start !== -1) {
-      buf = buf.slice(start);
-      start = 0;
-    } else {
-      buf = "";
-      start = -1;
-    }
+    // bound; everything already emitted or skipped is dropped. Reset the scanner
+    // state too: the next call re-derives depth/string state by scanning the
+    // retained buffer (which always begins at an object's `{`) from scratch.
+    // Without the reset, the carried-over depth double-counts the retained braces,
+    // so an object split across chunks never closes and its event is lost.
+    // ponytail: O(n^2) if a single object spans many chunks (each re-scans the
+    // retained prefix); fine for OpenCode's event sizes — switch to a suffix-only
+    // scan if it ever bites.
+    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
+    start = -1;
+    depth = 0;
+    inString = false;
+    escaped = false;
   };
 }
 

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -30,7 +30,8 @@
  * Options:
  *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
  *   --cd <dir>              Working root for OpenCode (default: current directory).
- *   --model <name>          Model as provider/model (default: OpenCode's configured default).
+ *   --model <name>          Model as provider/model. REQUIRED for a fresh run — OpenCode has no
+ *                           safe default; a resumed run inherits its session's model.
  *   --agent <name>          OpenCode agent (default: build). Use plan for read-only review.
  *   --read-only             Shortcut for --agent plan (review/diagnosis, no edits).
  *   --variant <name>        Provider reasoning effort (e.g. high, max, minimal).
@@ -372,6 +373,11 @@ function main() {
   const opts = parseArgs(process.argv.slice(2));
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+  // OpenCode has no safe default model (a bare `opencode run` errors), so a fresh run must name one.
+  // A resumed run inherits its session's model, so --model is optional there.
+  if (!opts.model && !opts.resumeLast && !opts.session) {
+    fail("no model given: pass --model provider/model — opencode has no safe default (e.g. a plan you're subscribed to, like opencode-go/kimi-k2.7-code)");
+  }
 
   const version = opencodeVersion();
   const run = prepareRunDir(opts, brief);

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -20,9 +20,10 @@
  * OpenCode autonomy is governed by the chosen agent, not a sandbox enum:
  *   build (default) — write-capable; edits files in the working dir headlessly.
  *   plan            — read-only; reviews/diagnoses without touching the tree.
- * Runs pass `--auto` by default so OpenCode never blocks on a permission prompt
- * no one can answer in headless mode; the orchestrator's diff review is the
+ * A build run passes `--auto` by default so OpenCode never blocks on a permission
+ * prompt no one can answer in headless mode; the orchestrator's diff review is the
  * safety net. Pass --no-auto to instead honor the agent's own permission config.
+ * A plan (read-only) run never gets --auto, so it can't be auto-approved into edits.
  *
  * Usage:
  *   node relay.mjs --brief <file> [options]
@@ -181,9 +182,12 @@ function buildArgv(opts) {
   }
   if (opts.model) argv.push("--model", opts.model);
   if (opts.variant) argv.push("--variant", opts.variant);
-  // --auto (on by default) auto-approves permissions so a headless run doesn't
+  // --auto (on by default) auto-approves permissions so a headless build run doesn't
   // block on a prompt no one can answer; --no-auto honors the agent's own config.
-  if (opts.auto) argv.push("--auto");
+  // Never on a plan (read-only) run: --auto would approve the plan agent's ask-gated
+  // edit/bash permissions and let a "read-only" review modify the tree. A plan run
+  // only reads, so it doesn't need auto-approval anyway.
+  if (opts.auto && opts.agent !== "plan") argv.push("--auto");
   // No message argument: the brief is piped on stdin (see dispatchToOpenCode),
   // which avoids all argv-quoting issues with multi-line, XML-tagged briefs.
   return argv;

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · opencode-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the OpenCode CLI (`opencode run`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every OpenCode-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against opencode CLI v1.17.6.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `opencode` and `git`. The `opencode` process it
+ * launches does authenticate — exactly as you do at the terminal. Read this
+ * file before you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job —
+ * after it reviews the diff and re-runs the project gates.
+ *
+ * OpenCode autonomy is governed by the chosen agent, not a sandbox enum:
+ *   build (default) — write-capable; edits files in the working dir headlessly.
+ *   plan            — read-only; reviews/diagnoses without touching the tree.
+ * `--dangerously-skip-permissions` auto-approves anything not explicitly denied
+ * (broad access — opt in only when the task genuinely needs it).
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for OpenCode (default: current directory).
+ *   --model <name>          Model as provider/model (default: OpenCode's configured default).
+ *   --agent <name>          OpenCode agent (default: build). Use plan for read-only review.
+ *   --read-only             Shortcut for --agent plan (review/diagnosis, no edits).
+ *   --variant <name>        Provider reasoning effort (e.g. high, max, minimal).
+ *   --dangerous             Add --dangerously-skip-permissions (broad access; use sparingly).
+ *   --resume-last           Continue the most recent OpenCode session; send only the delta brief.
+ *   --session <id>          Continue a specific session id (ses_...); send only the delta brief.
+ *   --pure                  Run OpenCode without external plugins (cleaner event stream).
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, opencodeVersion, sessionId (for a later resume), finalMessage
+ *   (OpenCode's own report), touchedFiles (git porcelain, null if git can't report), and the
+ *   paths to events.jsonl and final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `opencode` binary exits 127;
+ * otherwise the exit code mirrors OpenCode's own (0 success, non-zero failure).
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, or opencode_unavailable. An orchestrator that polls for the
+ * file must therefore also treat a non-zero exit with no file as a usage error.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { tmpdir } from "node:os";
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    agent: "build",
+    variant: null,
+    dangerous: false,
+    resumeLast: false,
+    session: null,
+    pure: false,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--agent": opts.agent = next(); break;
+      case "--read-only": opts.agent = "plan"; break;
+      case "--variant": opts.variant = next(); break;
+      case "--dangerous": opts.dangerous = true; break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--pure": opts.pure = true; break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to opencode run\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function opencodeVersion() {
+  try {
+    // On Windows, npm installs `opencode` as a .cmd shim; Node's CreateProcess only
+    // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
+    // ENOENTs on a working install. POSIX is unaffected. (git installs a real
+    // git.exe and must NOT get this flag — see gitTouchedFiles.)
+    return execFileSync("opencode", ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git can't report — git missing, or a non-repo run — so the
+  // caller can tell "git unavailable" apart from "OpenCode changed nothing."
+  // [] means git ran and the working tree is clean.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts) {
+  const argv = ["run", "--format", "json"];
+  if (opts.pure) argv.push("--pure");
+  // Resume continues an existing session; --session pins a specific id, otherwise
+  // --continue picks up the most recent one. A resumed run inherits its original
+  // agent, so we only set --agent on a fresh run.
+  if (opts.session) {
+    argv.push("--session", opts.session);
+  } else if (opts.resumeLast) {
+    argv.push("--continue");
+  } else {
+    argv.push("--agent", opts.agent);
+  }
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.variant) argv.push("--variant", opts.variant);
+  if (opts.dangerous) argv.push("--dangerously-skip-permissions");
+  // No message argument: the brief is piped on stdin (see dispatchToOpenCode),
+  // which avoids all argv-quoting issues with multi-line, XML-tagged briefs.
+  return argv;
+}
+
+function makeEventScanner(onObject) {
+  // OpenCode emits newline-delimited JSON events on stdout, but local plugins can
+  // prepend terminal-notify escape sequences (e.g. `]777;notify;...{...}`) on the
+  // same line. A plain line-splitter would choke on those. This brace-aware
+  // scanner instead walks the byte stream, ignores anything at depth 0 that isn't
+  // a top-level object, and emits each complete `{...}` it closes — robust to junk
+  // prefixes and concatenated objects alike. String/escape state is tracked so
+  // braces inside string values never throw off the depth count.
+  let buf = "";
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    buf += chunk;
+    for (let i = 0; i < buf.length; i += 1) {
+      const ch = buf[i];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (ch === "\\") escaped = true;
+        else if (ch === '"') inString = false;
+        continue;
+      }
+      if (ch === '"') { inString = true; continue; }
+      if (ch === "{") {
+        if (depth === 0) start = i;
+        depth += 1;
+      } else if (ch === "}") {
+        if (depth > 0) {
+          depth -= 1;
+          if (depth === 0 && start !== -1) {
+            const slice = buf.slice(start, i + 1);
+            try { onObject(JSON.parse(slice)); } catch { /* not a JSON object we care about */ }
+            start = -1;
+          }
+        }
+      }
+    }
+    // Retain only an in-progress object (if any) so the buffer can't grow without
+    // bound on a long run; everything already emitted or skipped is dropped.
+    if (depth > 0 && start !== -1) {
+      buf = buf.slice(start);
+      start = 0;
+    } else {
+      buf = "";
+      start = -1;
+    }
+  };
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only OpenCode's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    eventsPath: join(outDir, "events.jsonl"),
+    finalPath: join(outDir, "final.txt"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  return (extra) => {
+    const resuming = Boolean(opts.session || opts.resumeLast);
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "opencode",
+      workdir: opts.cd,
+      agent: resuming ? "(inherited from resumed session)" : opts.agent,
+      model: opts.model,
+      dangerous: opts.dangerous,
+      resumeLast: opts.resumeLast,
+      opencodeVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      eventsPath: run.eventsPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      ...extra,
+    };
+    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "opencode_unavailable", exitCode: 127, sessionId: null, finalMessage: "", touchedFiles: [], cost: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `opencode` not found on PATH. Install it (npm i -g opencode-ai) and run `opencode auth login`.\n");
+  process.exit(127);
+}
+
+function dispatchToOpenCode(opts, brief, run, writeResult) {
+  const argv = buildArgv(opts);
+  // shell:true on Windows so the opencode.cmd shim resolves (see opencodeVersion).
+  // Safe: the brief is fed via child.stdin below — never argv — and argv holds only
+  // flag names, an agent enum, a model string, and a session id, with no shell
+  // metacharacters.
+  const child = spawn("opencode", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32" });
+
+  let sessionId = opts.session || null;
+  let totalCost = 0;
+  let sawCost = false;
+  const textParts = new Map(); // part.id -> latest text
+  const textOrder = []; // part.ids in first-seen order
+  const stderrTail = [];
+
+  const scan = makeEventScanner((event) => {
+    // Session id: real events carry `sessionID` (camelCase); plugin notify objects
+    // carry `session_id` (snake_case). Accept either.
+    const sid = event.sessionID || event.session_id;
+    if (sid) sessionId = sid;
+    // Assistant text lives in `type:"text"` events under part.text. Key by part.id
+    // so streamed updates to the same part replace rather than duplicate; preserve
+    // first-seen order so multi-segment messages assemble correctly.
+    if (event.type === "text" && event.part && event.part.type === "text") {
+      const id = event.part.id || `anon-${textOrder.length}`;
+      if (!textParts.has(id)) textOrder.push(id);
+      textParts.set(id, event.part.text ?? "");
+    }
+    if (event.type === "step_finish" && event.part && typeof event.part.cost === "number") {
+      totalCost += event.part.cost;
+      sawCost = true;
+    }
+  });
+
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    appendFileSync(run.eventsPath, text, "utf8"); // faithful raw record of the event stream
+    scan(text);
+  });
+
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    process.stderr.write(text); // surface OpenCode progress live for the orchestrator
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textOrder.map((id) => textParts.get(id)).join("").trim();
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  child.on("error", (err) => {
+    const result = writeResult({ status: "failed", exitCode: 1, sessionId, finalMessage: assembleFinal(), touchedFiles: gitTouchedFiles(opts.cd), cost: sawCost ? totalCost : null, error: String(err && err.message ? err.message : err) });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code) => {
+    const finalMessage = assembleFinal();
+    const result = writeResult({
+      status: code === 0 ? "completed" : "failed",
+      exitCode: code === null ? 1 : code,
+      sessionId,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      cost: sawCost ? Number(totalCost.toFixed(6)) : null,
+      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+
+  // If the child failed to launch, writing to its stdin can emit a stray 'error'
+  // on the pipe; the 'error' handler above owns that outcome, so swallow it here.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const version = opencodeVersion();
+  const run = prepareRunDir(opts, brief);
+  const writeResult = makeResultWriter(opts, version, run);
+
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+
+  dispatchToOpenCode(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode})  ·  opencode ${result.opencodeVersion ?? "?"}`);
+  if (result.resumeLast || result.agent === "(inherited from resumed session)") lines.push("mode: resumed existing session");
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  if (typeof result.cost === "number") lines.push(`cost: $${result.cost}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- opencode final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -6,7 +6,7 @@
  * capture the run, and write a structured result the orchestrating agent can
  * review. The orchestrator runs this one command and reads the result JSON —
  * every OpenCode-specific mechanic lives in here, which keeps the skill
- * orchestrator-agnostic. Verified against opencode CLI v1.17.6.
+ * orchestrator-agnostic. Verified against opencode CLI v1.17.13.
  *
  * Trust posture: relay.mjs itself makes no network calls, reads or writes no
  * credentials, and sends no telemetry; it has no dependencies (Node built-ins

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -290,7 +290,7 @@ function makeResultWriter(opts, version, run) {
 }
 
 function reportUnavailable(writeResult, resultPath) {
-  const result = writeResult({ status: "opencode_unavailable", exitCode: 127, sessionId: null, finalMessage: "", touchedFiles: [], cost: null });
+  const result = writeResult({ status: "opencode_unavailable", exitCode: 127, sessionId: null, finalMessage: "", touchedFiles: null, cost: null });
   printSummary(result, resultPath);
   process.stderr.write("relay: `opencode` not found on PATH. Install it (npm i -g opencode-ai) and run `opencode auth login`.\n");
   process.exit(127);
@@ -394,6 +394,11 @@ function main() {
   const opts = parseArgs(process.argv.slice(2));
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+  // --session pins a specific session and --resume-last picks the most recent; passing both is a
+  // contradiction, and buildArgv would silently prefer --session. Reject it rather than guess.
+  if (opts.session && opts.resumeLast) {
+    fail("--session and --resume-last are mutually exclusive; pass only one");
+  }
   // OpenCode has no safe default model (a bare `opencode run` errors), so a fresh run must name one.
   // A resumed run inherits its session's model, so --model is optional there.
   if (!opts.model && !opts.resumeLast && !opts.session) {

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -168,11 +168,6 @@ function timestamp() {
 
 function buildArgv(opts) {
   const argv = ["run", "--format", "json"];
-  // Pin the working root explicitly. spawn() below sets the child's cwd, but
-  // OpenCode can resolve its project root from the inherited PWD env (which spawn
-  // does NOT rewrite), so without --dir a run may operate on the orchestrator's
-  // directory instead of opts.cd — and with --auto on, edit it unattended.
-  argv.push("--dir", opts.cd);
   if (opts.pure) argv.push("--pure");
   // Resume continues an existing session; --session pins a specific id, otherwise
   // --continue picks up the most recent one. A resumed run inherits its original
@@ -303,11 +298,22 @@ function reportUnavailable(writeResult, resultPath) {
 
 function dispatchToOpenCode(opts, brief, run, writeResult) {
   const argv = buildArgv(opts);
+  // Pin the working root two ways: `cwd` sets the child's real directory, and PWD
+  // is set explicitly because OpenCode can resolve its project root from the
+  // inherited PWD env — which spawn does NOT rewrite — so without it a run could
+  // operate on the orchestrator's directory instead of opts.cd (and, with --auto
+  // on, edit it unattended). Passing the path via env, not argv, keeps it clear of
+  // shell quoting.
   // shell:true on Windows so the opencode.cmd shim resolves (see opencodeVersion).
   // Safe: the brief is fed via child.stdin below — never argv — and argv holds only
   // flag names, an agent enum, a model string, and a session id, with no shell
-  // metacharacters.
-  const child = spawn("opencode", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32" });
+  // metacharacters or spaceable paths.
+  const child = spawn("opencode", argv, {
+    cwd: opts.cd,
+    env: { ...process.env, PWD: opts.cd },
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
 
   let sessionId = opts.session || null;
   let totalCost = 0;

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -20,8 +20,6 @@
  * OpenCode autonomy is governed by the chosen agent, not a sandbox enum:
  *   build (default) — write-capable; edits files in the working dir headlessly.
  *   plan            — read-only; reviews/diagnoses without touching the tree.
- * `--dangerously-skip-permissions` auto-approves anything not explicitly denied
- * (broad access — opt in only when the task genuinely needs it).
  *
  * Usage:
  *   node relay.mjs --brief <file> [options]
@@ -35,7 +33,6 @@
  *   --agent <name>          OpenCode agent (default: build). Use plan for read-only review.
  *   --read-only             Shortcut for --agent plan (review/diagnosis, no edits).
  *   --variant <name>        Provider reasoning effort (e.g. high, max, minimal).
- *   --dangerous             Add --dangerously-skip-permissions (broad access; use sparingly).
  *   --resume-last           Continue the most recent OpenCode session; send only the delta brief.
  *   --session <id>          Continue a specific session id (ses_...); send only the delta brief.
  *   --pure                  Run OpenCode without external plugins (cleaner event stream).
@@ -73,7 +70,6 @@ function parseArgs(argv) {
     model: null,
     agent: "build",
     variant: null,
-    dangerous: false,
     resumeLast: false,
     session: null,
     pure: false,
@@ -99,7 +95,6 @@ function parseArgs(argv) {
       case "--agent": opts.agent = next(); break;
       case "--read-only": opts.agent = "plan"; break;
       case "--variant": opts.variant = next(); break;
-      case "--dangerous": opts.dangerous = true; break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--session": opts.session = next(); break;
       case "--pure": opts.pure = true; break;
@@ -178,7 +173,6 @@ function buildArgv(opts) {
   }
   if (opts.model) argv.push("--model", opts.model);
   if (opts.variant) argv.push("--variant", opts.variant);
-  if (opts.dangerous) argv.push("--dangerously-skip-permissions");
   // No message argument: the brief is piped on stdin (see dispatchToOpenCode),
   // which avoids all argv-quoting issues with multi-line, XML-tagged briefs.
   return argv;
@@ -264,7 +258,6 @@ function makeResultWriter(opts, version, run) {
       workdir: opts.cd,
       agent: resuming ? "(inherited from resumed session)" : opts.agent,
       model: opts.model,
-      dangerous: opts.dangerous,
       resumeLast: opts.resumeLast,
       opencodeVersion: version,
       startedAt: run.startedAt,

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -212,7 +212,10 @@ function makeEventScanner(onObject) {
         else if (ch === '"') inString = false;
         continue;
       }
-      if (ch === '"') { inString = true; continue; }
+      // Only track strings inside an object (depth > 0). At depth 0 we're skipping a
+      // junk prefix (e.g. a terminal-notify escape), and an unmatched `"` there must
+      // not swallow the real `{...}` that follows in the same chunk.
+      if (ch === '"') { if (depth > 0) inString = true; continue; }
       if (ch === "{") {
         if (depth === 0) start = i;
         depth += 1;

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -20,6 +20,9 @@
  * OpenCode autonomy is governed by the chosen agent, not a sandbox enum:
  *   build (default) — write-capable; edits files in the working dir headlessly.
  *   plan            — read-only; reviews/diagnoses without touching the tree.
+ * Runs pass `--auto` by default so OpenCode never blocks on a permission prompt
+ * no one can answer in headless mode; the orchestrator's diff review is the
+ * safety net. Pass --no-auto to instead honor the agent's own permission config.
  *
  * Usage:
  *   node relay.mjs --brief <file> [options]
@@ -33,6 +36,8 @@
  *   --agent <name>          OpenCode agent (default: build). Use plan for read-only review.
  *   --read-only             Shortcut for --agent plan (review/diagnosis, no edits).
  *   --variant <name>        Provider reasoning effort (e.g. high, max, minimal).
+ *   --no-auto               Don't pass --auto; honor the agent's own permission config (a headless
+ *                           run may then hang if the agent is set to ask for a permission).
  *   --resume-last           Continue the most recent OpenCode session; send only the delta brief.
  *   --session <id>          Continue a specific session id (ses_...); send only the delta brief.
  *   --pure                  Run OpenCode without external plugins (cleaner event stream).
@@ -70,6 +75,7 @@ function parseArgs(argv) {
     model: null,
     agent: "build",
     variant: null,
+    auto: true,
     resumeLast: false,
     session: null,
     pure: false,
@@ -95,6 +101,8 @@ function parseArgs(argv) {
       case "--agent": opts.agent = next(); break;
       case "--read-only": opts.agent = "plan"; break;
       case "--variant": opts.variant = next(); break;
+      case "--auto": opts.auto = true; break;
+      case "--no-auto": opts.auto = false; break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--session": opts.session = next(); break;
       case "--pure": opts.pure = true; break;
@@ -173,6 +181,9 @@ function buildArgv(opts) {
   }
   if (opts.model) argv.push("--model", opts.model);
   if (opts.variant) argv.push("--variant", opts.variant);
+  // --auto (on by default) auto-approves permissions so a headless run doesn't
+  // block on a prompt no one can answer; --no-auto honors the agent's own config.
+  if (opts.auto) argv.push("--auto");
   // No message argument: the brief is piped on stdin (see dispatchToOpenCode),
   // which avoids all argv-quoting issues with multi-line, XML-tagged briefs.
   return argv;
@@ -258,6 +269,7 @@ function makeResultWriter(opts, version, run) {
       workdir: opts.cd,
       agent: resuming ? "(inherited from resumed session)" : opts.agent,
       model: opts.model,
+      auto: opts.auto,
       resumeLast: opts.resumeLast,
       opencodeVersion: version,
       startedAt: run.startedAt,


### PR DESCRIPTION
## What

Adds `opencode-delegate` — a second implementer backend for the umbrella, driving the OpenCode CLI. Builds directly on **@essov3's port in #1**, whose commit is preserved in this branch's history; rebased onto current `master` (clean) and finished off.

## Fixes on top of #1

- **Require `--model` on a fresh run.** OpenCode has no safe default — a bare `opencode run` errors even with providers authenticated — so #1's optional `--model` passed that cryptic error straight through. The relay now fails fast (exit 2) with a clear message. Resumed runs (`--resume-last` / `--session`) inherit their session's model and are exempt.
- **The model choice is the point.** New "Choose the implementer model" step: `opencode models` is a ~400-entry catalog where most entries meter per token and only your subscriptions are flat-rate, and the CLI can't tell them apart — so the model is a deliberate, human-owned decision. That's the differentiator a single-model backend (codex-delegate) never had.
- **Applied the recent codex-delegate learnings.** Trimmed the description under the 1024 loader cap (1038 → 601), removed three recap sections that A/B-tested as no-ops on the codex twin, and ported the strengthened `review-and-land.md` (test-integrity check before the gate re-run + the implementer sweep — the gate-gaming defenses are backend-agnostic). `writing-the-brief.md` gains a "Match the model to the brief" section.
- Rescoped the README verification claim to what's actually been run.

## Kept intact from #1

@essov3's relay design — stdin brief, stdout `--format json`, a brace-aware event scanner for OpenCode's noisier output, the win32 `.cmd` fix, and the `build`/`plan` autonomy mapping — is unchanged.

## Verified

- Relay parses (Node 22); `--help` works.
- Fresh run with **no** `--model` → exit 2 + guidance, no `result.json` written; resume without `--model` correctly does **not** trip the guard.
- Description ≤ 1024; vocabulary grep clean; every reference link resolves.

Supersedes #1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `opencode-delegate` as a new delegate-skill option, including a standardized OpenCode relay run flow and artifacts/results handling.
* **Documentation**
  * Updated README to describe the shared brief→dispatch→poll→review→commit loop for both delegate skills, expanded install/requirements, and clarified validation/trust boundaries.
  * Added detailed `opencode-delegate` guides (skill overview, brief writing, dispatch/poll, review/land, and multi-task queues).
  * Refreshed scope/terminology and publishing instructions in `AGENTS.md` (including Windows smoke-test guidance).
* **Bug Fixes**
  * Improved “Codex unavailable” reporting by differentiating “no changes” from “git cannot report” using `touchedFiles`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->