### PR TITLE
codex-delegate: add --effort for per-run reasoning effort

### DIFF
--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -35,6 +35,7 @@ Options:
 | `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
 | `--cd <dir>` | Working root for Codex (default: current directory). |
 | `--model <name>` | Codex model (default: Codex's own configured default). |
+| `--effort <level>` | Reasoning effort, passed to Codex as `-c model_reasoning_effort=<level>` (e.g. `low`, `medium`, `high`, `xhigh`, `max`, `ultra`; default: Codex's own configured default). The model owns the valid set — an unsupported level fails the run, not the dispatch. Applies to fresh and resumed runs alike. |
 | `--sandbox <mode>` | `read-only` \| `workspace-write` \| `danger-full-access` (default: `workspace-write`). |
 | `--read-only` | Shortcut for `--sandbox read-only` — review/diagnosis with no edits. |
 | `--resume-last` | Continue the most recent Codex session; send only the delta brief (see review-and-land). |
@@ -56,7 +57,7 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 - `finalMessage` — Codex's own final report (the `<structured_output_contract>` you asked for)
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report — `git` missing, or a non-repo run under `--skip-git-repo-check`; `[]` means git ran and the tree is clean
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSONL event stream, and the final-message file
-- `workdir`, `sandbox`, `model`, `resumeLast`, `startedAt`, `finishedAt`
+- `workdir`, `sandbox`, `model`, `effort`, `resumeLast`, `startedAt`, `finishedAt`
 - `stderrTail` — last ~20 stderr lines; present **only** on a failed run (a non-zero Codex exit), absent on `completed`, `codex_unavailable`, and launch failures
 - `error` — present **only** if Codex failed to launch
 
@@ -84,7 +85,7 @@ process has exited and `result.json` is written — not when a status line says 
 - **`status: codex_unavailable` (exit 127):** `codex` isn't on PATH or isn't found. Install
   (`npm i -g @openai/codex`) and `codex login`, then re-dispatch.
 - **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
-  Common causes: an auth lapse, an invalid `--model`, or a sandbox that blocked something the task
+  Common causes: an auth lapse, an invalid `--model` or `--effort`, or a sandbox that blocked something the task
   needed. Fix the cause and re-dispatch; don't paper over it by doing the work yourself unless that's
   what the user wants.
 - **Empty `finalMessage`:** Codex exited before producing a final message. Treat as a failed run;
@@ -95,8 +96,8 @@ process has exited and `result.json` is written — not when a status line says 
 Under the hood the helper runs roughly:
 
 ```bash
