### PR TITLE
Add cursor-delegate and antigravity-delegate skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,11 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   `--read-only` run against a throwaway repo) before relying on it.
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
   PowerShell/cmd, not just Git Bash/WSL): the `codex` and `opencode` launches need `shell:true` on
-  win32 to resolve the `.cmd` shim. The `agy` launch must **never** get `shell:true` — the brief
-  travels in argv (agy takes the prompt as the `--print` value, not on stdin), and agy is a real
-  native binary on every platform.
+  win32 to resolve the `.cmd` shim, and the `cursor-agent` launch keeps `shell:true` on win32 too (its
+  official installer ships a real binary, but the flag also resolves any shim-wrapped install; its argv
+  is guarded against whitespace on win32 for that reason). The `agy` launch must **never** get
+  `shell:true` — the brief travels in argv (agy takes the prompt as the `--print` value, not on
+  stdin), and agy is a real native binary on every platform.
 - Keep the README's "Verification status" honest — claim only what's been run.
 
 ## Local Claude Code config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Two skills ship today: `codex-delegate` (OpenAI Codex) and `opencode-delegate`
-(OpenCode); siblings like `gemini-delegate` can be added later without renaming the repo.
+and land the result. Four skills ship today: `codex-delegate` (OpenAI Codex), `opencode-delegate`
+(OpenCode), `cursor-delegate` (Cursor CLI), and `antigravity-delegate` (Google Antigravity CLI);
+siblings like `gemini-delegate` can be added later without renaming the repo.
 
 ## Vocabulary
 
@@ -14,7 +15,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the worker agent (Codex, OpenCode) | "worker", "sub-agent", "executor" |
+| **implementer** | the worker agent (Codex, OpenCode, Cursor, Antigravity) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -22,6 +23,8 @@ jargon. Use these terms; don't invent synonyms.
 | **relay** / `relay.mjs` | the dispatch **script** only | never a *category* of skills |
 | `exec`, `sandbox`, `resume`, `session` | Codex's own terms — use verbatim | don't paraphrase them |
 | `run`, `agent` (`build`/`plan`), `session` | OpenCode's own terms — use verbatim | "sandbox" (OpenCode has no sandbox enum; autonomy is the agent) |
+| `--print`, `--force`, `--trust`, `--mode` (`plan`/`ask`), `session` | Cursor CLI's own terms — use verbatim; the binary is `cursor-agent` | "yolo" (an alias; docs use `--force`) |
+| `--print`, `--add-dir`, `workspace`, `conversation`, `--dangerously-skip-permissions` | Antigravity CLI's own terms — use verbatim; the binary is `agy` | "session" (agy's term is conversation); any claim that `--mode plan` is read-only (verified: it is not enforced) |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -42,10 +45,11 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   the skill otherwise.
 - **Progressive disclosure:** keep `SKILL.md` lean; push depth into `references/*.md` that load only
   when needed.
-- **Executables:** keep them minimal and inspectable. Today there is one per skill —
-  `skills/codex-delegate/scripts/relay.mjs` and `skills/opencode-delegate/scripts/relay.mjs` — each
-  Node built-ins only, no dependencies, no network calls of its own, no credentials, no telemetry. New
-  scripts must hold the same line, and the README's trust section must stay accurate.
+- **Executables:** keep them minimal and inspectable. Today there is one per skill — each skill's
+  `scripts/relay.mjs` — each Node built-ins only, no dependencies, no network calls of its own, no
+  credentials, no telemetry. (The `antigravity-delegate` relay additionally reads agy's local
+  conversation-id cache; any such read must be disclosed in the relay header and the README's trust
+  section.) New scripts must hold the same line, and the README's trust section must stay accurate.
 
 ## Before publishing a change
 
@@ -53,8 +57,10 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - Smoke-test any changed script directly (e.g. `node skills/<skill>/scripts/relay.mjs --help`, and a
   `--read-only` run against a throwaway repo) before relying on it.
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
-  PowerShell/cmd, not just Git Bash/WSL): both the `codex` and `opencode` launches need `shell:true` on
-  win32 to resolve the `.cmd` shim.
+  PowerShell/cmd, not just Git Bash/WSL): the `codex` and `opencode` launches need `shell:true` on
+  win32 to resolve the `.cmd` shim. The `agy` launch must **never** get `shell:true` — the brief
+  travels in argv (agy takes the prompt as the `--print` value, not on stdin), and agy is a real
+  native binary on every platform.
 - Keep the README's "Verification status" honest — claim only what's been run.
 
 ## Local Claude Code config

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ is nothing for a relay to drive. Its GLM models are still reachable for delegati
 - For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai) installed and authenticated
   (`opencode auth login`).
 - For `cursor-delegate`: the [`cursor-agent` CLI](https://cursor.com/docs/cli) installed and
-  authenticated (`cursor-agent login`).
+  authenticated (`cursor-agent login`). The installer links the same binary as both `cursor-agent` and
+  `agent`; the relay invokes `cursor-agent`, so that name must resolve.
 - For `antigravity-delegate`: the [`agy` CLI](https://antigravity.google/docs/cli-install) installed
   and signed in with a Google account (first run opens the sign-in flow).
 - Node 18+ and `git`.
@@ -162,10 +163,13 @@ This package is intentionally inspectable:
 default. For `cursor-delegate` and `antigravity-delegate` the dispatch mechanics were verified with live
 runs against `cursor-agent` 2026.07.09 and `agy` 1.1.1: headless write runs, resume, result capture,
 plan-mode read-only enforcement (Cursor — enforced; Antigravity — **not** enforced, which is why its
-relay refuses `--read-only`), and agy's scratch-directory behavior without `--add-dir`. The full
-delegate → review → commit loop is designed for and run on Claude Code but not yet formally verified
-end-to-end here on a real task. Other orchestrators are designed-for but unproven. This line gets
-upgraded to "verified end-to-end" with evidence, not assumption.
+relay refuses `--read-only`), and agy's scratch-directory behavior without `--add-dir`. Those live runs
+were on macOS: **native Windows smoke testing has not been performed**, so the win32 launch paths (the
+`shell:true` handling in the `codex`, `opencode`, and `cursor-agent` relays, and the shell-less `agy`
+launch) remain designed-for but unverified. The full delegate → review → commit loop is designed for
+and run on Claude Code but not yet formally verified end-to-end here on a real task. Other
+orchestrators are designed-for but unproven. This line gets upgraded to "verified end-to-end" with
+evidence, not assumption.
 
 ## Repository shape
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, hands it to an implementer CLI, then reviews the diff and
 commits — staying the reviewer the whole way.
 
-Two skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, and **`opencode-delegate`**
-drives the OpenCode CLI. Same loop, different implementer.
+Four skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, **`opencode-delegate`**
+drives the OpenCode CLI, **`cursor-delegate`** drives the Cursor CLI, and **`antigravity-delegate`**
+drives Google's Antigravity CLI. Same loop, different implementer.
 
 ## Install
 
@@ -23,6 +24,8 @@ Install the package, or just one skill:
 npx skills add amElnagdy/delegate-skills
 npx skills add amElnagdy/delegate-skills --skill codex-delegate
 npx skills add amElnagdy/delegate-skills --skill opencode-delegate
+npx skills add amElnagdy/delegate-skills --skill cursor-delegate
+npx skills add amElnagdy/delegate-skills --skill antigravity-delegate
 ```
 
 Install for a specific agent, or globally:
@@ -89,10 +92,43 @@ quoting.
 **You'll feel it when:** a bounded task gets handed to OpenCode, comes back as a clean diff with a
 structured report and the run's cost, and you commit it after re-running the gates yourself.
 
+### cursor-delegate
+
+Drive the Cursor CLI (`cursor-agent`) as a background implementer: write the brief, dispatch via
+`relay.mjs`, review the diff, commit it yourself. Same four references and loop as its siblings.
+Headless permissions have two switches, and the relay sets both: file edits apply without prompting,
+and `--force` (the relay default) lets approval-gated shell commands auto-run so the brief's gate
+commands actually execute. `--read-only` maps to cursor-agent's `plan` mode, which is **enforced** —
+a plan run cannot write the tree. The brief is piped on stdin, so multi-line XML briefs need no quoting.
+
+**You'll feel it when:** a bounded task gets handed to Cursor, comes back as a clean diff with a
+structured report, the session id for rework, and the run's token usage — and you commit it after
+re-running the gates yourself.
+
+### antigravity-delegate
+
+Drive Google's Antigravity CLI (`agy`) as a background implementer: write the brief, dispatch via
+`relay.mjs`, review the diff, commit it yourself. Same four references and loop as its siblings, with
+two verified agy quirks encoded: the relay always adds the working root to agy's workspace
+(`--add-dir` — without it agy edits its own scratch directory, not the repo), and it offers **no
+`--read-only` flag** because agy has no enforced read-only mode (`--mode plan` can still write the
+tree). It also raises agy's 5-minute print timeout to a delegation-sized default.
+
+**You'll feel it when:** a bounded task gets handed to Antigravity, comes back as a clean diff with a
+structured report and the conversation id for rework — and you commit it after re-running the gates
+yourself.
+
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
 Reserved so the umbrella can grow without a rename.
+
+### What about ZCode?
+
+No skill — for now, deliberately. Z.ai's ZCode is a desktop app with no CLI or headless mode, so there
+is nothing for a relay to drive. Its GLM models are still reachable for delegation today through
+`opencode-delegate` (pick a GLM model with `--model`). If ZCode ships an official CLI, a
+`zcode-delegate` sibling can join without a rename.
 
 ## Requirements
 
@@ -100,6 +136,10 @@ Reserved so the umbrella can grow without a rename.
   (`codex login`).
 - For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai) installed and authenticated
   (`opencode auth login`).
+- For `cursor-delegate`: the [`cursor-agent` CLI](https://cursor.com/docs/cli) installed and
+  authenticated (`cursor-agent login`).
+- For `antigravity-delegate`: the [`agy` CLI](https://antigravity.google/docs/cli-install) installed
+  and signed in with a Google account (first run opens the sign-in flow).
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -111,16 +151,21 @@ This package is intentionally inspectable:
 - All skill content is Markdown, plus exactly **one** executable per skill — each a `scripts/relay.mjs`.
 - Each `relay.mjs` makes no network calls, reads or writes no credentials, sends no telemetry, and has
   no dependencies (Node built-ins only). It shells out only to its implementer CLI (`codex` /
-  `opencode`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the script
-  before you run it.
-- Neither ever commits — committing is always the orchestrator's job, after review.
+  `opencode` / `cursor-agent` / `agy`) and `git`. (The `antigravity-delegate` relay additionally reads
+  one local agy cache file — the per-directory conversation-id map — so `result.json` can carry the id
+  for a later resume.) That CLI authenticates exactly as you do at the terminal. Read the script before
+  you run it.
+- None of them ever commits — committing is always the orchestrator's job, after review.
 
 **Verification status:** each relay's mechanics are verified — argument handling, exit codes,
 `result.json`, resume, and (for `opencode-delegate`) the required-model guard, since OpenCode has no safe
-default. The full delegate → review → commit loop is designed for and run on Claude Code but not yet
-formally verified end-to-end here (OpenCode's cold start is slow in constrained shells, so exercise a
-real run in a normal terminal). Other orchestrators (Cursor, …) are designed-for but unproven. This line
-gets upgraded to "verified end-to-end" with evidence, not assumption.
+default. For `cursor-delegate` and `antigravity-delegate` the dispatch mechanics were verified with live
+runs against `cursor-agent` 2026.07.09 and `agy` 1.1.1: headless write runs, resume, result capture,
+plan-mode read-only enforcement (Cursor — enforced; Antigravity — **not** enforced, which is why its
+relay refuses `--read-only`), and agy's scratch-directory behavior without `--add-dir`. The full
+delegate → review → commit loop is designed for and run on Claude Code but not yet formally verified
+end-to-end here on a real task. Other orchestrators are designed-for but unproven. This line gets
+upgraded to "verified end-to-end" with evidence, not assumption.
 
 ## Repository shape
 
@@ -134,14 +179,18 @@ skills/
 │       ├── dispatch-and-poll.md
 │       ├── review-and-land.md
 │       └── multi-task-queues.md
-└── opencode-delegate/
+├── opencode-delegate/
+│   ├── SKILL.md
+│   ├── scripts/relay.mjs
+│   └── references/ (same four)
+├── cursor-delegate/
+│   ├── SKILL.md
+│   ├── scripts/relay.mjs
+│   └── references/ (same four)
+└── antigravity-delegate/
     ├── SKILL.md
     ├── scripts/relay.mjs
-    └── references/
-        ├── writing-the-brief.md
-        ├── dispatch-and-poll.md
-        ├── review-and-land.md
-        └── multi-task-queues.md
+    └── references/ (same four)
 ```
 
 The `SKILL.md` stays small so it loads cheaply; the references load only when the task needs them.

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -6,7 +6,9 @@
       "description": "Delegate a coding task to a CLI implementer agent, then review the diff and commit it yourself.",
       "skills": [
         "codex-delegate",
-        "opencode-delegate"
+        "opencode-delegate",
+        "cursor-delegate",
+        "antigravity-delegate"
       ]
     }
   ]

--- a/skills/antigravity-delegate/SKILL.md
+++ b/skills/antigravity-delegate/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: antigravity-delegate
+description: >-
+  Delegate a coding task to the Antigravity CLI (agy, Google's terminal coding agent) as a background
+  implementer, then review its diff and land it yourself. Use this whenever the user wants to hand
+  implementation work to Antigravity — phrasings like "have Antigravity do X", "delegate this to agy",
+  "run it through Antigravity", or "use agy to implement/fix/refactor" — or wants to run a queue of
+  coding tasks through Antigravity while staying the reviewer. Prefer it when the user will review the
+  diff and commit it themselves. DO NOT USE for tasks small enough to do inline, for review-only
+  dispatches that must be guaranteed read-only (agy has no enforced read-only mode), or when the user
+  wants the code written directly without delegating.
+license: MIT
+compatibility: Requires the `agy` CLI (Antigravity CLI) installed and signed in with a Google account, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows; Antigravity also ships native Windows installers).
+metadata:
+  version: 0.1.0
+---
+
+# Antigravity Delegate
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the Antigravity CLI (`agy`) — then review what it produced and land it yourself. You
+write the brief and own the judgment; agy does the typing in its own conversation; you verify and
+commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so any agent with those two capabilities — Claude Code, a sibling CLI session,
+or a comparable one — can drive it. (It is designed for and run on Claude Code; treat other
+orchestrators as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `agy` CLI is not installed or not signed in (first run opens a Google sign-in flow).
+- **You need a guaranteed read-only run.** agy has no enforced read-only mode — `--mode plan` was
+  verified to still write the working tree — so review/diagnosis dispatches can touch files. Use an
+  implementer with an enforced read-only mode for that, or work on a branch/stash and verify the tree
+  afterward.
+- You want to write the code yourself.
+
+## Prerequisites (check once)
+
+1. `agy --version` succeeds. If not, install (`curl -fsSL https://antigravity.google/cli/install.sh |
+   bash`; Antigravity's docs also list native Windows installers) and sign in on first run.
+2. **Confirm which `agy` is on PATH.** `command -v agy` shows the active binary and `agy --version` its
+   version. The relay records the version it ran into `result.json`, so a stale binary is visible after
+   the fact.
+3. You are in (or will point `--cd` at) the target git repository.
+
+## Choose the implementer model (optional)
+
+agy has a usable default model, so `--model` is optional — but still worth setting deliberately.
+`agy models` lists the available models (Gemini tiers plus partner models, depending on the account's
+plan). Match the model to the brief: a fast model for a mechanical sweep (rename, migration, removal);
+a strong one for a subtle bug or a money/security path. If the human has stated model preferences for
+delegated work (in the repo's `AGENTS.md` or their `CLAUDE.md`), honor those.
+
+More depth: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+agy sees **only** the text you send plus what it can read from the working tree — no chat history, no
+shared context. Everything the task needs goes in the brief: the goal, the current state, what to
+change, what to leave untouched, the project's **actual** gate commands (discover them from the repo's
+AGENTS.md/CLAUDE.md/Makefile — do not assume), and a report contract. Tell agy it will **not** commit
+(you will). Keep one task per brief. Full guidance and a template:
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to agy with the bundled helper. It wraps `agy --print`, captures the run, and writes a
+structured `result.json` — so your only job is "run a command, read a file." (`<skill-dir>` below is
+this skill's installed directory — the folder containing this `SKILL.md`. Claude Code prints it as
+"Base directory for this skill" when the skill loads; on other orchestrators use that same directory —
+if unsure where it landed, run `find ~ -name relay.mjs -path '*antigravity-delegate*'` and substitute
+the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# pick a model explicitly:                add --model <name>       (default: agy's configured default)
+# continue this repo's last conversation: add --resume-last        (delta brief only)
+# longer/shorter run budget:              add --timeout <duration> (default 60m; agy's own default is 5m)
+# see all options:                        node .../relay.mjs --help
+```
+
+The helper always adds the working root to agy's workspace (`--add-dir`) — without that, agy does its
+work in its own scratch directory instead of the repo (verified) — and writes its artifacts to a temp
+dir, so the repo under review stays clean. It **never commits** — see step 5. Mechanics, flags, and the
+`result.json` shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until agy finishes, so back it with whatever your orchestrator offers and resume when
+it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job`
+  in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a `status`. (A
+  pre-run usage error — bad args or an empty brief — instead exits with code 2 and writes no result
+  file, so check the exit code too. A missing `agy` binary exits 127 but *does* write a `result.json`
+  with status `agy_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line.
+
+### 4. Review — do not trust the self-report
+
+agy's `result.json` includes its own final message and any gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did agy do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Committing should be the act of
+the party that verified the work. Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
+  review again.
+
+## Autonomy model
+
+Every agy dispatch is **write-capable** — plan on it (all verified against agy 1.1.1):
+
+- agy only works on directories in its **workspace**: the relay always passes `--add-dir` for the
+  working root. Without it, agy operates in its own scratch directory and the repo never changes.
+- **There is no enforced read-only mode.** agy's `--mode plan` still writes the working tree when asked
+  to, so the relay refuses a `--read-only` flag rather than offer a false promise. If you need
+  isolation, work on a branch or stash first — and treat `touchedFiles` after any "review" dispatch as
+  a real diff to inspect.
+- Permissions **auto-approve by default**: the relay passes agy's `--dangerously-skip-permissions` so a
+  headless run never blocks on a prompt no one can answer. That is the point of unattended delegation —
+  the orchestrator's diff review and the implementer sweep (step 4) are the safety net, not a
+  per-action prompt. Pass `--no-skip-permissions` to withhold it and rely on agy's own defaults (which
+  already allow workspace file edits and safe commands headlessly, but may refuse riskier commands).
+- Headless runs are budgeted by agy's `--print-timeout`. agy's own default (5m) is too short for real
+  delegated work, so the relay defaults it to 60m; a run that exceeds the budget fails with
+  "timeout waiting for response".
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report agy's design decisions, defensible-but-unasked turns, and
+non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if correct
+completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
+is in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief agy can
+  execute blind: structure, XML blocks, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the rework cycle via `--resume-last`.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.

--- a/skills/antigravity-delegate/SKILL.md
+++ b/skills/antigravity-delegate/SKILL.md
@@ -39,8 +39,10 @@ orchestrators as designed-for, not yet proven.)
 
 ## Prerequisites (check once)
 
-1. `agy --version` succeeds. If not, install (`curl -fsSL https://antigravity.google/cli/install.sh |
-   bash`; Antigravity's docs also list native Windows installers) and sign in on first run.
+1. `agy --version` succeeds. If not, install it — download the installer and review it before running
+   (`curl -fsSL https://antigravity.google/cli/install.sh -o agy-install.sh`, read the script, then
+   `bash agy-install.sh`; Antigravity's docs also list native Windows installers) — and sign in on
+   first run.
 2. **Confirm which `agy` is on PATH.** `command -v agy` shows the active binary and `agy --version` its
    version. The relay records the version it ran into `result.json`, so a stale binary is visible after
    the fact.

--- a/skills/antigravity-delegate/references/dispatch-and-poll.md
+++ b/skills/antigravity-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,140 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `agy --print`, runs the brief in the working root's
+workspace, captures the output, and writes a structured `result.json`. Your job collapses to: run one
+command, then read one file. Everything Antigravity-specific lives in the helper, which is what keeps
+the loop portable across orchestrators.
+
+## Before the first run: check the binary
+
+Two gotchas, both worth 30 seconds:
+
+```bash
+command -v agy    # the active binary on PATH
+agy --version     # the relay records this in result.json too
+```
+
+If `agy` has never been run, its first invocation opens a Google sign-in flow — do that once
+interactively before dispatching headless runs.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for agy (default: current directory). The relay passes it to agy as `--add-dir` **and** uses it as the working directory — both are load-bearing (see below). |
+| `--model <name>` | Antigravity model (default: agy's configured default; `agy models` lists the choices). |
+| `--no-skip-permissions` | The relay passes agy's `--dangerously-skip-permissions` **by default** so a headless run doesn't block on a prompt; `--no-skip-permissions` drops it and relies on agy's own defaults (which allow workspace file edits and safe commands headlessly, but may refuse riskier commands). |
+| `--timeout <duration>` | agy's `--print-timeout` budget, Go duration format (e.g. `45m`, `2h`). Default `60m` — agy's own 5m default is too short for real delegated tasks. |
+| `--resume-last` | Continue the working root's most recent agy conversation; send only the delta brief (see review-and-land). |
+| `--conversation <id>` | Continue a specific conversation id; send only the delta brief. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+There is **no `--read-only` flag, on purpose**: agy has no enforced read-only mode (`--mode plan` was
+verified to still write the working tree), so the relay refuses the flag with an explanation rather
+than offer a false promise. Treat every dispatch as write-capable.
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only agy's edits and nothing of the helper's own.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `tool` — `agy`
+- `status` — `completed` | `failed` | `agy_unavailable`
+- `exitCode` — mirrors agy's exit code; `127` if `agy` isn't on PATH
+- `agyVersion` — the binary that actually ran
+- `conversationId` — feed this to a later `--conversation <id>` (or use `--resume-last`). Best-effort:
+  the relay reads it from agy's local per-directory conversation cache after the run; `null` if the
+  cache is absent or reshaped
+- `finalMessage` — agy's printed response, plain text (agy has no JSON output mode). Thin if the run
+  ended without a written summary — ask for the report explicitly
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point.
+  `null` (not `[]`) when git can't report — `git` missing, or a non-repo run; `[]` means git ran and
+  the tree is clean
+- `briefPath` / `finalPath` — the exact brief relay sent and the final-message file
+- `workdir`, `model`, `skipPermissions`, `timeout`, `resumeLast`, `startedAt`, `finishedAt`
+- `stderrTail` — last ~20 stderr lines; present **only** on a failed run
+- `error` — present **only** if agy failed to launch
+
+The helper also prints a summary to stdout and exits with agy's exit code, so a wrapping script can
+branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until agy finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job` in PowerShell,
+  `start /b` in cmd). A run is done when `result.json` exists with a `status`. **But** a pre-run usage
+  error (bad args, empty brief) exits with code 2 *before* writing any file — so check the exit code
+  too, don't only watch for the file. (A missing `agy` binary exits 127 but *does* write a
+  `result.json` with status `agy_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: agy_unavailable` (exit 127):** `agy` isn't on PATH or isn't found. Install
+  (`curl -fsSL https://antigravity.google/cli/install.sh | bash`), sign in on first run, then
+  re-dispatch.
+- **`status: failed` with "timeout waiting for response" in `stderrTail` or `finalMessage`:** the run
+  exceeded its `--print-timeout` budget (relay default 60m). Re-dispatch with a bigger `--timeout`, or
+  split the brief into smaller tasks.
+- **`status: failed`, other:** read `result.json`'s `stderrTail` for the cause. Common causes: an auth
+  lapse (run `agy` interactively once to re-sign-in) or an unknown `--model`. Fix the cause and
+  re-dispatch; don't paper over it by doing the work yourself unless that's what the user wants.
+- **The repo didn't change but the report claims work was done:** check whether the report's file links
+  point at agy's scratch directory instead of the repo. The relay always passes `--add-dir` for the
+  working root precisely to prevent this, but a brief that names no target directory can still steer
+  agy to scratch — name the working root in the brief (see
+  [writing-the-brief.md](writing-the-brief.md)).
+- **Thin `finalMessage`:** the run ended without a written closing summary. The edits may still be
+  correct — check `touchedFiles` and the diff. To get a report next time, add a
+  `<structured_output_contract>` block.
+
+## What the helper is doing (and the alternatives)
+
+Under the hood the helper runs roughly:
+
+```bash
+agy --add-dir /path/to/repo --print-timeout 60m --dangerously-skip-permissions --print "<brief>"                      # fresh run
+agy --add-dir /path/to/repo --print-timeout 60m --dangerously-skip-permissions --continue --print "<delta brief>"     # resume most recent
+agy --add-dir /path/to/repo --print-timeout 60m --dangerously-skip-permissions --conversation <id> --print "<delta>"  # resume a specific conversation
+```
+
+Two mechanics worth knowing:
+
+- **The brief travels as the `--print` value** — agy's non-interactive mode takes the prompt as an
+  argument and does not read stdin (the relay still accepts the brief on *its own* stdin or via
+  `--brief`, then hands it to agy as a single argv entry, so multi-line XML briefs need no quoting; no
+  shell is involved on any platform). One consequence: a brief that runs to tens of kilobytes can
+  exceed a platform's argument-length limit (Windows is the tightest) — keep briefs task-sized, which
+  they should be anyway.
+- **The working directory is load-bearing twice.** `--add-dir` puts the repo in agy's workspace (without
+  it agy works in its own scratch directory — verified), and the process working directory is what agy
+  keys its per-directory conversation history on, which is what makes `--resume-last` pick up *this*
+  repo's conversation. The relay sets both from `--cd`.
+
+If you ever want it, raw `agy --print` is fine for one-offs — you just give up the captured
+`result.json`, touched-files summary, and conversation-id lookup the helper does for you.
+
+## The commit boundary
+
+The helper never commits — by design, not omission. The robust contract is: agy edits the working tree,
+the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/antigravity-delegate/references/dispatch-and-poll.md
+++ b/skills/antigravity-delegate/references/dispatch-and-poll.md
@@ -90,9 +90,9 @@ process has exited and `result.json` is written — not when a status line says 
 
 ## When a run misbehaves
 
-- **`status: agy_unavailable` (exit 127):** `agy` isn't on PATH or isn't found. Install
-  (`curl -fsSL https://antigravity.google/cli/install.sh | bash`), sign in on first run, then
-  re-dispatch.
+- **`status: agy_unavailable` (exit 127):** `agy` isn't on PATH or isn't found. Install it — download
+  the installer and review it before running (`curl -fsSL https://antigravity.google/cli/install.sh -o
+  agy-install.sh`, read it, then `bash agy-install.sh`) — sign in on first run, then re-dispatch.
 - **`status: failed` with "timeout waiting for response" in `stderrTail` or `finalMessage`:** the run
   exceeded its `--print-timeout` budget (relay default 60m). Re-dispatch with a bigger `--timeout`, or
   split the brief into smaller tasks.

--- a/skills/antigravity-delegate/references/multi-task-queues.md
+++ b/skills/antigravity-delegate/references/multi-task-queues.md
@@ -1,0 +1,70 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential. One extra
+agy-specific caution: agy keys its conversation history per directory, so two concurrent runs in the
+same working root would also fight over what `--resume-last` means. (Each fresh `relay.mjs` dispatch
+starts a new agy conversation, so independent tasks don't share context — fold any shared constraint
+into each brief, see below.)
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. A fresh agy conversation has no memory of the earlier run, so a
+constraint that emerged in task 2 must be restated in task 5's brief or it won't hold. This is the
+queue equivalent of keeping briefs self-contained.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions agy made, non-blocking nitpicks, anything you want the human
+  to overrule or confirm. This is the section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/antigravity-delegate/references/review-and-land.md
+++ b/skills/antigravity-delegate/references/review-and-land.md
@@ -1,0 +1,121 @@
+# Review and land
+
+agy did the typing; you own the judgment. This is where delegation earns its keep or quietly ships a
+mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
+reality, never against the self-report — and read the diff as generated code, which fails in ways a
+green gate can't see.**
+
+One agy-specific habit up front: because agy has no enforced read-only mode, **check `touchedFiles`
+after every dispatch, including "review-only" ones.** A diagnosis run that touched the tree is a diff
+to review like any other.
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries agy's own claim that the gates passed. Treat that as a claim, not evidence —
+re-run the project's actual test/lint/build commands in the working tree and read the output. And keep
+the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a gate,
+not just misreport it — that is what the test check above and the sweep below exist to catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Scope creep** — did agy change things the brief said to leave untouched? Unasked refactors,
+  renames, "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version? Check in particular that the work landed in the repo and not in agy's
+  scratch directory (the report's file links tell you).
+- **Quiet judgment calls** — sometimes agy makes a defensible decision the brief didn't anticipate.
+  Don't just accept it because it looks reasonable; understand it and decide.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If agy couldn't implement something,
+  the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to agy as a delta brief (below) or gets fixed in the tree before
+commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never the implementer. A
+headless agy run *can* write the working tree, but committing should be the act of the party that
+verified the work, not the one that produced it. Write a clear message describing what landed. If your
+project attributes co-authorship, that's the place for it.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same agy conversation
+with just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
+
+`--resume-last` continues the working root's most recent agy conversation, so a short delta is enough.
+(The relay runs agy from `--cd`, which is what scopes "most recent" to this repo; `--conversation <id>`
+pins an exact one — the id is in the previous run's `result.json`.) Then review again — rework gets the
+same gate-rerun, test check, diff-read, and sweep as the original, no shortcuts. Repeat until it's
+right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** agy made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or agy's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/antigravity-delegate/references/writing-the-brief.md
+++ b/skills/antigravity-delegate/references/writing-the-brief.md
@@ -1,0 +1,136 @@
+# Writing the brief
+
+A brief is the entire task as agy will see it. agy runs in a fresh conversation with **no memory of
+your conversation, no access to your prior notes, and no shared context** — only the text you send and
+whatever it can read from the working tree. If a constraint isn't in the brief or discoverable in the
+repo, it doesn't exist for agy. The single most common failure is a brief that assumes context agy
+doesn't have.
+
+## Match the model to the brief
+
+agy has a usable default model, so a bare dispatch runs; naming one anyway is often worth it:
+
+- **The available set is the account's.** `agy models` lists the choices (Gemini tiers plus partner
+  models, depending on the account's plan). If the human has stated model preferences for delegated
+  work (in the target repo's `AGENTS.md` or their `CLAUDE.md`), honor those; when in doubt about
+  cost-sensitive choices, ask rather than guess.
+- **Read the task's difficulty off the brief you just wrote.** A mechanical, well-bounded brief — a
+  rename sweep, a library migration, a dead-code removal — is safe on a fast model. A brief whose risk
+  lives in judgment — a concurrency fix, a money or auth path, an ambiguous spec — wants a strong one,
+  because the sweep's failure modes (plausible-but-wrong logic, swallowed errors) are exactly what a
+  weaker model produces more of.
+- **A resumed run continues its conversation.** With `--resume-last` / `--conversation`, send only the
+  delta brief.
+
+## The shape that works
+
+agy responds well to compact, block-structured prompts with XML tags rather than long prose. State the
+task, what "done" looks like, how to behave by default, and the few constraints that actually matter.
+Add a block only when the task needs it — don't ship empty ceremony.
+
+One agy-specific rule: **name the working root in the brief.** agy's workspace can hold several
+directories, and its scratch space is always available — an explicit "work only under /path/to/repo"
+line pins the edits where you expect them (the relay adds the directory to the workspace, but the brief
+should still say it's the target).
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives (the absolute path of the working root).
+Then the specifics — current state, what to change, and explicitly what to leave untouched. The
+"leave untouched" list is what keeps agy from wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task, inside the working root only. No unrelated refactors, renames, or
+cleanup unless required for correctness. Do NOT run git add or git commit — the orchestrator commits
+after reviewing. Leave the work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis** — add `<grounding_rules>` (ground every claim in evidence; label inferences)
+  and an explicit "do not modify any files" instruction. **Treat that instruction as advisory, not
+  enforced** — agy has no read-only mode, so check `touchedFiles` afterward and expect it to be empty.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Always ask for the report explicitly
+
+agy's `--print` output is the plain text it chooses to print when it stops — there is no structured
+event stream to assemble a report from. If the agent finishes a task purely through tool calls and
+stops without a closing summary, `finalMessage` comes back thin — not a relay defect, just nothing
+said. The `<structured_output_contract>` block is what guarantees a report you can read: it tells agy
+to end with a written summary, so the result file carries one.
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you an agy that guesses — or skips.
+
+## Honor the repo's conventions
+
+If the project forbids certain things in code — say, spec/ticket IDs in comments, process language like
+"MVP"/"for now"/"phase N", or specific test conventions, whatever the repo's own conventions ban —
+restate the load-bearing ones in the brief. agy can read the repo's rules files from the working tree,
+but its compliance is only as reliable as what's explicitly in front of it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and suggest
+a roadmap" produces a muddled run; split it into separate dispatches. One brief → one agy run → one
+commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at /home/dev/shop/services/billing/, the refund path double-charges when a
+refund is retried after a network timeout (the idempotency key isn't checked before re-submitting).
+Make the refund submission idempotent: check for an existing refund by idempotency key before creating
+a new one. Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes,
+and the data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix, inside /home/dev/shop only. No unrelated refactors. Do
+NOT git add or commit; leave changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/antigravity-delegate/scripts/relay.mjs
+++ b/skills/antigravity-delegate/scripts/relay.mjs
@@ -258,7 +258,7 @@ function makeResultWriter(opts, version, run) {
 function reportUnavailable(writeResult, resultPath) {
   const result = writeResult({ status: "agy_unavailable", exitCode: 127, conversationId: null, finalMessage: "", touchedFiles: null });
   printSummary(result, resultPath);
-  process.stderr.write("relay: `agy` not found on PATH. Install the Antigravity CLI (curl -fsSL https://antigravity.google/cli/install.sh | bash) and sign in on first run.\n");
+  process.stderr.write("relay: `agy` not found on PATH. Install the Antigravity CLI (see https://antigravity.google/docs/cli-install — download the installer and review it before running) and sign in on first run.\n");
   process.exit(127);
 }
 

--- a/skills/antigravity-delegate/scripts/relay.mjs
+++ b/skills/antigravity-delegate/scripts/relay.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · antigravity-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Antigravity CLI (`agy --print`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Antigravity-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against agy 1.1.1.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `agy` and `git`, and reads one local agy cache
+ * file (last_conversations.json) to report the conversation id for resume.
+ * The `agy` process it launches does authenticate — exactly as you do at the
+ * terminal. Read this file before you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job —
+ * after it reviews the diff and re-runs the project gates.
+ *
+ * Two verified agy behaviors shape this relay:
+ *   1. The working root must be added to agy's workspace with --add-dir, or agy
+ *      does its work in its own scratch directory instead of the repo. The relay
+ *      always passes --add-dir for the working root.
+ *   2. There is NO enforced read-only mode: `--mode plan` can still write the
+ *      working tree (verified). This relay therefore has no --read-only flag and
+ *      treats every run as write-capable — work on a branch or snapshot first if
+ *      you need isolation.
+ *
+ * Permissions auto-approve by default: the relay passes agy's
+ * `--dangerously-skip-permissions` so a headless run never blocks on a prompt no
+ * one can answer; the orchestrator's diff review is the safety net. Pass
+ * --no-skip-permissions to withhold it and rely on agy's own defaults (which
+ * already allow workspace file edits and safe commands headlessly, but may
+ * refuse riskier commands).
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *                           (Read by the relay; agy itself receives it as the --print value.)
+ *   --cd <dir>              Working root for agy (default: current directory). Passed as
+ *                           --add-dir and used as the working directory.
+ *   --model <name>          Antigravity model (default: agy's own configured default;
+ *                           `agy models` lists the choices).
+ *   --no-skip-permissions   Don't pass `--dangerously-skip-permissions`; rely on agy's
+ *                           own permission defaults instead.
+ *   --timeout <duration>    agy --print-timeout value, Go duration format (default: 60m —
+ *                           agy's own 5m default is too short for real delegated tasks).
+ *   --resume-last           Continue the working root's most recent agy conversation;
+ *                           send only the delta brief.
+ *   --conversation <id>     Continue a specific conversation id; send only the delta brief.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, agyVersion, conversationId (for a later resume, best-effort),
+ *   finalMessage (agy's printed response — plain text; agy has no JSON output mode),
+ *   touchedFiles (git porcelain, null if git can't report), and the path to final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `agy` binary exits 127;
+ * otherwise the exit code mirrors agy's own (0 success, non-zero failure; a
+ * --print-timeout expiry exits 1 with "Error: timeout waiting for response").
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, or agy_unavailable. An orchestrator that polls for the
+ * file must therefore also treat a non-zero exit with no file as a usage error.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, realpathSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { tmpdir, homedir } from "node:os";
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    skipPermissions: true,
+    timeout: "60m",
+    resumeLast: false,
+    conversation: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--no-skip-permissions": opts.skipPermissions = false; break;
+      case "--timeout": opts.timeout = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--conversation": opts.conversation = next(); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      case "--read-only":
+        // Refused on purpose, not unimplemented: agy has no enforced read-only —
+        // `--mode plan` was verified to still write the working tree, so offering
+        // a --read-only flag here would be a false promise.
+        fail("agy has no enforced read-only mode (a plan-mode run can still write the tree); treat every dispatch as write-capable — work on a branch or stash first if you need isolation");
+        break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to agy --print\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function agyVersion() {
+  try {
+    // agy ships as a real native binary on every platform (curl/PowerShell
+    // installer, never an npm .cmd shim), so no shell:true is needed anywhere —
+    // and it must stay off: the brief travels in argv (agy --print takes the
+    // prompt as a value, it does not read stdin), and a shell would mangle a
+    // multi-line XML brief.
+    return execFileSync("agy", ["--version"], { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git can't report — git missing, or a non-repo run — so the
+  // caller can tell "git unavailable" apart from "agy changed nothing."
+  // [] means git ran and the working tree is clean.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, brief) {
+  // --add-dir is not optional: without the working root in agy's workspace, agy
+  // does the work in its own scratch directory (~/.gemini/antigravity-cli/scratch)
+  // and the repo never changes (verified).
+  const argv = ["--add-dir", opts.cd, "--print-timeout", opts.timeout];
+  if (opts.conversation) {
+    argv.push("--conversation", opts.conversation);
+  } else if (opts.resumeLast) {
+    argv.push("--continue");
+  }
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.skipPermissions) argv.push("--dangerously-skip-permissions");
+  // The brief is the value of --print — agy's non-interactive mode takes the
+  // prompt as an argument and does not read stdin. spawn() passes it as a single
+  // argv entry with no shell involved, so multi-line XML briefs need no quoting.
+  argv.push("--print", brief);
+  return argv;
+}
+
+function conversationIdFor(cd) {
+  // Best-effort: agy records each directory's most recent conversation id in a
+  // local cache. Reading it lets result.json carry the id for a later
+  // --conversation resume. Absent or reshaped cache → null, never an error.
+  try {
+    const cachePath = join(homedir(), ".gemini", "antigravity-cli", "cache", "last_conversations.json");
+    const map = JSON.parse(readFileSync(cachePath, "utf8"));
+    if (map[cd]) return map[cd];
+    // agy stores the fully-resolved path (e.g. /private/tmp on macOS, not /tmp).
+    const real = realpathSync(cd);
+    return map[real] || null;
+  } catch {
+    return null;
+  }
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only agy's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    finalPath: join(outDir, "final.txt"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "agy",
+      workdir: opts.cd,
+      model: opts.model,
+      skipPermissions: opts.skipPermissions,
+      timeout: opts.timeout,
+      resumeLast: opts.resumeLast,
+      agyVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      ...extra,
+    };
+    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "agy_unavailable", exitCode: 127, conversationId: null, finalMessage: "", touchedFiles: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `agy` not found on PATH. Install the Antigravity CLI (curl -fsSL https://antigravity.google/cli/install.sh | bash) and sign in on first run.\n");
+  process.exit(127);
+}
+
+function dispatchToAgy(opts, brief, run, writeResult) {
+  const argv = buildArgv(opts, brief);
+  // Pin the working root two ways: `cwd` sets the child's real directory (agy
+  // keys its per-directory conversation history on it, which is what makes
+  // --resume-last pick up this repo's conversation), and PWD is set explicitly
+  // because spawn does NOT rewrite the inherited PWD env.
+  // No shell anywhere: the brief travels as one argv entry (see agyVersion).
+  const child = spawn("agy", argv, {
+    cwd: opts.cd,
+    env: { ...process.env, PWD: opts.cd },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdoutBuf = "";
+  const stderrTail = [];
+
+  child.stdout.on("data", (chunk) => {
+    stdoutBuf += chunk.toString();
+  });
+
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    process.stderr.write(text); // surface agy progress live for the orchestrator
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = stdoutBuf.trim();
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  child.on("error", (err) => {
+    const result = writeResult({ status: "failed", exitCode: 1, conversationId: conversationIdFor(opts.cd), finalMessage: assembleFinal(), touchedFiles: gitTouchedFiles(opts.cd), error: String(err && err.message ? err.message : err) });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code) => {
+    const finalMessage = assembleFinal();
+    const result = writeResult({
+      status: code === 0 ? "completed" : "failed",
+      exitCode: code === null ? 1 : code,
+      conversationId: conversationIdFor(opts.cd),
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+  // --conversation pins a specific conversation and --resume-last picks the working root's most
+  // recent; passing both is a contradiction, and buildArgv would silently prefer --conversation.
+  if (opts.conversation && opts.resumeLast) {
+    fail("--conversation and --resume-last are mutually exclusive; pass only one");
+  }
+
+  const version = agyVersion();
+  const run = prepareRunDir(opts, brief);
+  const writeResult = makeResultWriter(opts, version, run);
+
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+
+  dispatchToAgy(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode})  ·  agy ${result.agyVersion ?? "?"}`);
+  if (result.resumeLast) lines.push("mode: resumed the working root's most recent conversation");
+  if (result.conversationId) lines.push(`conversation id (resume with: --conversation ${result.conversationId}): ${result.conversationId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- agy final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -35,8 +35,10 @@ orchestrators as designed-for, not yet proven.)
 
 ## Prerequisites (check once)
 
-1. `cursor-agent --version` succeeds. If not, install (`curl https://cursor.com/install -fsS | bash`;
-   Cursor's docs also list a native Windows PowerShell installer) and `cursor-agent login`.
+1. `cursor-agent --version` succeeds. If not, install it — download Cursor's installer and review it
+   before running (`curl -fsS https://cursor.com/install -o cursor-install.sh`, read the script, then
+   `bash cursor-install.sh`; Cursor's docs also list a native Windows PowerShell installer) — and
+   `cursor-agent login`.
 2. **Confirm which `cursor-agent` is on PATH.** The installer also links a plain `agent` alias — the
    relay invokes `cursor-agent`, so that name must resolve. `command -v cursor-agent` shows the active
    binary and `cursor-agent --version` its version. The relay records the version it ran into

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: cursor-delegate
+description: >-
+  Delegate a coding task to the Cursor CLI (cursor-agent) as a background implementer, then review its
+  diff and land it yourself. Use this whenever the user wants to hand implementation work to Cursor —
+  phrasings like "have Cursor do X", "delegate this to Cursor", "run it through cursor-agent", or "use
+  Cursor to implement/fix/refactor" — or wants to run a queue of coding tasks through Cursor while
+  staying the reviewer. Prefer it when the user will review the diff and commit it themselves. DO NOT
+  USE for tasks small enough to do inline, or when the user wants the code written directly without
+  delegating.
+license: MIT
+compatibility: Requires the `cursor-agent` CLI (Cursor CLI) installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows; Cursor also ships a native Windows installer).
+metadata:
+  version: 0.1.0
+---
+
+# Cursor Delegate
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the Cursor CLI (`cursor-agent`) — then review what it produced and land it yourself.
+You write the brief and own the judgment; cursor-agent does the typing in its own session; you verify
+and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so any agent with those two capabilities — Claude Code, a sibling CLI session,
+or a comparable one — can drive it. (It is designed for and run on Claude Code; treat other
+orchestrators as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `cursor-agent` CLI is not installed or not authenticated (run `cursor-agent login`).
+- You want to write the code yourself, or you only need a review (use `--read-only`, which runs
+  cursor-agent in its enforced read-only `plan` mode).
+
+## Prerequisites (check once)
+
+1. `cursor-agent --version` succeeds. If not, install (`curl https://cursor.com/install -fsS | bash`;
+   Cursor's docs also list a native Windows PowerShell installer) and `cursor-agent login`.
+2. **Confirm which `cursor-agent` is on PATH.** The installer also links a plain `agent` alias — the
+   relay invokes `cursor-agent`, so that name must resolve. `command -v cursor-agent` shows the active
+   binary and `cursor-agent --version` its version. The relay records the version it ran into
+   `result.json`, so a stale binary is visible after the fact.
+3. `cursor-agent status` shows you are logged in.
+4. You are in (or will point `--cd` at) the target git repository.
+
+## Choose the implementer model (optional)
+
+Unlike OpenCode, cursor-agent has a **usable default**: a bare run uses the Cursor account's configured
+model, and the relay records which model actually ran (`resolvedModel` in `result.json`). So `--model`
+is optional — but still worth setting deliberately:
+
+- `cursor-agent models` lists what the account can use. Availability and metering depend on the human's
+  Cursor plan, so if they've stated model preferences for delegation (in the repo's `AGENTS.md` or their
+  `CLAUDE.md`), honor those.
+- Match the model to the brief: a fast model for a mechanical sweep (rename, migration, removal); a
+  strong one for a subtle bug or a money/security path.
+
+More depth: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+cursor-agent sees **only** the text you send plus what it can read from the working tree (including the
+repo's own rules files, which it picks up automatically). No chat history, no shared context. Everything
+the task needs goes in the brief: the goal, the current state, what to change, what to leave untouched,
+the project's **actual** gate commands (discover them from the repo's AGENTS.md/CLAUDE.md/Makefile — do
+not assume), and a report contract. Tell cursor-agent it will **not** commit (you will). Keep one task
+per brief. Full guidance and a template:
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to cursor-agent with the bundled helper. It wraps `cursor-agent --print`, captures the
+run, and writes a structured `result.json` — so your only job is "run a command, read a file."
+(`<skill-dir>` below is this skill's installed directory — the folder containing this `SKILL.md`.
+Claude Code prints it as "Base directory for this skill" when the skill loads; on other orchestrators
+use that same directory — if unsure where it landed, run
+`find ~ -name relay.mjs -path '*cursor-delegate*'` and substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# pick a model explicitly:                 add --model <name>   (default: the account's configured model)
+# read-only (review/diagnosis, no edits):  add --read-only      (cursor-agent's enforced plan mode)
+# continue the previous session:           add --resume-last    (delta brief only)
+# see all options:                         node .../relay.mjs --help
+```
+
+The helper defaults to a write-capable run and writes its artifacts to a temp dir, so the repo under
+review stays clean. It **never commits** — see step 5. Mechanics, flags, and the `result.json` shape:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until cursor-agent finishes, so back it with whatever your orchestrator offers and
+resume when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job`
+  in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a `status`. (A
+  pre-run usage error — bad args or an empty brief — instead exits with code 2 and writes no result
+  file, so check the exit code too. A missing `cursor-agent` binary exits 127 but *does* write a
+  `result.json` with status `cursor_agent_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line.
+
+### 4. Review — do not trust the self-report
+
+cursor-agent's `result.json` includes its own final message and any gate claims. **Re-verify, don't
+accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did cursor-agent do what was asked, nothing more (scope creep)
+  and nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Committing should be the act of
+the party that verified the work. Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
+  review again.
+
+## Autonomy model
+
+cursor-agent's autonomy in headless (`--print`) mode has two independent switches, and the relay sets
+both (verified against cursor-agent 2026.07.09):
+
+- **File edits** are applied without prompting in a headless run — with or without `--force`. There is
+  no per-edit approval to lean on; the orchestrator's diff review (step 4) is the safety net.
+- **Shell commands** only auto-run under `--force`. The relay passes it by default so the brief's gate
+  commands (tests, lint) actually execute instead of being refused; pass `--no-force` to withhold it —
+  approval-gated commands are then refused rather than prompted (a headless run never prompts).
+- **`--read-only`** runs cursor-agent in its `plan` mode, which **is enforced**: a plan run cannot
+  write the working tree (verified — a write instruction in plan mode produced a plan, not a file). It
+  never gets `--force`.
+- Every run gets `--trust`: without it, dispatching into a not-yet-trusted workspace hangs on a prompt
+  no one can answer. Choosing to dispatch into a repo is itself the trust decision, made by the human
+  who opted into delegation.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report cursor-agent's design decisions, defensible-but-unasked
+turns, and non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if
+correct completion needs going beyond the brief, ask — don't expand the mandate yourself). The full
+treatment is in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief
+  cursor-agent can execute blind: structure, XML blocks, the report contract, embedding the real gate
+  commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the rework cycle via `--resume-last`.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -83,9 +83,10 @@ use that same directory — if unsure where it landed, run
 
 ```bash
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
-# pick a model explicitly:                 add --model <name>   (default: the account's configured model)
-# read-only (review/diagnosis, no edits):  add --read-only      (cursor-agent's enforced plan mode)
-# continue the previous session:           add --resume-last    (delta brief only)
+# pick a model explicitly:                 add --model <name>       (default: the account's configured model)
+# read-only (review/diagnosis, no edits):  add --read-only          (cursor-agent's enforced plan mode)
+# continue the previous session:           add --resume-last        (delta brief only)
+# longer/shorter run budget:               add --timeout <duration> (default 60m, relay-enforced)
 # see all options:                         node .../relay.mjs --help
 ```
 

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -95,7 +95,9 @@ process has exited and `result.json` is written — not when a status line says 
 ## When a run misbehaves
 
 - **`status: cursor_agent_unavailable` (exit 127):** `cursor-agent` isn't on PATH or isn't found.
-  Install (`curl https://cursor.com/install -fsS | bash`) and `cursor-agent login`, then re-dispatch.
+  Install it — download Cursor's installer and review it before running (`curl -fsS
+  https://cursor.com/install -o cursor-install.sh`, read it, then `bash cursor-install.sh`) — then
+  `cursor-agent login` and re-dispatch.
 - **`status: failed` with a "timed out after …" `error`:** the run exceeded the relay's `--timeout`
   budget (default 60m) and was terminated. Re-dispatch with a bigger `--timeout`, or split the brief
   into smaller tasks.

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,132 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `cursor-agent --print`, runs the brief, captures
+everything, and writes a structured `result.json`. Your job collapses to: run one command, then read one
+file. Everything Cursor-specific lives in the helper, which is what keeps the loop portable across
+orchestrators.
+
+## Before the first run: check the binary
+
+Three gotchas, all worth 30 seconds:
+
+```bash
+command -v cursor-agent    # the active binary on PATH (the installer also links a plain `agent` alias)
+cursor-agent --version     # the relay records this in result.json too
+cursor-agent status        # must show you logged in
+```
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for cursor-agent (default: current directory). |
+| `--model <name>` | Cursor model (default: the account's configured model; `cursor-agent models` lists the choices). The result's `resolvedModel` records what actually ran. |
+| `--read-only` | Run in cursor-agent's `plan` mode — review/diagnosis with no edits, **enforced by cursor-agent** (verified: a plan run cannot write the tree). |
+| `--no-force` | The relay passes cursor-agent's `--force` (auto-run approval-gated shell commands) **by default** so the brief's gate commands actually execute; `--no-force` drops it, and such commands are then refused rather than prompted (a headless run never prompts). Headless **file edits are applied either way** — `--force` only governs commands. A `--read-only` run never gets `--force`. |
+| `--resume-last` | Continue the most recent cursor-agent session; send only the delta brief (see review-and-land). |
+| `--session <id>` | Continue a specific session id; send only the delta brief. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Every run also gets cursor-agent's `--trust` — without it, a dispatch into a not-yet-trusted workspace
+hangs on a prompt no one can answer in headless mode. Dispatching into the repo is itself the trust
+decision.
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only cursor-agent's edits and nothing of the helper's own.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `tool` — `cursor-agent`
+- `status` — `completed` | `failed` | `cursor_agent_unavailable`. A run that exits 0 but reports
+  `is_error` in its result event is still `failed` — the relay treats either signal as failure
+- `exitCode` — mirrors cursor-agent's exit code; `127` if `cursor-agent` isn't on PATH
+- `cursorAgentVersion` — the binary that actually ran
+- `mode` — `default` (write-capable) or `plan` (read-only)
+- `sessionId` — feed this to a later `--session <id>` (or use `--resume-last`)
+- `resolvedModel` — the model that actually ran (from the run's init event), useful when `--model` was
+  omitted and the account default applied
+- `finalMessage` — cursor-agent's own closing report (from the run's `result` event, falling back to
+  its assistant messages). Thin if the run ended without a written summary — ask for the report
+  explicitly
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point.
+  `null` (not `[]`) when git can't report — `git` missing, or a non-repo run; `[]` means git ran and
+  the tree is clean
+- `usage` — token counts from the run's result event (`null` if none were reported)
+- `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSON event stream, and
+  the final-message file
+- `workdir`, `model`, `force`, `resumeLast`, `startedAt`, `finishedAt`
+- `stderrTail` — last ~20 stderr lines; present **only** on a failed run
+- `error` — present **only** if cursor-agent failed to launch
+
+The helper also prints a summary to stdout and exits non-zero on any failure, so a wrapping script can
+branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until cursor-agent finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job` in PowerShell,
+  `start /b` in cmd). A run is done when `result.json` exists with a `status`. **But** a pre-run usage
+  error (bad args, empty brief) exits with code 2 *before* writing any file — so check the exit code
+  too, don't only watch for the file. (A missing `cursor-agent` binary exits 127 but *does* write a
+  `result.json` with status `cursor_agent_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: cursor_agent_unavailable` (exit 127):** `cursor-agent` isn't on PATH or isn't found.
+  Install (`curl https://cursor.com/install -fsS | bash`) and `cursor-agent login`, then re-dispatch.
+- **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
+  Common causes: an auth lapse (`cursor-agent status`), or an unknown `--model` — cursor-agent rejects
+  it up front and lists the valid names. Fix the cause and re-dispatch; don't paper over it by doing
+  the work yourself unless that's what the user wants.
+- **Thin `finalMessage`:** the run ended without a written closing summary (common when it completes
+  purely through tool calls). The edits may still be correct — check `touchedFiles` and the diff. To
+  get a report next time, add a `<structured_output_contract>` block (see
+  [writing-the-brief.md](writing-the-brief.md)).
+- **Gate commands didn't run:** if the report says commands were skipped or refused, check whether the
+  run was dispatched with `--no-force` — approval-gated commands are refused without `--force` in
+  headless mode.
+
+## What the helper is doing (and the alternatives)
+
+Under the hood the helper runs roughly:
+
+```bash
+cursor-agent --print --output-format stream-json --trust --force        < brief.txt   # fresh write run
+cursor-agent --print --output-format stream-json --trust --mode plan    < brief.txt   # read-only run
+cursor-agent --print --output-format stream-json --trust --force --continue      < delta-brief.txt   # resume most recent
+cursor-agent --print --output-format stream-json --trust --force --resume <id>   < delta-brief.txt   # resume a specific session
+```
+
+The brief is fed on **stdin**, never as an argument — which is why a multi-line, XML-tagged brief needs
+no quoting. The `stream-json` output is newline-delimited JSON events; the relay records them all to
+`events.jsonl`, takes `finalMessage` and `usage` from the closing `result` event, `resolvedModel` from
+the `init` event, and `session_id` from any event that carries it.
+
+If you ever want it, raw `cursor-agent -p` is fine for one-offs — you just give up the captured
+`result.json`, touched-files summary, and session-id extraction the helper does for you.
+
+## The commit boundary
+
+The helper never commits — by design, not omission. The robust contract is: cursor-agent edits the
+working tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -36,6 +36,7 @@ Options:
 | `--no-force` | The relay passes cursor-agent's `--force` (auto-run approval-gated shell commands) **by default** so the brief's gate commands actually execute; `--no-force` drops it, and such commands are then refused rather than prompted (a headless run never prompts). Headless **file edits are applied either way** — `--force` only governs commands. A `--read-only` run never gets `--force`. |
 | `--resume-last` | Continue the most recent cursor-agent session; send only the delta brief (see review-and-land). |
 | `--session <id>` | Continue a specific session id; send only the delta brief. |
+| `--timeout <duration>` | Run budget, Go duration format (e.g. `90s`, `45m`, `2h`). Default `60m`. cursor-agent has no timeout flag of its own, so the relay terminates a run that exceeds the budget and reports it `failed`. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
 
 Every run also gets cursor-agent's `--trust` — without it, a dispatch into a not-yet-trusted workspace
@@ -95,6 +96,9 @@ process has exited and `result.json` is written — not when a status line says 
 
 - **`status: cursor_agent_unavailable` (exit 127):** `cursor-agent` isn't on PATH or isn't found.
   Install (`curl https://cursor.com/install -fsS | bash`) and `cursor-agent login`, then re-dispatch.
+- **`status: failed` with a "timed out after …" `error`:** the run exceeded the relay's `--timeout`
+  budget (default 60m) and was terminated. Re-dispatch with a bigger `--timeout`, or split the brief
+  into smaller tasks.
 - **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
   Common causes: an auth lapse (`cursor-agent status`), or an unknown `--model` — cursor-agent rejects
   it up front and lists the valid names. Fix the cause and re-dispatch; don't paper over it by doing

--- a/skills/cursor-delegate/references/multi-task-queues.md
+++ b/skills/cursor-delegate/references/multi-task-queues.md
@@ -1,0 +1,68 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential. (Each fresh
+`relay.mjs` dispatch starts a new cursor-agent session, so independent tasks don't share context — fold
+any shared constraint into each brief, see below.)
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. A fresh cursor-agent session has no memory of the earlier run, so a
+constraint that emerged in task 2 must be restated in task 5's brief or it won't hold. This is the queue
+equivalent of keeping briefs self-contained.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions cursor-agent made, non-blocking nitpicks, anything you want
+  the human to overrule or confirm. This is the section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/cursor-delegate/references/review-and-land.md
+++ b/skills/cursor-delegate/references/review-and-land.md
@@ -1,0 +1,115 @@
+# Review and land
+
+cursor-agent did the typing; you own the judgment. This is where delegation earns its keep or quietly
+ships a mistake. The discipline is simple to state and easy to skip under time pressure: **verify
+against reality, never against the self-report — and read the diff as generated code, which fails in
+ways a green gate can't see.**
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries cursor-agent's own claim that the gates passed. Treat that as a claim, not
+evidence — re-run the project's actual test/lint/build commands in the working tree and read the
+output. And keep the result in proportion: **passing is necessary, not sufficient.** An implementer can
+*game* a gate, not just misreport it — that is what the test check above and the sweep below exist to
+catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Scope creep** — did cursor-agent change things the brief said to leave untouched? Unasked refactors,
+  renames, "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version?
+- **Quiet judgment calls** — sometimes cursor-agent makes a defensible decision the brief didn't
+  anticipate. Don't just accept it because it looks reasonable; understand it and decide.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If cursor-agent couldn't implement
+  something, the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to cursor-agent as a delta brief (below) or gets fixed in the tree
+before commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never the implementer. A
+headless cursor-agent run *can* write the working tree, but committing should be the act of the party
+that verified the work, not the one that produced it. Write a clear message describing what landed. If
+your project attributes co-authorship, that's the place for it.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same cursor-agent session
+with just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
+
+`--resume-last` keeps cursor-agent's session context from the first run, so a short delta is enough.
+Then review again — rework gets the same gate-rerun, test check, diff-read, and sweep as the original,
+no shortcuts. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** cursor-agent made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or cursor-agent's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/cursor-delegate/references/writing-the-brief.md
+++ b/skills/cursor-delegate/references/writing-the-brief.md
@@ -1,0 +1,136 @@
+# Writing the brief
+
+A brief is the entire task as cursor-agent will see it. cursor-agent runs in a fresh session with **no
+memory of your conversation, no access to your prior notes, and no shared context** — only the text you
+send and whatever it can read from the working tree (including the repo's own rules files, which it
+picks up automatically). If a constraint isn't in the brief or discoverable in the repo, it doesn't
+exist for cursor-agent. The single most common failure is a brief that assumes context cursor-agent
+doesn't have.
+
+## Match the model to the brief
+
+cursor-agent has a usable default — a bare dispatch runs the Cursor account's configured model, and the
+relay reports which model actually ran (`resolvedModel` in `result.json`). Naming one anyway is often
+worth it:
+
+- **The available set is the account's.** `cursor-agent models` lists what the human's Cursor plan can
+  use; availability and metering are plan-dependent, so if the human has stated model preferences for
+  delegated work (in the target repo's `AGENTS.md` or their `CLAUDE.md`), honor those. When in doubt
+  about cost-sensitive choices, ask rather than guess.
+- **Read the task's difficulty off the brief you just wrote.** A mechanical, well-bounded brief — a
+  rename sweep, a library migration, a dead-code removal — is safe on a fast model. A brief whose risk
+  lives in judgment — a concurrency fix, a money or auth path, an ambiguous spec — wants a strong one,
+  because the sweep's failure modes (plausible-but-wrong logic, swallowed errors) are exactly what a
+  weaker model produces more of.
+- **A resumed run continues its session.** With `--resume-last` / `--session`, send only the delta
+  brief.
+
+## The shape that works
+
+cursor-agent responds well to compact, block-structured prompts with XML tags rather than long prose.
+State the task, what "done" looks like, how to behave by default, and the few constraints that actually
+matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps cursor-agent
+from wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences) and dispatch with `--read-only` so cursor-agent runs in its enforced `plan` mode and
+  can't edit.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Always ask for the report explicitly
+
+The relay takes cursor-agent's final report from the run's closing `result` event (falling back to its
+assistant messages). If the agent finishes a task purely through tool calls and stops without a closing
+summary, `finalMessage` can come back thin — not a relay defect, just nothing said. The
+`<structured_output_contract>` block is what guarantees a report you can read: it tells cursor-agent to
+end with a written summary, so the result file carries one.
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you a cursor-agent that guesses — or skips. And remember the relay's `--force` default
+exists precisely so these commands can run unattended; with `--no-force` they may be refused.
+
+## Honor the repo's conventions
+
+cursor-agent picks up the repo's rules files (`AGENTS.md`, `.cursor/rules`) automatically, so house
+rules there (style, forbidden patterns, commit conventions) already apply. If the project forbids
+certain things in code — say, spec/ticket IDs in comments, process language like "MVP"/"for now"/"phase
+N", or specific test conventions, whatever the repo's own conventions ban — restate the load-bearing
+ones in the brief too, because cursor-agent's compliance is only as reliable as what's in front of it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and suggest
+a roadmap" produces a muddled run; split it into separate dispatches. One brief → one cursor-agent run →
+one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -257,7 +257,7 @@ function makeResultWriter(opts, version, run) {
 function reportUnavailable(writeResult, resultPath) {
   const result = writeResult({ status: "cursor_agent_unavailable", exitCode: 127, sessionId: null, finalMessage: "", touchedFiles: null, usage: null });
   printSummary(result, resultPath);
-  process.stderr.write("relay: `cursor-agent` not found on PATH. Install it (curl https://cursor.com/install -fsS | bash) and run `cursor-agent login`.\n");
+  process.stderr.write("relay: `cursor-agent` not found on PATH. Install it (see https://cursor.com/docs/cli — download the installer and review it before running) and run `cursor-agent login`.\n");
   process.exit(127);
 }
 

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -44,6 +44,9 @@
  *   --resume-last           Continue the most recent cursor-agent session; send only the
  *                           delta brief.
  *   --session <id>          Continue a specific session id; send only the delta brief.
+ *   --timeout <duration>    Run budget, Go duration format (e.g. 90s, 45m, 2h; default: 60m).
+ *                           cursor-agent has no timeout flag of its own, so the relay
+ *                           terminates a run that exceeds the budget and reports it failed.
  *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
  *                           the system temp dir, so the repo under review stays clean).
  *   -h, --help              Show this help.
@@ -82,6 +85,7 @@ function parseArgs(argv) {
     force: true,
     resumeLast: false,
     session: null,
+    timeout: "60m",
     outDir: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -106,6 +110,7 @@ function parseArgs(argv) {
       case "--no-force": opts.force = false; break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--session": opts.session = next(); break;
+      case "--timeout": opts.timeout = next(); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
         fail(`unknown option: ${arg}`);
@@ -147,6 +152,17 @@ function cursorAgentVersion() {
   } catch {
     return null;
   }
+}
+
+function parseDurationMs(text) {
+  // Go duration format, same as the sibling agy relay's --timeout: "90s", "45m",
+  // "2h", "1h30m". Returns milliseconds, or null when the text doesn't parse.
+  if (!/^(\d+[hms])+$/.test(text)) return null;
+  let ms = 0;
+  for (const [, count, unit] of text.matchAll(/(\d+)([hms])/g)) {
+    ms += Number(count) * (unit === "h" ? 3600000 : unit === "m" ? 60000 : 1000);
+  }
+  return ms;
 }
 
 function gitTouchedFiles(cwd) {
@@ -223,6 +239,7 @@ function makeResultWriter(opts, version, run) {
       mode: opts.readOnly ? "plan" : "default",
       force: opts.force && !opts.readOnly,
       model: opts.model,
+      timeout: opts.timeout,
       resumeLast: opts.resumeLast,
       cursorAgentVersion: version,
       startedAt: run.startedAt,
@@ -253,7 +270,8 @@ function dispatchToCursorAgent(opts, brief, run, writeResult) {
   // shell:true on win32 for parity with a shim-wrapped install (see
   // cursorAgentVersion). Safe: the brief is fed via child.stdin below — never
   // argv — and argv holds only flag names, a mode enum, a model string, and a
-  // session id, with no shell metacharacters or spaceable paths.
+  // session id; main() rejects whitespace in the user-provided values on win32,
+  // where the shell would split them.
   const child = spawn("cursor-agent", argv, {
     cwd: opts.cd,
     env: { ...process.env, PWD: opts.cd },
@@ -267,6 +285,17 @@ function dispatchToCursorAgent(opts, brief, run, writeResult) {
   const assistantParts = [];
   const stderrTail = [];
   let stdoutBuf = "";
+
+  // cursor-agent has no run-budget flag of its own (agy has --print-timeout), so
+  // the relay enforces one: past the budget the child is terminated and the run
+  // reported failed. On win32 with shell:true this kills the wrapping shell;
+  // ponytail: a detached grandchild could survive — acceptable for a budget
+  // whose job is unblocking the orchestrator, not process hygiene.
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGTERM");
+  }, opts.timeoutMs);
 
   const handleEvent = (event) => {
     if (event.session_id) sessionId = event.session_id;
@@ -314,21 +343,24 @@ function dispatchToCursorAgent(opts, brief, run, writeResult) {
   };
 
   child.on("error", (err) => {
+    clearTimeout(timer);
     const result = writeResult({ status: "failed", exitCode: 1, sessionId, finalMessage: assembleFinal(), touchedFiles: gitTouchedFiles(opts.cd), usage: null, error: String(err && err.message ? err.message : err) });
     printSummary(result, run.resultPath);
     process.exit(1);
   });
 
   child.on("close", (code) => {
+    clearTimeout(timer);
     if (stdoutBuf.trim()) {
       appendFileSync(run.eventsPath, `${stdoutBuf}\n`, "utf8");
       try { handleEvent(JSON.parse(stdoutBuf)); } catch { /* non-JSON tail; kept in events.jsonl */ }
     }
     const finalMessage = assembleFinal();
     // A run can exit 0 yet report is_error in its result event; treat either
-    // signal as failure so the orchestrator never mistakes it for success.
+    // signal — or a relay-enforced timeout — as failure so the orchestrator
+    // never mistakes it for success.
     const isError = Boolean(resultEvent && resultEvent.is_error);
-    const failed = code !== 0 || isError;
+    const failed = code !== 0 || isError || timedOut;
     const result = writeResult({
       status: failed ? "failed" : "completed",
       exitCode: code === null ? 1 : code,
@@ -337,6 +369,7 @@ function dispatchToCursorAgent(opts, brief, run, writeResult) {
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
       usage: resultEvent && resultEvent.usage ? resultEvent.usage : null,
+      ...(timedOut ? { error: `timed out after ${opts.timeout}; the run was terminated (re-dispatch with a bigger --timeout, or split the brief)` } : {}),
       ...(failed ? { stderrTail: stderrTail.slice(-20) } : {}),
     });
     printSummary(result, run.resultPath);
@@ -358,6 +391,20 @@ function main() {
   // contradiction, and buildArgv would silently prefer --session. Reject it rather than guess.
   if (opts.session && opts.resumeLast) {
     fail("--session and --resume-last are mutually exclusive; pass only one");
+  }
+  opts.timeoutMs = parseDurationMs(opts.timeout);
+  if (opts.timeoutMs === null || opts.timeoutMs <= 0) {
+    fail(`invalid --timeout "${opts.timeout}" (Go duration format, e.g. 90s, 45m, 2h)`);
+  }
+  // On win32 the launch goes through a shell (see dispatchToCursorAgent), which
+  // would split a value containing whitespace. Cursor model ids and session ids
+  // never legitimately contain it, so reject early instead of mangling silently.
+  if (process.platform === "win32") {
+    for (const [flag, value] of [["--model", opts.model], ["--session", opts.session]]) {
+      if (value && /\s/.test(value)) {
+        fail(`${flag} value contains whitespace, which the win32 shell launch would split: "${value}"`);
+      }
+    }
   }
 
   const version = cursorAgentVersion();

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -1,0 +1,404 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · cursor-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Cursor CLI (`cursor-agent --print`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Cursor-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against cursor-agent 2026.07.09.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `cursor-agent` and `git`. The `cursor-agent`
+ * process it launches does authenticate — exactly as you do at the terminal.
+ * Read this file before you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job —
+ * after it reviews the diff and re-runs the project gates.
+ *
+ * Cursor's headless permissions (verified): file edits are applied without
+ * prompting, but shell commands only auto-run under `--force`. A write run
+ * passes `--force` by default so the brief's gate commands (tests, lint) don't
+ * silently get skipped; the orchestrator's diff review is the safety net. Pass
+ * --no-force to withhold it — cursor-agent then refuses approval-gated commands
+ * rather than prompting (headless runs never prompt).
+ * A plan (read-only) run never gets --force, and `--mode plan` is enforced by
+ * cursor-agent itself (verified: a plan run cannot write the tree).
+ * Every run gets `--trust`: headless dispatch into a workspace is itself the
+ * trust decision, made by the human who opted into delegation.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for cursor-agent (default: current directory).
+ *   --model <name>          Cursor model (default: the account's configured default;
+ *                           `cursor-agent models` lists the choices).
+ *   --read-only             Run with `--mode plan` (review/diagnosis, no edits — enforced
+ *                           by cursor-agent).
+ *   --no-force              Don't pass `--force`; approval-gated shell commands are then
+ *                           refused instead of auto-run (a headless run never prompts).
+ *   --resume-last           Continue the most recent cursor-agent session; send only the
+ *                           delta brief.
+ *   --session <id>          Continue a specific session id; send only the delta brief.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, cursorAgentVersion, sessionId (for a later resume), finalMessage
+ *   (cursor-agent's own report), touchedFiles (git porcelain, null if git can't report),
+ *   usage (token counts), and the paths to events.jsonl and final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `cursor-agent` binary exits 127;
+ * otherwise the exit code mirrors cursor-agent's own (0 success, non-zero failure),
+ * except that a run which exits 0 while reporting is_error in its result event
+ * makes the relay exit 1 — either failure signal means failed.
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, or cursor_agent_unavailable. An orchestrator that polls for the
+ * file must therefore also treat a non-zero exit with no file as a usage error.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { tmpdir } from "node:os";
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    readOnly: false,
+    force: true,
+    resumeLast: false,
+    session: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--read-only": opts.readOnly = true; break;
+      case "--force": opts.force = true; break;
+      case "--no-force": opts.force = false; break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to cursor-agent --print\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function cursorAgentVersion() {
+  try {
+    // cursor-agent installs as a real binary (curl installer, not an npm .cmd
+    // shim), but shell:true on win32 is kept for parity with any shim-wrapped
+    // install; argv here is a bare --version, so quoting is a non-issue. (git
+    // installs a real git.exe and must NOT get this flag — see gitTouchedFiles.)
+    return execFileSync("cursor-agent", ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git can't report — git missing, or a non-repo run — so the
+  // caller can tell "git unavailable" apart from "cursor-agent changed nothing."
+  // [] means git ran and the working tree is clean.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts) {
+  const argv = ["--print", "--output-format", "stream-json"];
+  // --trust is required for headless work in a not-yet-trusted workspace (without
+  // it a fresh workspace prompts, which a headless run can't answer). Dispatching
+  // into the workspace is itself the trust decision, so every run gets it.
+  argv.push("--trust");
+  // Resume continues an existing session; --session pins a specific id, otherwise
+  // --continue picks up the most recent one.
+  if (opts.session) {
+    argv.push("--resume", opts.session);
+  } else if (opts.resumeLast) {
+    argv.push("--continue");
+  }
+  // --mode plan is passed on resumed runs too: cursor-agent applies the mode to
+  // the new turn, and a read-only rework must stay read-only.
+  if (opts.readOnly) argv.push("--mode", "plan");
+  // --force (on by default) lets approval-gated shell commands auto-run so the
+  // brief's gate commands actually execute; headless file edits are applied even
+  // without it (verified). Never on a read-only run: plan mode should not get
+  // command approval it cannot use for edits anyway.
+  if (opts.force && !opts.readOnly) argv.push("--force");
+  if (opts.model) argv.push("--model", opts.model);
+  // No prompt argument: the brief is piped on stdin (see dispatchToCursorAgent),
+  // which avoids all argv-quoting issues with multi-line, XML-tagged briefs.
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only cursor-agent's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    eventsPath: join(outDir, "events.jsonl"),
+    finalPath: join(outDir, "final.txt"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "cursor-agent",
+      workdir: opts.cd,
+      mode: opts.readOnly ? "plan" : "default",
+      force: opts.force && !opts.readOnly,
+      model: opts.model,
+      resumeLast: opts.resumeLast,
+      cursorAgentVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      eventsPath: run.eventsPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      ...extra,
+    };
+    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "cursor_agent_unavailable", exitCode: 127, sessionId: null, finalMessage: "", touchedFiles: null, usage: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `cursor-agent` not found on PATH. Install it (curl https://cursor.com/install -fsS | bash) and run `cursor-agent login`.\n");
+  process.exit(127);
+}
+
+function dispatchToCursorAgent(opts, brief, run, writeResult) {
+  const argv = buildArgv(opts);
+  // Pin the working root two ways: `cwd` sets the child's real directory (which
+  // cursor-agent uses as the workspace), and PWD is set explicitly because spawn
+  // does NOT rewrite the inherited PWD env — a tool that consults it could
+  // otherwise resolve the orchestrator's directory instead of opts.cd.
+  // shell:true on win32 for parity with a shim-wrapped install (see
+  // cursorAgentVersion). Safe: the brief is fed via child.stdin below — never
+  // argv — and argv holds only flag names, a mode enum, a model string, and a
+  // session id, with no shell metacharacters or spaceable paths.
+  const child = spawn("cursor-agent", argv, {
+    cwd: opts.cd,
+    env: { ...process.env, PWD: opts.cd },
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
+
+  let sessionId = opts.session || null;
+  let resolvedModel = null;
+  let resultEvent = null;
+  const assistantParts = [];
+  const stderrTail = [];
+  let stdoutBuf = "";
+
+  const handleEvent = (event) => {
+    if (event.session_id) sessionId = event.session_id;
+    // The init event carries the resolved model (useful when --model was omitted
+    // and the account default ran).
+    if (event.type === "system" && event.subtype === "init" && event.model) resolvedModel = event.model;
+    // Assistant text is the fallback report if no result event arrives.
+    if (event.type === "assistant" && event.message && Array.isArray(event.message.content)) {
+      for (const part of event.message.content) {
+        if (part && part.type === "text" && part.text) assistantParts.push(part.text);
+      }
+    }
+    // The final `result` event carries cursor-agent's own summary, error flag,
+    // and token usage — the authoritative report for result.json.
+    if (event.type === "result") resultEvent = event;
+  };
+
+  child.stdout.on("data", (chunk) => {
+    stdoutBuf += chunk.toString();
+    let nl;
+    while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+      const line = stdoutBuf.slice(0, nl);
+      stdoutBuf = stdoutBuf.slice(nl + 1);
+      if (!line.trim()) continue;
+      appendFileSync(run.eventsPath, `${line}\n`, "utf8"); // faithful raw record of the event stream
+      try { handleEvent(JSON.parse(line)); } catch { /* non-JSON progress line; kept in events.jsonl */ }
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    process.stderr.write(text); // surface cursor-agent progress live for the orchestrator
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = (resultEvent && typeof resultEvent.result === "string" && resultEvent.result.trim())
+      ? resultEvent.result.trim()
+      : assistantParts.join("").trim();
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  child.on("error", (err) => {
+    const result = writeResult({ status: "failed", exitCode: 1, sessionId, finalMessage: assembleFinal(), touchedFiles: gitTouchedFiles(opts.cd), usage: null, error: String(err && err.message ? err.message : err) });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code) => {
+    if (stdoutBuf.trim()) {
+      appendFileSync(run.eventsPath, `${stdoutBuf}\n`, "utf8");
+      try { handleEvent(JSON.parse(stdoutBuf)); } catch { /* non-JSON tail; kept in events.jsonl */ }
+    }
+    const finalMessage = assembleFinal();
+    // A run can exit 0 yet report is_error in its result event; treat either
+    // signal as failure so the orchestrator never mistakes it for success.
+    const isError = Boolean(resultEvent && resultEvent.is_error);
+    const failed = code !== 0 || isError;
+    const result = writeResult({
+      status: failed ? "failed" : "completed",
+      exitCode: code === null ? 1 : code,
+      sessionId,
+      resolvedModel,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      usage: resultEvent && resultEvent.usage ? resultEvent.usage : null,
+      ...(failed ? { stderrTail: stderrTail.slice(-20) } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode !== 0 ? result.exitCode : (failed ? 1 : 0));
+  });
+
+  // If the child failed to launch, writing to its stdin can emit a stray 'error'
+  // on the pipe; the 'error' handler above owns that outcome, so swallow it here.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+  // --session pins a specific session and --resume-last picks the most recent; passing both is a
+  // contradiction, and buildArgv would silently prefer --session. Reject it rather than guess.
+  if (opts.session && opts.resumeLast) {
+    fail("--session and --resume-last are mutually exclusive; pass only one");
+  }
+
+  const version = cursorAgentVersion();
+  const run = prepareRunDir(opts, brief);
+  const writeResult = makeResultWriter(opts, version, run);
+
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+
+  dispatchToCursorAgent(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode})  ·  cursor-agent ${result.cursorAgentVersion ?? "?"}`);
+  if (result.resumeLast) lines.push("mode: resumed most recent session");
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  if (result.resolvedModel) lines.push(`model: ${result.resolvedModel}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- cursor-agent final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();


### PR DESCRIPTION
## What

Two new implementer backends for the same brief → dispatch → review → land loop, following the exact structure of `codex-delegate` / `opencode-delegate` (lean `SKILL.md`, the same four references, one dependency-free `relay.mjs` each):

### cursor-delegate

Drives the Cursor CLI (`cursor-agent --print --output-format stream-json`).

- Brief piped on **stdin** (no argv quoting for multi-line XML briefs).
- Headless permissions have two switches and the relay sets both: file edits apply without prompting (verified), and `--force` (relay default) lets approval-gated shell commands auto-run so the brief's gate commands actually execute. `--no-force` withholds it.
- `--read-only` maps to cursor-agent's `plan` mode, which **is enforced** — verified that a plan-mode write instruction produces a plan, not a file.
- Every run gets `--trust` (a fresh workspace otherwise hangs on a prompt no headless run can answer).
- Resume via `--resume-last` / `--session <id>`; `result.json` carries `sessionId`, `resolvedModel` (from the init event — useful since `--model` is optional and the account default applies), `finalMessage` (from the closing `result` event), token `usage`, and `touchedFiles`.
- A run that exits 0 while reporting `is_error` is still `failed` — either signal counts.

### antigravity-delegate

Drives Google's Antigravity CLI (`agy --print`). Two verified agy behaviors shape it:

1. **`--add-dir` is not optional.** Without the working root in agy's workspace, agy does the work in its own scratch directory (`~/.gemini/antigravity-cli/scratch`) and the repo never changes. The relay always passes it.
2. **There is no enforced read-only mode.** `agy --mode plan` still writes the working tree (verified twice with direct write instructions). The relay therefore **refuses** a `--read-only` flag with an explanation, rather than offer a false promise — and the docs tell reviewers to check `touchedFiles` even after "review-only" dispatches.

Also: the brief travels as the `--print` argv value (agy does not read stdin — no shell involved on any platform, and agy is a native binary everywhere, so no `shell:true` anywhere); agy's 5-minute print timeout is raised to a delegation-sized 60m default (`--timeout` to change); resume via `--continue` / `--conversation <id>`, with the conversation id reported best-effort from agy's per-directory cache (`last_conversations.json`) — that one local cache read is disclosed in the relay header, the README trust section, and AGENTS.md.

### Why no zcode-delegate

Researched: Z.ai's ZCode is a desktop app with no CLI or headless mode, so there is nothing for a relay to drive. Added a short README note (its GLM models remain reachable today through `opencode-delegate`), reserved alongside the existing `gemini-delegate` placeholder.

## Verification

- Live runs against `cursor-agent 2026.07.09` and `agy 1.1.1` (macOS): headless write runs land in the repo, `--read-only` (Cursor) leaves the tree clean, resume recalls the right session/conversation through each relay, usage errors exit 2 with no result file, missing-binary path exits 127 with a `result.json`.
- `npx skills add . --list` validates the package and shows all four skills; all descriptions are under the 1024-char cap.
- README "Verification status" updated to claim exactly the above, no more.
- Windows launch paths follow the house notes (shell:true for shim-wrapped CLIs; never for `agy`, whose brief travels in argv) but were **not** smoke-tested on native Windows here.

Vocabulary rows for both CLIs added to AGENTS.md (verbatim terms, including a ban on claiming agy's plan mode is read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTnTixuC9KsEqwAAqoZKLL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cursor and Antigravity delegation skills for bounded coding tasks, structured results, polling/resume, and controlled change delivery.
  * Introduced per-skill relay workflows that produce consistent artifacts for an orchestrator to review before commit.
  * Updated the delegate-skills catalog and install examples to include the new skills.
* **Documentation**
  * Added/expanded skill guides and references for writing briefs, dispatch-and-poll, review-and-land, and multi-task queues.
  * Clarified authentication, trust/validation expectations, and platform-specific command/permission behavior for Cursor and Antigravity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->