-codex exec --json -o <final.txt> -s workspace-write [-m model] - < brief.txt   # fresh run
-codex exec resume --last --json -o <final.txt> - < delta-brief.txt            # resume (no -s/-C)
+codex exec --json -o <final.txt> -s workspace-write [-m model] [-c model_reasoning_effort=<level>] - < brief.txt   # fresh run
+codex exec resume --last --json -o <final.txt> [-m model] [-c model_reasoning_effort=<level>] - < delta-brief.txt  # resume (no -s/-C)
 ```
 
 `resume` deliberately gets no `-s`/`-C` — it inherits the original session's sandbox and working root —

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -27,6 +27,9 @@
  *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
  *   --cd <dir>              Working root for Codex (default: current directory).
  *   --model <name>          Codex model (default: Codex's own configured default).
+ *   --effort <level>        Reasoning effort, passed to Codex as
+ *                           `-c model_reasoning_effort=<level>` (e.g. low, medium, high,
+ *                           xhigh, max, ultra; default: Codex's own configured default).
  *   --sandbox <mode>        read-only | workspace-write | danger-full-access
  *                           (default: workspace-write).
  *   --read-only             Shortcut for --sandbox read-only (review/diagnosis, no edits).
@@ -67,6 +70,7 @@ function parseArgs(argv) {
     brief: null,
     cd: process.cwd(),
     model: null,
+    effort: null,
     sandbox: "workspace-write",
     resumeLast: false,
     skipGitRepoCheck: false,
@@ -89,6 +93,7 @@ function parseArgs(argv) {
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
       case "--model": opts.model = next(); break;
+      case "--effort": opts.effort = next(); break;
       case "--sandbox": opts.sandbox = next(); break;
       case "--read-only": opts.sandbox = "read-only"; break;
       case "--resume-last": opts.resumeLast = true; break;
@@ -100,6 +105,12 @@ function parseArgs(argv) {
   }
   if (!SANDBOX_MODES.has(opts.sandbox)) {
     fail(`invalid --sandbox "${opts.sandbox}" (expected: ${[...SANDBOX_MODES].join(", ")})`);
+  }
+  // Codex owns the set of valid levels (it varies by model and CLI version); the
+  // relay only enforces a bare token so argv keeps its no-shell-metacharacters
+  // invariant (see the shell:true note in dispatchToCodex).
+  if (opts.effort && !/^[a-z][a-z0-9-]*$/i.test(opts.effort)) {
+    fail(`invalid --effort "${opts.effort}" (expected a bare level name, e.g. low, medium, high, xhigh, max, ultra)`);
   }
   return opts;
 }
@@ -171,6 +182,9 @@ function buildArgv(opts, finalPath) {
     argv.push("-s", opts.sandbox);
   }
   if (opts.model) argv.push("-m", opts.model);
+  // `-c` is accepted by `exec resume` (unlike `-s`/`-C`), so the effort override
+  // applies to fresh and resumed runs alike.
+  if (opts.effort) argv.push("-c", `model_reasoning_effort=${opts.effort}`);
   if (opts.skipGitRepoCheck) argv.push("--skip-git-repo-check");
   argv.push("-"); // read the prompt from stdin
   return argv;
@@ -225,6 +239,7 @@ function makeResultWriter(opts, version, run) {
       workdir: opts.cd,
       sandbox: opts.resumeLast ? "(inherited from resumed session)" : opts.sandbox,
       model: opts.model,
+      effort: opts.effort,
       resumeLast: opts.resumeLast,
       codexVersion: version,
       startedAt: run.startedAt,
@@ -250,7 +265,8 @@ function dispatchToCodex(opts, brief, run, writeResult) {
   const argv = buildArgv(opts, run.finalPath);
   // shell:true on Windows so the codex.cmd shim resolves (see codexVersion). Safe:
   // the brief is fed via child.stdin below — never argv — and argv holds only
-  // sandbox enums, model names, and file paths, with no shell metacharacters.
+  // sandbox enums, model names, a pattern-checked effort level, and file paths,
+  // with no shell metacharacters.
   const child = spawn("codex", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32" });
 
   let threadId = null;


### PR DESCRIPTION
## Why

`codex-delegate` lets the orchestrator pick the model per run (`--model`), but reasoning effort was locked to the user's standing `model_reasoning_effort` in `~/.codex/config.toml`. Someone whose default is `high`/`xhigh` pays that on every delegated task, including routine mechanical ones — and the sibling `opencode-delegate` already exposes exactly this knob as `--variant`. This brings `codex-delegate` to parity.

## What

- `relay.mjs`: new `--effort <level>` option, forwarded to Codex as `-c model_reasoning_effort=<level>`. Since `-c` (unlike `-s`/`-C`) is accepted by `exec resume`, the override applies to fresh and resumed runs alike. The level is recorded in `result.json` next to `model`.
- The relay validates only that the value is a bare token (`/^[a-z][a-z0-9-]*$/i`) — Codex/the model own the valid set, which varies by model and CLI version, so the relay doesn't pin it. The token check also preserves the argv no-shell-metacharacters invariant that the win32 `shell:true` launch relies on.
- `references/dispatch-and-poll.md`: flags table row, `result.json` field list, the misbehaves section (an unsupported level fails the run, not the dispatch), and the under-the-hood command sketch.

## Verification (macOS, codex-cli 0.144.3)

- `node relay.mjs --help` shows the new option.
- `--effort "lo w; rm"` → usage error, exit 2, no result file.
- `npx skills add . --list` validates the package.
- Live `--read-only --effort low` run against a throwaway repo → `status: completed`, `"effort": "low"` in `result.json`.
- Same for `--effort max` and `--effort ultra` → both `status: completed` with the level recorded.
- Live run with a level the model rejects (`minimal` on a model supporting `none/low/medium/high/xhigh`) → the API 400 surfaces as `status: failed` with the cause in `events.jsonl`, matching the documented failure mode.

Not re-tested on Windows: launch mechanics are untouched; the only new argv content is the pattern-checked bare token above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `--effort <level>` setting to control Codex reasoning intensity for both fresh and resumed runs.
  * Relay forwards the selected effort level to Codex during execution.
  * Run outputs now record the chosen `effort` level.
* **Bug Fixes**
  * Invalid `--effort` values are rejected up front (including empty values).
* **Documentation**
  * Updated usage guidance, example `codex exec`/resume commands, and troubleshooting notes to include `--effort`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
