### PR TITLE
Add grok-delegate skill for Grok Build CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, hands it to an implementer CLI, then reviews the diff and
 commits — staying the reviewer the whole way.
 
-Two skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, and **`opencode-delegate`**
-drives the OpenCode CLI. Same loop, different implementer.
+Three skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, **`opencode-delegate`**
+drives the OpenCode CLI, and **`grok-delegate`** drives the Grok Build CLI. Same loop, different
+implementer.
 
 ## Install
 
@@ -23,6 +24,7 @@ Install the package, or just one skill:
 npx skills add amElnagdy/delegate-skills
 npx skills add amElnagdy/delegate-skills --skill codex-delegate
 npx skills add amElnagdy/delegate-skills --skill opencode-delegate
+npx skills add amElnagdy/delegate-skills --skill grok-delegate
 ```
 
 Install for a specific agent, or globally:
@@ -89,6 +91,17 @@ quoting.
 **You'll feel it when:** a bounded task gets handed to OpenCode, comes back as a clean diff with a
 structured report and the run's cost, and you commit it after re-running the gates yourself.
 
+### grok-delegate
+
+Drive the Grok Build CLI (`grok`) as a background implementer: write the brief, dispatch via
+`relay.mjs`, review the diff, commit it yourself. Same four references and loop as the siblings.
+Autonomy is set explicitly because Grok's default is `ask` (which would hang a headless pipe) —
+default is `--always-approve --sandbox workspace`, `--read-only` uses `--sandbox read-only`, and
+`--full-access` is the unrestricted opt-in.
+
+**You'll feel it when:** a bounded task gets handed to Grok Build, comes back as a clean diff with a
+structured report, and you commit it after re-running the gates yourself.
+
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
@@ -100,6 +113,8 @@ Reserved so the umbrella can grow without a rename.
   (`codex login`).
 - For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai) installed and authenticated
   (`opencode auth login`).
+- For `grok-delegate`: the [`grok` CLI](https://x.ai/cli) (Grok Build) installed and authenticated
+  (`grok login`, or `XAI_API_KEY`; beta access needs an eligible xAI subscription).
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -111,16 +126,19 @@ This package is intentionally inspectable:
 - All skill content is Markdown, plus exactly **one** executable per skill — each a `scripts/relay.mjs`.
 - Each `relay.mjs` makes no network calls, reads or writes no credentials, sends no telemetry, and has
   no dependencies (Node built-ins only). It shells out only to its implementer CLI (`codex` /
-  `opencode`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the script
-  before you run it.
-- Neither ever commits — committing is always the orchestrator's job, after review.
+  `opencode` / `grok`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the
+  script before you run it.
+- None of them ever commit — committing is always the orchestrator's job, after review.
 
 **Verification status:** each relay's mechanics are verified — argument handling, exit codes,
 `result.json`, resume, and (for `opencode-delegate`) the required-model guard, since OpenCode has no safe
-default. The full delegate → review → commit loop is designed for and run on Claude Code but not yet
-formally verified end-to-end here (OpenCode's cold start is slow in constrained shells, so exercise a
-real run in a normal terminal). Other orchestrators (Cursor, …) are designed-for but unproven. This line
-gets upgraded to "verified end-to-end" with evidence, not assumption.
+default. For `grok-delegate`, relay mechanics (arg handling, exit codes, `result.json`, autonomy flag
+assembly, resume/session mutual exclusion, missing-binary `grok_unavailable`) are exercised; a full
+authenticated `grok -p` end-to-end run is not claimed here (Grok Build is beta-gated). The full
+delegate → review → commit loop is designed for and run on Claude Code but not yet formally verified
+end-to-end here (OpenCode's cold start is slow in constrained shells, so exercise a real run in a
+normal terminal). Other orchestrators (Cursor, …) are designed-for but unproven. This line gets
+upgraded to "verified end-to-end" with evidence, not assumption.
 
 ## Repository shape
 
@@ -134,7 +152,15 @@ skills/
 │       ├── dispatch-and-poll.md
 │       ├── review-and-land.md
 │       └── multi-task-queues.md
-└── opencode-delegate/
+├── opencode-delegate/
+│   ├── SKILL.md
+│   ├── scripts/relay.mjs
+│   └── references/
+│       ├── writing-the-brief.md
+│       ├── dispatch-and-poll.md
+│       ├── review-and-land.md
+│       └── multi-task-queues.md
+└── grok-delegate/
     ├── SKILL.md
     ├── scripts/relay.mjs
     └── references/

--- a/README.md
+++ b/README.md
@@ -132,13 +132,17 @@ This package is intentionally inspectable:
 
 **Verification status:** each relay's mechanics are verified — argument handling, exit codes,
 `result.json`, resume, and (for `opencode-delegate`) the required-model guard, since OpenCode has no safe
-default. For `grok-delegate`, relay mechanics (arg handling, exit codes, `result.json`, autonomy flag
-assembly, resume/session mutual exclusion, missing-binary `grok_unavailable`) are exercised; a full
-authenticated `grok -p` end-to-end run is not claimed here (Grok Build is beta-gated). The full
-delegate → review → commit loop is designed for and run on Claude Code but not yet formally verified
-end-to-end here (OpenCode's cold start is slow in constrained shells, so exercise a real run in a
-normal terminal). Other orchestrators (Cursor, …) are designed-for but unproven. This line gets
-upgraded to "verified end-to-end" with evidence, not assumption.
+default. `grok-delegate` is verified end-to-end on macOS against **grok 0.2.101**: a headless run streams
+`--output-format streaming-json`, the relay reconstructs `finalMessage` from the `text` events and the
+session id + token `usage` from the end event, default autonomy (`--always-approve --sandbox workspace`)
+edits the working tree headlessly, `--resume-last` continues a prior session, and the deterministic paths
+(arg handling, exit codes, autonomy-flag assembly, resume/session mutual exclusion, missing-binary
+`grok_unavailable`) hold. **One caveat, confirmed by testing:** `--read-only` is *best-effort*, not
+enforced — grok's read-only sandbox restricts out-of-workspace access, not its own edit tool, so a
+headless run can still write the tree; verify `touchedFiles` rather than trusting the flag. Windows
+launch is not yet smoke-tested for `grok-delegate`. The full delegate → review → commit loop is designed
+for and run on Claude Code; other orchestrators (Cursor, …) are designed-for but unproven. This line gets
+upgraded with evidence, not assumption.
 
 ## Repository shape
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -6,7 +6,8 @@
       "description": "Delegate a coding task to a CLI implementer agent, then review the diff and commit it yourself.",
       "skills": [
         "codex-delegate",
-        "opencode-delegate"
+        "opencode-delegate",
+        "grok-delegate"
       ]
     }
   ]

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -35,8 +35,9 @@ orchestrators as designed-for, not yet proven.)
 ## Prerequisites (check once)
 
 1. `grok version` succeeds. If not, install on any platform with
-   `npm i -g @xai-official/grok` and authenticate (`grok login`, or `grok login --device-auth` on
-   headless hosts, or set `XAI_API_KEY`).
+   `npm i -g @xai-official/grok` (or use the installer from xAI's official Grok CLI docs) and
+   authenticate (`grok login`, or `grok login --device-auth` on headless hosts, or set
+   `XAI_API_KEY`).
 2. **Confirm which `grok` is on PATH.** `command -v grok` shows the active binary and `grok version`
    its version — the relay records the version it ran into `result.json`, so a stale binary is visible
    after the fact.

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -135,6 +135,8 @@ verified here still wrote the working tree when told to. Use `--read-only` to *s
 but always confirm `touchedFiles` afterward; treat the diff, not the flag, as the guarantee. The relay
 automates the check: it snapshots `git status` before a `--read-only` run and sets
 `readOnlyViolation: true` in `result.json` (with a summary warning) when the tree changed anyway.
+It's a porcelain-level tripwire — an edit inside an already-dirty file can evade it, so on a dirty
+tree the diff review stays the only real guarantee.
 
 ## Authorization model
 

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: grok-delegate
+description: >-
+  Delegate a coding task to the Grok Build CLI as a background implementer, then review its diff and
+  land it yourself. Use this whenever the user wants to hand implementation work to Grok — phrasings
+  like "have Grok do X", "delegate this to Grok", "run it through Grok", "use Grok Build to
+  implement/fix/refactor", or "have grok CLI do this" — or to run a queue of coding tasks through
+  Grok while staying the reviewer. Prefer it when the user will review the diff and commit it
+  themselves. DO NOT USE for tasks small enough to do inline, or when the user wants the code written
+  directly without delegating.
+license: MIT
+compatibility: Requires the `grok` CLI (Grok Build) installed and authenticated (`grok login`, or `XAI_API_KEY`; beta access needs an eligible xAI subscription), Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.1.0
+---
+
+# Grok Delegate
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the Grok Build CLI (`grok`) — then review what it produced and land it yourself. You
+write the brief and own the judgment; Grok does the typing under an explicit autonomy profile; you
+verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so it works the same whether you are Claude Code, Cursor, OpenCode with a
+selected model, or any comparable agent. (It is designed for Claude Code and Cursor; treat other
+orchestrators as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `grok` CLI is not installed, not authenticated, or the account lacks Grok Build beta access.
+- You want to write the code yourself, or you only need a review without an implementer run.
+
+## Prerequisites (check once)
+
+1. `grok version` succeeds. If not, install (`curl -fsSL https://x.ai/cli/install.sh | bash`, or
+   `npm i -g @xai-official/grok` on Windows PowerShell use `irm https://x.ai/cli/install.ps1 | iex`)
+   and authenticate (`grok login`, or `grok login --device-auth` on headless hosts, or set
+   `XAI_API_KEY`).
+2. **Confirm which `grok` is on PATH.** `command -v grok` shows the active binary and `grok version`
+   its version — the relay records the version it ran into `result.json`, so a stale binary is visible
+   after the fact.
+3. You are in (or will point `--cd` at) the target git repository.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Grok sees **only** the text you send — no orchestrator chat history, no shared context. Everything the
+task needs goes in the brief: the goal, the current state, what to change, what to leave untouched,
+the project's **actual** gate commands (discover them from the repo's CLAUDE.md/AGENTS.md/Makefile —
+do not assume), and a report contract. Tell Grok it will **not** commit (you will). Keep one task per
+brief. Full guidance and a template: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to Grok with the bundled helper. It wraps `grok -p`, captures the run, and writes a
+structured `result.json` — so your only job is "run a command, read a file." (`<skill-dir>` below is
+this skill's installed directory — the folder containing this `SKILL.md`, i.e. the directory you loaded
+the skill from. Claude Code prints it as "Base directory for this skill" when the skill loads; on other
+orchestrators use that same directory — if unsure where it landed, run
+`find ~ -name relay.mjs -path '*grok-delegate*'` and substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (review/diagnosis, no edits):   add --read-only
+# continue the previous Grok session:       add --resume-last  (send only the delta brief)
+# see all options:                          node .../relay.mjs --help
+```
+
+The helper defaults to a write-capable (`workspace-write`) autonomy profile — `--always-approve` plus
+`--sandbox workspace` — and writes its artifacts to a temp dir, so the repo under review stays clean.
+It **never commits** — see step 5. Mechanics, flags, and the `result.json` shape:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Grok finishes, so back it with whatever your orchestrator offers and resume
+when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job`
+  in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a `status`. (A
+  pre-run usage error — bad args or an empty brief — instead exits with code 2 and a stderr message and
+  writes no result file, so check the exit code too. A missing `grok` binary exits 127 but *does* write
+  a `result.json` with status `grok_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line.
+
+### 4. Review — do not trust the self-report
+
+Grok's `result.json` includes its own summary and gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did Grok do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+**The orchestrator commits.** Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
+  review again.
+
+## Autonomy model
+
+Grok's default permission mode is `ask`, which **blocks on approval prompts in a headless pipe**. The
+relay therefore always sets autonomy explicitly:
+
+| Relay flag | What Grok gets | Use when |
+| --- | --- | --- |
+| *(default)* | `--always-approve --sandbox workspace` | Normal implementation — writes scoped to the working tree |
+| `--read-only` | `--sandbox read-only --permission-mode plan` | Review / diagnosis with no working-tree edits |
+| `--full-access` | `--always-approve --sandbox off` | Explicit opt-in when the task needs unrestricted tools |
+
+`--always-approve` alone would approve *all* tools (writes, shell, network) — closer to unrestricted
+than to a workspace-scoped write. Pairing it with `--sandbox workspace` is what keeps the default
+safe. Reach for `--full-access` only when the human asks for it.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report Grok's design decisions, defensible-but-unasked turns, and
+non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if correct
+completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
+is in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief Grok can
+  execute blind: structure, XML blocks, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the rework cycle via `--resume-last`.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -132,7 +132,9 @@ safe. Reach for `--full-access` only when the human asks for it.
 **`--read-only` is best-effort, not a hard guarantee.** The read-only sandbox restricts out-of-workspace
 filesystem/network access, not grok's own edit tool, and headless `plan` mode is advisory — a run
 verified here still wrote the working tree when told to. Use `--read-only` to *signal* review intent,
-but always confirm `touchedFiles` afterward; treat the diff, not the flag, as the guarantee.
+but always confirm `touchedFiles` afterward; treat the diff, not the flag, as the guarantee. The relay
+automates the check: it snapshots `git status` before a `--read-only` run and sets
+`readOnlyViolation: true` in `result.json` (with a summary warning) when the tree changed anyway.
 
 ## Authorization model
 

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -66,7 +66,7 @@ orchestrators use that same directory — if unsure where it landed, run
 
 ```bash
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
-# read-only (review/diagnosis, no edits):   add --read-only
+# read-only (review/diagnosis; best-effort — verify touchedFiles): add --read-only
 # continue the previous Grok session:       add --resume-last  (send only the delta brief)
 # see all options:                          node .../relay.mjs --help
 ```
@@ -122,12 +122,17 @@ relay therefore always sets autonomy explicitly:
 | Relay flag | What Grok gets | Use when |
 | --- | --- | --- |
 | *(default)* | `--always-approve --sandbox workspace` | Normal implementation — writes scoped to the working tree |
-| `--read-only` | `--sandbox read-only --permission-mode plan` | Review / diagnosis with no working-tree edits |
+| `--read-only` | `--sandbox read-only --permission-mode plan` | Review / diagnosis — **best-effort, not enforced** (see caveat below) |
 | `--full-access` | `--always-approve --sandbox off` | Explicit opt-in when the task needs unrestricted tools |
 
 `--always-approve` alone would approve *all* tools (writes, shell, network) — closer to unrestricted
 than to a workspace-scoped write. Pairing it with `--sandbox workspace` is what keeps the default
 safe. Reach for `--full-access` only when the human asks for it.
+
+**`--read-only` is best-effort, not a hard guarantee.** On grok 0.2.101 the read-only sandbox restricts
+out-of-workspace filesystem/network access, not grok's own edit tool, and headless `plan` mode is
+advisory — a run verified here still wrote the working tree when told to. Use `--read-only` to *signal*
+review intent, but always confirm `touchedFiles` afterward; treat the diff, not the flag, as the guarantee.
 
 ## Authorization model
 

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -34,10 +34,9 @@ orchestrators as designed-for, not yet proven.)
 
 ## Prerequisites (check once)
 
-1. `grok version` succeeds. If not, install (`curl -fsSL https://x.ai/cli/install.sh | bash`, or
-   `npm i -g @xai-official/grok` on Windows PowerShell use `irm https://x.ai/cli/install.ps1 | iex`)
-   and authenticate (`grok login`, or `grok login --device-auth` on headless hosts, or set
-   `XAI_API_KEY`).
+1. `grok version` succeeds. If not, install on any platform with
+   `npm i -g @xai-official/grok` and authenticate (`grok login`, or `grok login --device-auth` on
+   headless hosts, or set `XAI_API_KEY`).
 2. **Confirm which `grok` is on PATH.** `command -v grok` shows the active binary and `grok version`
    its version — the relay records the version it ran into `result.json`, so a stale binary is visible
    after the fact.
@@ -129,10 +128,10 @@ relay therefore always sets autonomy explicitly:
 than to a workspace-scoped write. Pairing it with `--sandbox workspace` is what keeps the default
 safe. Reach for `--full-access` only when the human asks for it.
 
-**`--read-only` is best-effort, not a hard guarantee.** On grok 0.2.101 the read-only sandbox restricts
-out-of-workspace filesystem/network access, not grok's own edit tool, and headless `plan` mode is
-advisory — a run verified here still wrote the working tree when told to. Use `--read-only` to *signal*
-review intent, but always confirm `touchedFiles` afterward; treat the diff, not the flag, as the guarantee.
+**`--read-only` is best-effort, not a hard guarantee.** The read-only sandbox restricts out-of-workspace
+filesystem/network access, not grok's own edit tool, and headless `plan` mode is advisory — a run
+verified here still wrote the working tree when told to. Use `--read-only` to *signal* review intent,
+but always confirm `touchedFiles` afterward; treat the diff, not the flag, as the guarantee.
 
 ## Authorization model
 

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -67,7 +67,9 @@ touched-files report shows only Grok's edits and nothing of the helper's own.
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw streaming-json event stream, and the final-message file
 - `workdir`, `autonomy`, `model`, `effort`, `resumeLast`, `startedAt`, `finishedAt`
 - `readOnlyViolation` — present on `--read-only` runs only: `true` when the working tree changed
-  between dispatch and completion, i.e. the best-effort read-only was not honored
+  between dispatch and completion, i.e. the best-effort read-only was not honored. A porcelain-level
+  tripwire: it catches new dirt, but an edit inside an already-dirty file can evade it — the diff
+  review, not this flag, is the guarantee
 - `stderrTail` — last ~20 stderr lines; present **only** on a failed run (a non-zero Grok exit), absent on `completed`, `grok_unavailable`, and launch failures
 - `error` — present **only** if Grok failed to launch
 

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -36,7 +36,8 @@ Options:
 | `--cd <dir>` | Working root for Grok (default: current directory); passed as `--cwd`. |
 | `--model <name>` | Grok model (default: Grok's own configured default). |
 | `--effort <level>` | Reasoning effort for this run (`--effort`). |
-| `--read-only` | Review/diagnosis intent (`--sandbox read-only --permission-mode plan`). **Best-effort, not enforced** — grok can still edit the tree headlessly, so always verify `touchedFiles`. |
+| `--max-turns <n>` | Maximum number of agent turns for this run (`--max-turns`). |
+| `--read-only` | Review/diagnosis intent (`--sandbox read-only --permission-mode plan`). **Best-effort, not enforced** — grok can still edit the tree headlessly. The relay snapshots `git status` before the run and sets `readOnlyViolation: true` in `result.json` if the tree changed. |
 | `--full-access` | Unrestricted auto-approve (`--always-approve --sandbox off`); opt-in. |
 | `--resume-last` | Continue the most recent Grok session for this cwd; send only the delta brief. |
 | `--session <id>` | Continue a specific session id; mutually exclusive with `--resume-last`. |
@@ -65,6 +66,8 @@ touched-files report shows only Grok's edits and nothing of the helper's own.
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report; `[]` means git ran and the tree is clean
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw streaming-json event stream, and the final-message file
 - `workdir`, `autonomy`, `model`, `effort`, `resumeLast`, `startedAt`, `finishedAt`
+- `readOnlyViolation` — present on `--read-only` runs only: `true` when the working tree changed
+  between dispatch and completion, i.e. the best-effort read-only was not honored
 - `stderrTail` — last ~20 stderr lines; present **only** on a failed run (a non-zero Grok exit), absent on `completed`, `grok_unavailable`, and launch failures
 - `error` — present **only** if Grok failed to launch
 

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,138 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `grok -p` (headless mode), runs the brief under
+an explicit autonomy profile, captures everything, and writes a structured `result.json`. Your job
+collapses to: run one command, then read one file. Everything Grok-specific lives in the helper, which
+is what keeps the loop portable across orchestrators.
+
+## Before the first run: check the binary
+
+Two gotchas, both worth 30 seconds:
+
+```bash
+command -v grok      # the active binary; a stale install can shadow a current one
+grok version         # recorded into result.json so a stale binary is visible after the fact
+grok login           # or: grok login --device-auth / export XAI_API_KEY=...
+```
+
+Grok Build is an early beta gated behind an eligible xAI subscription (SuperGrok / X Premium+). An
+auth failure or missing beta access shows up as a failed run, not as `grok_unavailable`.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for Grok (default: current directory); passed as `--cwd`. |
+| `--model <name>` | Grok model (default: Grok's own configured default). |
+| `--effort <level>` | Reasoning effort for this run (`--effort`). |
+| `--read-only` | Review/diagnosis with no edits (`--sandbox read-only --permission-mode plan`). |
+| `--full-access` | Unrestricted auto-approve (`--always-approve --sandbox off`); opt-in. |
+| `--resume-last` | Continue the most recent Grok session for this cwd; send only the delta brief. |
+| `--session <id>` | Continue a specific session id; mutually exclusive with `--resume-last`. |
+| `--prompt-stdin` | **Experimental.** Pipe the brief on stdin and pass `-p -` instead of putting the brief in argv. Unverified — use while testing which delivery path Grok accepts. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Default autonomy (neither `--read-only` nor `--full-access`) is **workspace-write**:
+`--always-approve --sandbox workspace`. Grok's native default is `ask`, which would hang a headless
+pipe; the relay always sets autonomy explicitly.
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only Grok's edits and nothing of the helper's own.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `tool` — `"grok"`
+- `status` — `completed` | `failed` | `grok_unavailable`
+- `exitCode` — mirrors Grok's exit code; `127` if `grok` isn't on PATH
+- `grokVersion` — the binary that actually ran
+- `sessionId` — feed this to a later `--session <id>` (or use `--resume-last`)
+- `finalMessage` — Grok's own final report (the `<structured_output_contract>` you asked for)
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report; `[]` means git ran and the tree is clean
+- `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw streaming-json event stream, and the final-message file
+- `workdir`, `autonomy`, `model`, `effort`, `resumeLast`, `promptStdin`, `startedAt`, `finishedAt`
+- `stderrTail` — last ~20 stderr lines; present **only** on a failed run (a non-zero Grok exit), absent on `completed`, `grok_unavailable`, and launch failures
+- `error` — present **only** if Grok failed to launch
+
+The helper also prints a summary to stdout and exits with Grok's exit code, so a wrapping script can
+branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until Grok finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job` in PowerShell,
+  `start /b` in cmd). A run is done when `result.json` exists with a `status`. **But** a pre-run usage
+  error (bad args, empty brief) exits with code 2 *before* writing any file — so check the exit code
+  too, don't only watch for the file. (A missing `grok` binary exits 127 but *does* write a
+  `result.json` with status `grok_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: grok_unavailable` (exit 127):** `grok` isn't on PATH or isn't found. Install
+  (`curl -fsSL https://x.ai/cli/install.sh | bash`, or `npm i -g @xai-official/grok`) and
+  `grok login`, then re-dispatch.
+- **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
+  Common causes: an auth lapse, missing beta access, an invalid `--model`, or a sandbox that blocked
+  something the task needed. Fix the cause and re-dispatch; don't paper over it by doing the work
+  yourself unless that's what the user wants.
+- **Empty `finalMessage`:** Grok exited before producing a final message, or the streaming-json event
+  shape didn't match the extractor. Treat as a failed run; the events log usually shows where it
+  stopped — and is the source of truth for tightening the parser.
+
+## What the helper is doing (and the alternatives)
+
+Under the hood the helper runs roughly:
+
+```bash
+# fresh run (default workspace-write autonomy)
+grok --no-auto-update --no-alt-screen --output-format streaming-json --cwd <repo> \
+  --always-approve --sandbox workspace -p "<brief>"
+
+# resume most recent session for this cwd
+grok --no-auto-update --no-alt-screen --output-format streaming-json --cwd <repo> \
+  --continue --always-approve --sandbox workspace -p "<delta>"
+
+# resume a specific session
+grok --no-auto-update --no-alt-screen --output-format streaming-json --cwd <repo> \
+  --resume <id> --always-approve --sandbox workspace -p "<delta>"
+```
+
+`--no-auto-update` and `--no-alt-screen` are always set so automated runs don't check for updates or
+take over the terminal. Autonomy flags are re-passed on resume because headless permission mode may
+not inherit.
+
+**Prompt delivery:** by default the brief is the `-p` argv value. `--prompt-stdin` is an experimental
+alternate that pipes the brief on stdin and passes `-p -` — use it while testing which path Grok
+accepts for multi-line XML briefs; lock in the winner once verified.
+
+Two alternatives exist if you ever want them, but the helper is the recommended path:
+
+- **Raw `grok -p`** — fine for one-offs; you give up the captured `result.json`, touched-files
+  summary, and session-id extraction the helper does for you.
+- **`grok agent stdio` (ACP)** — richer IDE/tool integration over JSON-RPC. Out of scope for this
+  skill; the headless `-p` path is the one the relay drives.
+
+## The commit boundary
+
+The helper never commits — by design, not omission. The robust contract is: Grok edits the working
+tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -36,11 +36,10 @@ Options:
 | `--cd <dir>` | Working root for Grok (default: current directory); passed as `--cwd`. |
 | `--model <name>` | Grok model (default: Grok's own configured default). |
 | `--effort <level>` | Reasoning effort for this run (`--effort`). |
-| `--read-only` | Review/diagnosis with no edits (`--sandbox read-only --permission-mode plan`). |
+| `--read-only` | Review/diagnosis intent (`--sandbox read-only --permission-mode plan`). **Best-effort, not enforced** on grok 0.2.101 — grok can still edit the tree headlessly, so always verify `touchedFiles`. |
 | `--full-access` | Unrestricted auto-approve (`--always-approve --sandbox off`); opt-in. |
 | `--resume-last` | Continue the most recent Grok session for this cwd; send only the delta brief. |
 | `--session <id>` | Continue a specific session id; mutually exclusive with `--resume-last`. |
-| `--prompt-stdin` | **Experimental.** Pipe the brief on stdin and pass `-p -` instead of putting the brief in argv. Unverified — use while testing which delivery path Grok accepts. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
 
 Default autonomy (neither `--read-only` nor `--full-access`) is **workspace-write**:
@@ -60,10 +59,11 @@ touched-files report shows only Grok's edits and nothing of the helper's own.
 - `exitCode` — mirrors Grok's exit code; `127` if `grok` isn't on PATH
 - `grokVersion` — the binary that actually ran
 - `sessionId` — feed this to a later `--session <id>` (or use `--resume-last`)
-- `finalMessage` — Grok's own final report (the `<structured_output_contract>` you asked for)
+- `finalMessage` — Grok's own final report (the `<structured_output_contract>` you asked for), assembled from the streaming-json `text` events
+- `usage` — token counts from the run's end event (`input_tokens` / `output_tokens` / `total_tokens`); `null` if none were reported
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report; `[]` means git ran and the tree is clean
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw streaming-json event stream, and the final-message file
-- `workdir`, `autonomy`, `model`, `effort`, `resumeLast`, `promptStdin`, `startedAt`, `finishedAt`
+- `workdir`, `autonomy`, `model`, `effort`, `resumeLast`, `startedAt`, `finishedAt`
 - `stderrTail` — last ~20 stderr lines; present **only** on a failed run (a non-zero Grok exit), absent on `completed`, `grok_unavailable`, and launch failures
 - `error` — present **only** if Grok failed to launch
 
@@ -106,31 +106,32 @@ Under the hood the helper runs roughly:
 ```bash
 # fresh run (default workspace-write autonomy)
 grok --no-auto-update --no-alt-screen --output-format streaming-json --cwd <repo> \
-  --always-approve --sandbox workspace -p "<brief>"
+  --always-approve --sandbox workspace --prompt-file <brief.txt>
 
 # resume most recent session for this cwd
 grok --no-auto-update --no-alt-screen --output-format streaming-json --cwd <repo> \
-  --continue --always-approve --sandbox workspace -p "<delta>"
+  --continue --always-approve --sandbox workspace --prompt-file <delta.txt>
 
 # resume a specific session
 grok --no-auto-update --no-alt-screen --output-format streaming-json --cwd <repo> \
-  --resume <id> --always-approve --sandbox workspace -p "<delta>"
+  --resume <id> --always-approve --sandbox workspace --prompt-file <delta.txt>
 ```
 
 `--no-auto-update` and `--no-alt-screen` are always set so automated runs don't check for updates or
 take over the terminal. Autonomy flags are re-passed on resume because headless permission mode may
 not inherit.
 
-**Prompt delivery:** by default the brief is the `-p` argv value. `--prompt-stdin` is an experimental
-alternate that pipes the brief on stdin and passes `-p -` — use it while testing which path Grok
-accepts for multi-line XML briefs; lock in the winner once verified.
+**Prompt delivery:** the brief is handed to grok via `--prompt-file`, never argv — so it stays out of
+the host process list, isn't bounded by the OS argument-length cap, and a brief that begins with `-`
+can't be misread as a flag. The relay writes the brief you pass (via `--brief` or stdin) to a file and
+points `--prompt-file` at it.
 
 Two alternatives exist if you ever want them, but the helper is the recommended path:
 
-- **Raw `grok -p`** — fine for one-offs; you give up the captured `result.json`, touched-files
-  summary, and session-id extraction the helper does for you.
+- **Raw `grok --prompt-file`** — fine for one-offs; you give up the captured `result.json`,
+  touched-files summary, and session-id extraction the helper does for you.
 - **`grok agent stdio` (ACP)** — richer IDE/tool integration over JSON-RPC. Out of scope for this
-  skill; the headless `-p` path is the one the relay drives.
+  skill; the headless single-turn path is the one the relay drives.
 
 ## The commit boundary
 

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -56,7 +56,8 @@ touched-files report shows only Grok's edits and nothing of the helper's own.
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
 - `tool` — `"grok"`
 - `status` — `completed` | `failed` | `grok_unavailable`
-- `exitCode` — mirrors Grok's exit code; `127` if `grok` isn't on PATH
+- `exitCode` — mirrors Grok's exit code; `128` plus the signal number if the child was killed; `127` if `grok` isn't on PATH
+- `signal` — the signal that killed the child, otherwise `null`
 - `grokVersion` — the binary that actually ran
 - `sessionId` — feed this to a later `--session <id>` (or use `--resume-last`)
 - `finalMessage` — Grok's own final report (the `<structured_output_contract>` you asked for), assembled from the streaming-json `text` events
@@ -90,6 +91,9 @@ process has exited and `result.json` is written — not when a status line says 
 
 - **`status: grok_unavailable` (exit 127):** `grok` isn't on PATH or isn't found. Install with
   `npm i -g @xai-official/grok` and `grok login`, then re-dispatch.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
 - **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
   Common causes: an auth lapse, missing beta access, an invalid `--model`, or a sandbox that blocked
   something the task needed. Fix the cause and re-dispatch; don't paper over it by doing the work

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -36,7 +36,7 @@ Options:
 | `--cd <dir>` | Working root for Grok (default: current directory); passed as `--cwd`. |
 | `--model <name>` | Grok model (default: Grok's own configured default). |
 | `--effort <level>` | Reasoning effort for this run (`--effort`). |
-| `--read-only` | Review/diagnosis intent (`--sandbox read-only --permission-mode plan`). **Best-effort, not enforced** on grok 0.2.101 — grok can still edit the tree headlessly, so always verify `touchedFiles`. |
+| `--read-only` | Review/diagnosis intent (`--sandbox read-only --permission-mode plan`). **Best-effort, not enforced** — grok can still edit the tree headlessly, so always verify `touchedFiles`. |
 | `--full-access` | Unrestricted auto-approve (`--always-approve --sandbox off`); opt-in. |
 | `--resume-last` | Continue the most recent Grok session for this cwd; send only the delta brief. |
 | `--session <id>` | Continue a specific session id; mutually exclusive with `--resume-last`. |
@@ -88,9 +88,8 @@ process has exited and `result.json` is written — not when a status line says 
 
 ## When a run misbehaves
 
-- **`status: grok_unavailable` (exit 127):** `grok` isn't on PATH or isn't found. Install
-  (`curl -fsSL https://x.ai/cli/install.sh | bash`, or `npm i -g @xai-official/grok`) and
-  `grok login`, then re-dispatch.
+- **`status: grok_unavailable` (exit 127):** `grok` isn't on PATH or isn't found. Install with
+  `npm i -g @xai-official/grok` and `grok login`, then re-dispatch.
 - **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
   Common causes: an auth lapse, missing beta access, an invalid `--model`, or a sandbox that blocked
   something the task needed. Fix the cause and re-dispatch; don't paper over it by doing the work

--- a/skills/grok-delegate/references/multi-task-queues.md
+++ b/skills/grok-delegate/references/multi-task-queues.md
@@ -1,0 +1,67 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential.
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. Each fresh dispatch starts a **new** Grok session with no memory of
+the earlier run (unless you deliberately `--resume-last` / `--session`), so a constraint that emerged
+in task 2 must be restated in task 5's brief or it won't hold. This is the queue equivalent of keeping
+briefs self-contained.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions Grok made, non-blocking nitpicks, anything you want the
+  human to overrule or confirm. This is the section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/grok-delegate/references/review-and-land.md
+++ b/skills/grok-delegate/references/review-and-land.md
@@ -1,0 +1,115 @@
+# Review and land
+
+Grok did the typing; you own the judgment. This is where delegation earns its keep or quietly ships a
+mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
+reality, never against the self-report — and read the diff as generated code, which fails in ways a
+green gate can't see.**
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries Grok's own claim that the gates passed. Treat that as a claim, not evidence —
+re-run the project's actual test/lint/build commands in the working tree and read the output. And keep
+the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a gate,
+not just misreport it — that is what the test check above and the sweep below exist to catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Scope creep** — did Grok change things the brief said to leave untouched? Unasked refactors,
+  renames, "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version?
+- **Quiet judgment calls** — sometimes Grok makes a defensible decision the brief didn't anticipate.
+  Don't just accept it because it looks reasonable; understand it and decide.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If Grok couldn't implement something,
+  the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to Grok as a delta brief (below) or gets fixed in the tree before
+commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never Grok. This isn't a
+workaround for a missing feature; it's the deliberate boundary. Committing should be the act of the
+party that verified the work. Write a clear message describing what landed. If your project attributes
+co-authorship, that's the place for it.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same Grok session with
+just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
+
+`--resume-last` keeps Grok's context from the first run (via `grok --continue`), so a short delta is
+enough. To resume a specific session from `result.json`'s `sessionId`, pass `--session <id>` instead.
+Then review again — rework gets the same gate-rerun, test check, diff-read, and sweep as the original,
+no shortcuts. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** Grok made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or Grok's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/grok-delegate/references/writing-the-brief.md
+++ b/skills/grok-delegate/references/writing-the-brief.md
@@ -1,0 +1,109 @@
+# Writing the brief
+
+A brief is the entire task as Grok will see it. Grok runs in a fresh process with **no memory of
+your conversation, no access to your prior notes, and no shared context** — only the text you send and
+whatever it can read from the working tree (including repo rules it discovers via `grok inspect`, and
+the repo's own `AGENTS.md` when present).
+If a constraint isn't in the brief or discoverable in the repo, it doesn't exist for Grok. The single
+most common failure is a brief that assumes context Grok doesn't have.
+
+## The shape that works
+
+Grok responds best to compact, block-structured prompts with XML tags rather
+than long prose. State the task, what "done" looks like, how to behave by default, and the few
+constraints that actually matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps Grok from
+wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences) and run with `--read-only` so Grok can't edit.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`CLAUDE.md` / `AGENTS.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you a Grok that guesses — or skips.
+
+## Honor the repo's conventions
+
+Grok discovers project configuration for the current directory (`grok inspect` shows rules, skills,
+plugins, hooks, and MCP servers). House rules in the repo (style, forbidden patterns, commit
+conventions) already apply when configured. If the project forbids certain things in code — say,
+spec/ticket IDs in comments, process language like "MVP"/"for now"/"phase N", or specific test
+conventions — restate the load-bearing ones in the brief too, because compliance is only as reliable
+as what's in front of the implementer.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and
+suggest a roadmap" produces a muddled run; split it into separate dispatches. One brief → one Grok
+run → one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/grok-delegate/references/writing-the-brief.md
+++ b/skills/grok-delegate/references/writing-the-brief.md
@@ -50,7 +50,8 @@ profile calls for them:
   first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
   state what's unknown).
 - **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
-  inferences) and run with `--read-only` so Grok can't edit.
+  inferences), tell Grok in the brief not to edit anything, and run with `--read-only`. Note
+  `--read-only` is best-effort on grok, not a hard block — verify `touchedFiles` after the run.
 - **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
   questions).
 

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -1,0 +1,500 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · grok-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Grok Build CLI (`grok -p`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Grok-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Designed against the Grok Build headless docs; other
+ * shell-capable agents (Claude Code, Cursor, …) are designed-for but not yet
+ * verified end-to-end here.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `grok` and `git`. The `grok` process it
+ * launches does authenticate — exactly as you do at the terminal. Read this
+ * file before you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job —
+ * after it reviews the diff and re-runs the project gates.
+ *
+ * Grok's default permission mode is `ask`, which blocks on approval prompts in
+ * a non-interactive pipe. The relay therefore sets autonomy explicitly:
+ *   default        — `--always-approve --sandbox workspace` (write in CWD)
+ *   --read-only    — `--sandbox read-only --permission-mode plan` (no edits)
+ *   --full-access  — `--always-approve --sandbox off` (unrestricted; opt-in)
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for Grok (default: current directory).
+ *   --model <name>          Grok model (default: Grok's own configured default).
+ *   --effort <level>        Reasoning effort for this run (passed as `--effort`).
+ *   --read-only             Review/diagnosis with no edits (`--sandbox read-only`).
+ *   --full-access           Unrestricted auto-approve (`--sandbox off`); opt-in.
+ *   --resume-last           Continue the most recent Grok session for this cwd;
+ *                           send only the delta brief.
+ *   --session <id>          Continue a specific session id; send only the delta brief.
+ *                           Mutually exclusive with --resume-last.
+ *   --prompt-stdin          Experimental: pipe the brief on stdin and pass `-p -`
+ *                           instead of putting the brief in argv. Unverified —
+ *                           use while testing which delivery path Grok accepts.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, grokVersion, sessionId (for a later resume), finalMessage
+ *   (Grok's own report), touchedFiles (git porcelain, null if git can't report), and the
+ *   paths to events.jsonl and final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `grok` binary exits 127;
+ * otherwise the exit code mirrors Grok's own (0 success, non-zero failure).
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, or grok_unavailable. An orchestrator that polls for the
+ * file must therefore also treat a non-zero exit with no file as a usage error.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { tmpdir } from "node:os";
+
+const AUTONOMY_MODES = new Set(["workspace-write", "read-only", "full-access"]);
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    autonomy: "workspace-write",
+    resumeLast: false,
+    session: null,
+    promptStdin: false,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--effort": opts.effort = next(); break;
+      case "--read-only": opts.autonomy = "read-only"; break;
+      case "--full-access": opts.autonomy = "full-access"; break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--prompt-stdin": opts.promptStdin = true; break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  if (!AUTONOMY_MODES.has(opts.autonomy)) {
+    fail(`invalid autonomy "${opts.autonomy}"`);
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive");
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to grok -p\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function grokVersion() {
+  try {
+    // On Windows, npm installs `grok` as a .cmd shim; Node's CreateProcess only
+    // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
+    // ENOENTs on a working install. POSIX is unaffected. (git installs a real
+    // git.exe and must NOT get this flag — see gitTouchedFiles.)
+    // Prefer `grok version` (documented subcommand); fall back to `--version`.
+    try {
+      return execFileSync("grok", ["version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
+    } catch {
+      return execFileSync("grok", ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
+    }
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git can't report — git missing, or a non-repo run —
+  // so the caller can tell "git unavailable" apart from "Grok changed nothing."
+  // [] means git ran and the working tree is clean.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function autonomyFlags(autonomy) {
+  // Maps the relay's three autonomy modes onto Grok's native --sandbox /
+  // --always-approve / --permission-mode flags. Grok's default permission mode
+  // is `ask`, which hangs a headless pipe — so every path sets autonomy
+  // explicitly. Sandbox profiles (from the Enterprise docs):
+  //   workspace  — write CWD /tmp ~/.grok/   (workspace-write analog)
+  //   read-only  — no working-tree writes    (review/diagnosis)
+  //   off        — unrestricted              (full-access opt-in)
+  switch (autonomy) {
+    case "read-only":
+      return ["--sandbox", "read-only", "--permission-mode", "plan"];
+    case "full-access":
+      return ["--always-approve", "--sandbox", "off"];
+    case "workspace-write":
+    default:
+      return ["--always-approve", "--sandbox", "workspace"];
+  }
+}
+
+function quoteForCmd(value) {
+  // cmd.exe quoting when shell:true on win32: wrap in ", double internal ".
+  return `"${String(value).replace(/"/g, '""')}"`;
+}
+
+function buildArgv(opts, brief) {
+  // Always: automation hygiene + structured events + working root.
+  const argv = [
+    "--no-auto-update",
+    "--no-alt-screen",
+    "--output-format", "streaming-json",
+    "--cwd", opts.cd,
+  ];
+
+  if (opts.resumeLast) argv.push("--continue");
+  else if (opts.session) argv.push("--resume", opts.session);
+
+  // Re-pass autonomy on resume too — headless permission mode may not inherit.
+  argv.push(...autonomyFlags(opts.autonomy));
+
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.effort) argv.push("--effort", opts.effort);
+
+  // Prompt delivery: default puts the brief in `-p` argv; --prompt-stdin is the
+  // experimental alternate (pipe + `-p -`). Isolated here so A/B testing is a
+  // one-flag change. See deliverPrompt().
+  if (opts.promptStdin) {
+    argv.push("-p", "-");
+  } else {
+    // On win32 + shell:true the brief must be cmd-quoted or spaces/newlines split.
+    const prompt = process.platform === "win32" ? quoteForCmd(brief) : brief;
+    argv.push("-p", prompt);
+  }
+  return argv;
+}
+
+function makeEventScanner(onObject) {
+  // streaming-json is documented as newline-delimited JSON, but be defensive:
+  // brace-aware scan (same approach as opencode-delegate) tolerates junk prefixes
+  // and concatenated objects if the format drifts.
+  let buf = "";
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    buf += chunk;
+    for (let i = 0; i < buf.length; i += 1) {
+      const ch = buf[i];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (ch === "\\") escaped = true;
+        else if (ch === '"') inString = false;
+        continue;
+      }
+      if (ch === '"') { if (depth > 0) inString = true; continue; }
+      if (ch === "{") {
+        if (depth === 0) start = i;
+        depth += 1;
+      } else if (ch === "}") {
+        if (depth > 0) {
+          depth -= 1;
+          if (depth === 0 && start !== -1) {
+            const slice = buf.slice(start, i + 1);
+            try { onObject(JSON.parse(slice)); } catch { /* ignore non-objects */ }
+            start = -1;
+          }
+        }
+      }
+    }
+    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
+    start = -1;
+    depth = 0;
+    inString = false;
+    escaped = false;
+  };
+}
+
+function extractSessionId(event) {
+  return (
+    event.sessionId ??
+    event.session_id ??
+    event.sessionID ??
+    (event.session && (event.session.id ?? event.session.sessionId ?? event.session.session_id)) ??
+    event.params?.sessionId ??
+    event.params?.session_id ??
+    null
+  );
+}
+
+function extractTextChunk(event) {
+  // Tolerant of several plausible streaming-json / ACP-like shapes until a real
+  // event stream confirms the canonical field names (see plan §6.4).
+  if (typeof event.text === "string") return event.text;
+  if (typeof event.message === "string") return event.message;
+  if (typeof event.content === "string") return event.content;
+  if (event.content && typeof event.content.text === "string") return event.content.text;
+  if (event.delta && typeof event.delta.text === "string") return event.delta.text;
+  if (event.part && typeof event.part.text === "string") return event.part.text;
+  const update = event.params?.update ?? event.update;
+  if (update?.sessionUpdate === "agent_message_chunk" && update.content?.text) {
+    return update.content.text;
+  }
+  if (update?.content?.text) return update.content.text;
+  // type:"text" / type:"assistant" / type:"message" with nested text
+  if ((event.type === "text" || event.type === "assistant" || event.type === "message" ||
+       event.type === "agent_message" || event.type === "result") &&
+      typeof (event.text ?? event.message ?? event.result) === "string") {
+    return event.text ?? event.message ?? event.result;
+  }
+  if (event.type === "result" && typeof event.result?.text === "string") return event.result.text;
+  return null;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only Grok's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    eventsPath: join(outDir, "events.jsonl"),
+    finalPath: join(outDir, "final.txt"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "grok",
+      workdir: opts.cd,
+      autonomy: opts.autonomy,
+      model: opts.model,
+      effort: opts.effort,
+      resumeLast: opts.resumeLast,
+      promptStdin: opts.promptStdin,
+      grokVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      eventsPath: run.eventsPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      ...extra,
+    };
+    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "grok_unavailable", exitCode: 127, sessionId: null, finalMessage: "", touchedFiles: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `grok` not found on PATH. Install it (curl -fsSL https://x.ai/cli/install.sh | bash, or npm i -g @xai-official/grok) and run `grok login`.\n");
+  process.exit(127);
+}
+
+function deliverPrompt(child, brief, opts) {
+  // Isolated seam for A/B testing prompt delivery (plan §2e / §6.1).
+  // Default: brief already in `-p` argv — close stdin.
+  // --prompt-stdin: write brief to stdin (paired with `-p -` in buildArgv).
+  child.stdin.on("error", () => {});
+  if (opts.promptStdin) {
+    child.stdin.write(brief);
+  }
+  child.stdin.end();
+}
+
+function dispatchToGrok(opts, brief, run, writeResult) {
+  const argv = buildArgv(opts, brief);
+  // shell:true on Windows so the grok.cmd shim resolves (see grokVersion).
+  // When the brief is in argv on win32 it is cmd-quoted in buildArgv; prefer
+  // --prompt-stdin for pathological multi-line briefs if quoting misbehaves.
+  const child = spawn("grok", argv, {
+    cwd: opts.cd,
+    env: { ...process.env },
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
+
+  let sessionId = opts.session || null;
+  const textChunks = [];
+  const stderrTail = [];
+
+  const scan = makeEventScanner((event) => {
+    const sid = extractSessionId(event);
+    if (sid) sessionId = sid;
+    const chunk = extractTextChunk(event);
+    if (chunk) textChunks.push(chunk);
+  });
+
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    appendFileSync(run.eventsPath, text, "utf8"); // faithful raw record
+    scan(text);
+  });
+
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    process.stderr.write(text); // surface Grok progress live for the orchestrator
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textChunks.join("").trim();
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  child.on("error", (err) => {
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      sessionId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code) => {
+    const finalMessage = assembleFinal();
+    const result = writeResult({
+      status: code === 0 ? "completed" : "failed",
+      exitCode: code === null ? 1 : code,
+      sessionId,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+
+  deliverPrompt(child, brief, opts);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const version = grokVersion();
+  const run = prepareRunDir(opts, brief);
+  const writeResult = makeResultWriter(opts, version, run);
+
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+
+  dispatchToGrok(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode})  ·  grok ${result.grokVersion ?? "?"}`);
+  lines.push(`autonomy: ${result.autonomy}`);
+  if (result.resumeLast) lines.push("mode: resumed most recent session (--continue)");
+  else if (result.sessionId && result.status !== "grok_unavailable") {
+    lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  }
+  if (result.promptStdin) lines.push("prompt delivery: stdin (-p -)  [experimental]");
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- grok final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -75,6 +75,7 @@ import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
 
 const AUTONOMY_MODES = new Set(["workspace-write", "read-only", "full-access"]);
 
@@ -400,15 +401,19 @@ function dispatchToGrok(opts, run, writeResult) {
     if (event.usage && typeof event.usage === "object") usage = event.usage;
   });
 
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
   child.stdout.on("data", (chunk) => {
-    const text = chunk.toString();
-    appendFileSync(run.eventsPath, text, "utf8"); // faithful raw record
-    scan(text);
+    appendFileSync(run.eventsPath, chunk); // faithful raw record
+    scan(stdoutDecoder.write(chunk));
   });
 
   child.stderr.on("data", (chunk) => {
-    const text = chunk.toString();
-    process.stderr.write(text); // surface Grok progress live for the orchestrator
+    process.stderr.write(chunk); // surface Grok progress live for the orchestrator
+    const text = stderrDecoder.write(chunk);
     for (const line of text.split("\n")) {
       if (line.trim()) stderrTail.push(line.trimEnd());
     }

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -2,13 +2,13 @@
 /**
  * delegate-skills · grok-delegate · relay.mjs
  *
- * Dispatch a self-contained brief to the Grok Build CLI (`grok -p`),
+ * Dispatch a self-contained brief to the Grok Build CLI (`grok --prompt-file`),
  * capture the run, and write a structured result the orchestrating agent can
  * review. The orchestrator runs this one command and reads the result JSON —
  * every Grok-specific mechanic lives in here, which keeps the skill
- * orchestrator-agnostic. Designed against the Grok Build headless docs; other
- * shell-capable agents (Claude Code, Cursor, …) are designed-for but not yet
- * verified end-to-end here.
+ * orchestrator-agnostic. Verified end-to-end on macOS against grok 0.2.101;
+ * other shell-capable agents (Claude Code, Cursor, …) are designed-for but not
+ * yet verified there.
  *
  * Trust posture: relay.mjs itself makes no network calls, reads or writes no
  * credentials, and sends no telemetry; it has no dependencies (Node built-ins
@@ -22,8 +22,18 @@
  * Grok's default permission mode is `ask`, which blocks on approval prompts in
  * a non-interactive pipe. The relay therefore sets autonomy explicitly:
  *   default        — `--always-approve --sandbox workspace` (write in CWD)
- *   --read-only    — `--sandbox read-only --permission-mode plan` (no edits)
+ *   --read-only    — `--sandbox read-only --permission-mode plan` (review intent)
  *   --full-access  — `--always-approve --sandbox off` (unrestricted; opt-in)
+ *
+ * `--read-only` is best-effort, NOT a hard guarantee: on grok 0.2.101 the
+ * read-only sandbox governs out-of-workspace filesystem/network access, not the
+ * agent's own edit tool, and headless `plan` mode is advisory — a determined run
+ * can still write the working tree. Always confirm `touchedFiles` after a
+ * read-only run; don't rely on the flag alone.
+ *
+ * The brief is handed to grok via `--prompt-file`, never argv: it stays out of
+ * the host process list, isn't bounded by the OS arg-length cap, and a brief
+ * that starts with "-" can't be misread as a flag.
  *
  * Usage:
  *   node relay.mjs --brief <file> [options]
@@ -40,17 +50,15 @@
  *                           send only the delta brief.
  *   --session <id>          Continue a specific session id; send only the delta brief.
  *                           Mutually exclusive with --resume-last.
- *   --prompt-stdin          Experimental: pipe the brief on stdin and pass `-p -`
- *                           instead of putting the brief in argv. Unverified —
- *                           use while testing which delivery path Grok accepts.
  *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
  *                           the system temp dir, so the repo under review stays clean).
  *   -h, --help              Show this help.
  *
  * Result: written to <out-dir>/result.json and summarized on stdout —
  *   status, exitCode, grokVersion, sessionId (for a later resume), finalMessage
- *   (Grok's own report), touchedFiles (git porcelain, null if git can't report), and the
- *   paths to events.jsonl and final.txt.
+ *   (Grok's own report), usage (token counts from the run's end event, null if
+ *   none), touchedFiles (git porcelain, null if git can't report), and the paths
+ *   to events.jsonl and final.txt.
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `grok` binary exits 127;
@@ -81,7 +89,6 @@ function parseArgs(argv) {
     autonomy: "workspace-write",
     resumeLast: false,
     session: null,
-    promptStdin: false,
     outDir: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -106,7 +113,6 @@ function parseArgs(argv) {
       case "--full-access": opts.autonomy = "full-access"; break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--session": opts.session = next(); break;
-      case "--prompt-stdin": opts.promptStdin = true; break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
         fail(`unknown option: ${arg}`);
@@ -125,7 +131,7 @@ function headerComment() {
   // The leading block comment doubles as --help text.
   const src = readFileSync(new URL(import.meta.url), "utf8");
   const match = src.match(/\/\*\*([\s\S]*?)\*\//);
-  if (!match) return "relay.mjs — dispatch a brief to grok -p\n";
+  if (!match) return "relay.mjs — dispatch a brief to grok --prompt-file\n";
   return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
 }
 
@@ -182,9 +188,11 @@ function autonomyFlags(autonomy) {
   // Maps the relay's three autonomy modes onto Grok's native --sandbox /
   // --always-approve / --permission-mode flags. Grok's default permission mode
   // is `ask`, which hangs a headless pipe — so every path sets autonomy
-  // explicitly. Sandbox profiles (from the Enterprise docs):
+  // explicitly. Sandbox profiles (verified valid on grok 0.2.101):
   //   workspace  — write CWD /tmp ~/.grok/   (workspace-write analog)
-  //   read-only  — no working-tree writes    (review/diagnosis)
+  //   read-only  — review intent ONLY; the sandbox restricts out-of-workspace
+  //                access, not grok's own edit tool, so a headless run can still
+  //                write the tree. Best-effort — verify touchedFiles afterward.
   //   off        — unrestricted              (full-access opt-in)
   switch (autonomy) {
     case "read-only":
@@ -197,12 +205,7 @@ function autonomyFlags(autonomy) {
   }
 }
 
-function quoteForCmd(value) {
-  // cmd.exe quoting when shell:true on win32: wrap in ", double internal ".
-  return `"${String(value).replace(/"/g, '""')}"`;
-}
-
-function buildArgv(opts, brief) {
+function buildArgv(opts, run) {
   // Always: automation hygiene + structured events + working root.
   const argv = [
     "--no-auto-update",
@@ -220,16 +223,10 @@ function buildArgv(opts, brief) {
   if (opts.model) argv.push("--model", opts.model);
   if (opts.effort) argv.push("--effort", opts.effort);
 
-  // Prompt delivery: default puts the brief in `-p` argv; --prompt-stdin is the
-  // experimental alternate (pipe + `-p -`). Isolated here so A/B testing is a
-  // one-flag change. See deliverPrompt().
-  if (opts.promptStdin) {
-    argv.push("-p", "-");
-  } else {
-    // On win32 + shell:true the brief must be cmd-quoted or spaces/newlines split.
-    const prompt = process.platform === "win32" ? quoteForCmd(brief) : brief;
-    argv.push("-p", prompt);
-  }
+  // Deliver the brief via a file, not argv: keeps it out of the host process
+  // list, isn't bounded by the OS arg-length cap, and a brief that begins with
+  // "-" can't be misread as a flag. prepareRunDir already wrote run.briefPath.
+  argv.push("--prompt-file", run.briefPath);
   return argv;
 }
 
@@ -276,38 +273,23 @@ function makeEventScanner(onObject) {
 }
 
 function extractSessionId(event) {
+  // grok's streaming-json carries sessionId (camelCase) on the end event; the
+  // extra fallbacks tolerate a shape drift across versions.
   return (
     event.sessionId ??
     event.session_id ??
-    event.sessionID ??
-    (event.session && (event.session.id ?? event.session.sessionId ?? event.session.session_id)) ??
-    event.params?.sessionId ??
-    event.params?.session_id ??
+    (event.session && (event.session.id ?? event.session.sessionId)) ??
     null
   );
 }
 
 function extractTextChunk(event) {
-  // Tolerant of several plausible streaming-json / ACP-like shapes until a real
-  // event stream confirms the canonical field names (see plan §6.4).
+  // grok streams the assistant reply as {"type":"text","data":"…"}; reasoning
+  // arrives as type:"thought" and is deliberately kept out of the report.
+  // The type:"text"+event.text fallback covers a possible field rename.
+  if (event.type !== "text") return null;
+  if (typeof event.data === "string") return event.data;
   if (typeof event.text === "string") return event.text;
-  if (typeof event.message === "string") return event.message;
-  if (typeof event.content === "string") return event.content;
-  if (event.content && typeof event.content.text === "string") return event.content.text;
-  if (event.delta && typeof event.delta.text === "string") return event.delta.text;
-  if (event.part && typeof event.part.text === "string") return event.part.text;
-  const update = event.params?.update ?? event.update;
-  if (update?.sessionUpdate === "agent_message_chunk" && update.content?.text) {
-    return update.content.text;
-  }
-  if (update?.content?.text) return update.content.text;
-  // type:"text" / type:"assistant" / type:"message" with nested text
-  if ((event.type === "text" || event.type === "assistant" || event.type === "message" ||
-       event.type === "agent_message" || event.type === "result") &&
-      typeof (event.text ?? event.message ?? event.result) === "string") {
-    return event.text ?? event.message ?? event.result;
-  }
-  if (event.type === "result" && typeof event.result?.text === "string") return event.result.text;
   return null;
 }
 
@@ -342,7 +324,6 @@ function makeResultWriter(opts, version, run) {
       model: opts.model,
       effort: opts.effort,
       resumeLast: opts.resumeLast,
-      promptStdin: opts.promptStdin,
       grokVersion: version,
       startedAt: run.startedAt,
       finishedAt: new Date().toISOString(),
@@ -357,36 +338,26 @@ function makeResultWriter(opts, version, run) {
 }
 
 function reportUnavailable(writeResult, resultPath) {
-  const result = writeResult({ status: "grok_unavailable", exitCode: 127, sessionId: null, finalMessage: "", touchedFiles: null });
+  const result = writeResult({ status: "grok_unavailable", exitCode: 127, sessionId: null, finalMessage: "", usage: null, touchedFiles: null });
   printSummary(result, resultPath);
   process.stderr.write("relay: `grok` not found on PATH. Install it (curl -fsSL https://x.ai/cli/install.sh | bash, or npm i -g @xai-official/grok) and run `grok login`.\n");
   process.exit(127);
 }
 
-function deliverPrompt(child, brief, opts) {
-  // Isolated seam for A/B testing prompt delivery (plan §2e / §6.1).
-  // Default: brief already in `-p` argv — close stdin.
-  // --prompt-stdin: write brief to stdin (paired with `-p -` in buildArgv).
-  child.stdin.on("error", () => {});
-  if (opts.promptStdin) {
-    child.stdin.write(brief);
-  }
-  child.stdin.end();
-}
-
-function dispatchToGrok(opts, brief, run, writeResult) {
-  const argv = buildArgv(opts, brief);
-  // shell:true on Windows so the grok.cmd shim resolves (see grokVersion).
-  // When the brief is in argv on win32 it is cmd-quoted in buildArgv; prefer
-  // --prompt-stdin for pathological multi-line briefs if quoting misbehaves.
+function dispatchToGrok(opts, run, writeResult) {
+  const argv = buildArgv(opts, run);
+  // shell:true on Windows so the grok.cmd shim resolves (see grokVersion). Safe:
+  // the brief is delivered via --prompt-file (never argv), and argv holds only
+  // flag names, enums, a model id, and file paths — no shell metacharacters.
   const child = spawn("grok", argv, {
     cwd: opts.cd,
     env: { ...process.env },
-    stdio: ["pipe", "pipe", "pipe"],
+    stdio: ["ignore", "pipe", "pipe"],
     shell: process.platform === "win32",
   });
 
   let sessionId = opts.session || null;
+  let usage = null;
   const textChunks = [];
   const stderrTail = [];
 
@@ -395,6 +366,7 @@ function dispatchToGrok(opts, brief, run, writeResult) {
     if (sid) sessionId = sid;
     const chunk = extractTextChunk(event);
     if (chunk) textChunks.push(chunk);
+    if (event.usage && typeof event.usage === "object") usage = event.usage;
   });
 
   child.stdout.on("data", (chunk) => {
@@ -424,6 +396,7 @@ function dispatchToGrok(opts, brief, run, writeResult) {
       exitCode: 1,
       sessionId,
       finalMessage: assembleFinal(),
+      usage,
       touchedFiles: gitTouchedFiles(opts.cd),
       error: String(err && err.message ? err.message : err),
     });
@@ -438,14 +411,13 @@ function dispatchToGrok(opts, brief, run, writeResult) {
       exitCode: code === null ? 1 : code,
       sessionId,
       finalMessage,
+      usage,
       touchedFiles: gitTouchedFiles(opts.cd),
       ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
   });
-
-  deliverPrompt(child, brief, opts);
 }
 
 function main() {
@@ -462,7 +434,7 @@ function main() {
     return;
   }
 
-  dispatchToGrok(opts, brief, run, writeResult);
+  dispatchToGrok(opts, run, writeResult);
 }
 
 function printSummary(result, resultPath) {
@@ -474,7 +446,10 @@ function printSummary(result, resultPath) {
   else if (result.sessionId && result.status !== "grok_unavailable") {
     lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
   }
-  if (result.promptStdin) lines.push("prompt delivery: stdin (-p -)  [experimental]");
+  if (result.usage) {
+    const u = result.usage;
+    lines.push(`tokens: ${u.total_tokens ?? "?"} total (in ${u.input_tokens ?? "?"}, out ${u.output_tokens ?? "?"})`);
+  }
   const touched = result.touchedFiles;
   if (touched === null) {
     lines.push("touched files: git unavailable — inspect the working tree directly");

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -216,12 +216,18 @@ function autonomyFlags(autonomy) {
 }
 
 function buildArgv(opts, run) {
+  // ponytail: shell:true on win32 (needed for the grok.cmd shim) doesn't quote
+  // args, so a path with spaces (C:\Users\First Last\...) splits before grok
+  // sees it. Quote the two spaceable path args; --model/--effort/--session are
+  // already restricted to safe tokens at parse time.
+  // Ceiling: if quoting proves too blunt, drop shell:true and resolve the shim.
+  const quotePath = (p) => (process.platform === "win32" ? `"${p}"` : p);
   // Always: automation hygiene + structured events + working root.
   const argv = [
     "--no-auto-update",
     "--no-alt-screen",
     "--output-format", "streaming-json",
-    "--cwd", opts.cd,
+    "--cwd", quotePath(opts.cd),
   ];
 
   if (opts.resumeLast) argv.push("--continue");
@@ -236,7 +242,7 @@ function buildArgv(opts, run) {
   // Deliver the brief via a file, not argv: keeps it out of the host process
   // list, isn't bounded by the OS arg-length cap, and a brief that begins with
   // "-" can't be misread as a flag. prepareRunDir already wrote run.briefPath.
-  argv.push("--prompt-file", run.briefPath);
+  argv.push("--prompt-file", quotePath(run.briefPath));
   return argv;
 }
 
@@ -357,8 +363,9 @@ function reportUnavailable(writeResult, resultPath) {
 function dispatchToGrok(opts, run, writeResult) {
   const argv = buildArgv(opts, run);
   // shell:true on Windows so the grok.cmd shim resolves (see grokVersion). Safe:
-  // the brief is delivered via --prompt-file (never argv), and argv holds only
-  // flag names, enums, a model id, and file paths — no shell metacharacters.
+  // the brief is delivered via --prompt-file (never argv), --model/--effort/--session
+  // are restricted to safe tokens at parse time, and the two path args are
+  // quoted for win32 in buildArgv.
   const child = spawn("grok", argv, {
     cwd: opts.cd,
     env: { ...process.env },

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -44,6 +44,7 @@
  *   --cd <dir>              Working root for Grok (default: current directory).
  *   --model <name>          Grok model (default: Grok's own configured default).
  *   --effort <level>        Reasoning effort for this run (passed as `--effort`).
+ *   --max-turns <n>         Maximum number of agent turns for this run.
  *   --read-only             Review/diagnosis with no edits (`--sandbox read-only`).
  *   --full-access           Unrestricted auto-approve (`--sandbox off`); opt-in.
  *   --resume-last           Continue the most recent Grok session for this cwd;
@@ -88,6 +89,7 @@ function parseArgs(argv) {
     cd: process.cwd(),
     model: null,
     effort: null,
+    maxTurns: null,
     autonomy: "workspace-write",
     resumeLast: false,
     session: null,
@@ -111,6 +113,7 @@ function parseArgs(argv) {
       case "--cd": opts.cd = resolve(next()); break;
       case "--model": opts.model = next(); break;
       case "--effort": opts.effort = next(); break;
+      case "--max-turns": opts.maxTurns = next(); break;
       case "--read-only": opts.autonomy = "read-only"; break;
       case "--full-access": opts.autonomy = "full-access"; break;
       case "--resume-last": opts.resumeLast = true; break;
@@ -132,6 +135,10 @@ function parseArgs(argv) {
     if (opts[flag] !== null && !safeToken.test(opts[flag])) {
       fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
     }
+  }
+  // Digits-only also keeps the value safe for the win32 shell launch.
+  if (opts.maxTurns !== null && !/^[1-9]\d*$/.test(opts.maxTurns)) {
+    fail("--max-turns must be a positive integer");
   }
   return opts;
 }
@@ -240,6 +247,7 @@ function buildArgv(opts, run) {
 
   if (opts.model) argv.push("--model", opts.model);
   if (opts.effort) argv.push("--effort", opts.effort);
+  if (opts.maxTurns) argv.push("--max-turns", opts.maxTurns);
 
   // Deliver the brief via a file, not argv: keeps it out of the host process
   // list, isn't bounded by the OS arg-length cap, and a brief that begins with
@@ -363,6 +371,10 @@ function reportUnavailable(writeResult, resultPath) {
 }
 
 function dispatchToGrok(opts, run, writeResult) {
+  // grok cannot be prevented from writing headlessly (the read-only sandbox and
+  // plan mode are advisory), so a --read-only run snapshots the tree up front
+  // and flags a violation in the result instead of pretending to enforce.
+  const beforeTree = opts.autonomy === "read-only" ? gitTouchedFiles(opts.cd) : null;
   const argv = buildArgv(opts, run);
   // shell:true on Windows so the grok.cmd shim resolves (see grokVersion). Safe:
   // the brief is delivered via --prompt-file (never argv), --model/--effort/--session
@@ -431,6 +443,7 @@ function dispatchToGrok(opts, run, writeResult) {
     if (settled) return;
     settled = true;
     const finalMessage = assembleFinal();
+    const touchedFiles = gitTouchedFiles(opts.cd);
     const result = writeResult({
       status: code === 0 ? "completed" : "failed",
       exitCode: code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1),
@@ -438,7 +451,10 @@ function dispatchToGrok(opts, run, writeResult) {
       sessionId,
       finalMessage,
       usage,
-      touchedFiles: gitTouchedFiles(opts.cd),
+      touchedFiles,
+      ...(opts.autonomy === "read-only"
+        ? { readOnlyViolation: beforeTree !== null && touchedFiles !== null && JSON.stringify(beforeTree) !== JSON.stringify(touchedFiles) }
+        : {}),
       ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
     });
     printSummary(result, run.resultPath);
@@ -468,6 +484,7 @@ function printSummary(result, resultPath) {
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  grok ${result.grokVersion ?? "?"}`);
   if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a grok error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.readOnlyViolation) lines.push("warning: this --read-only run modified the working tree — grok's read-only is best-effort; review the diff before trusting the run.");
   lines.push(`autonomy: ${result.autonomy}`);
   if (result.resumeLast) lines.push("mode: resumed most recent session (--continue)");
   else if (result.sessionId && result.status !== "grok_unavailable") {

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -62,7 +62,9 @@
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `grok` binary exits 127;
- * otherwise the exit code mirrors Grok's own (0 success, non-zero failure).
+ * otherwise the exit code mirrors Grok's own (0 success, non-zero failure). If
+ * the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome —
  * completed, failed, or grok_unavailable. An orchestrator that polls for the
  * file must therefore also treat a non-zero exit with no file as a usage error.
@@ -71,7 +73,7 @@
 import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
-import { tmpdir } from "node:os";
+import { constants, tmpdir } from "node:os";
 
 const AUTONOMY_MODES = new Set(["workspace-write", "read-only", "full-access"]);
 
@@ -354,7 +356,7 @@ function makeResultWriter(opts, version, run) {
 }
 
 function reportUnavailable(writeResult, resultPath) {
-  const result = writeResult({ status: "grok_unavailable", exitCode: 127, sessionId: null, finalMessage: "", usage: null, touchedFiles: null });
+  const result = writeResult({ status: "grok_unavailable", exitCode: 127, signal: null, sessionId: null, finalMessage: "", usage: null, touchedFiles: null });
   printSummary(result, resultPath);
   process.stderr.write("relay: `grok` not found on PATH. Install it with `npm i -g @xai-official/grok` and run `grok login`.\n");
   process.exit(127);
@@ -414,6 +416,7 @@ function dispatchToGrok(opts, run, writeResult) {
     const result = writeResult({
       status: "failed",
       exitCode: 1,
+      signal: null,
       sessionId,
       finalMessage: assembleFinal(),
       usage,
@@ -424,13 +427,14 @@ function dispatchToGrok(opts, run, writeResult) {
     process.exit(1);
   });
 
-  child.on("close", (code) => {
+  child.on("close", (code, signal) => {
     if (settled) return;
     settled = true;
     const finalMessage = assembleFinal();
     const result = writeResult({
       status: code === 0 ? "completed" : "failed",
-      exitCode: code === null ? 1 : code,
+      exitCode: code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1),
+      signal: signal ?? null,
       sessionId,
       finalMessage,
       usage,
@@ -462,7 +466,8 @@ function main() {
 function printSummary(result, resultPath) {
   const lines = [];
   lines.push("");
-  lines.push(`relay: ${result.status} (exit ${result.exitCode})  ·  grok ${result.grokVersion ?? "?"}`);
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  grok ${result.grokVersion ?? "?"}`);
+  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a grok error; check host memory and re-dispatch, or split the task into smaller briefs.");
   lines.push(`autonomy: ${result.autonomy}`);
   if (result.resumeLast) lines.push("mode: resumed most recent session (--continue)");
   else if (result.sessionId && result.status !== "grok_unavailable") {

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -124,6 +124,13 @@ function parseArgs(argv) {
   if (opts.resumeLast && opts.session) {
     fail("--resume-last and --session are mutually exclusive");
   }
+  // These values reach a shell on win32 (shell:true for the .cmd shim), so restrict them to safe tokens.
+  const safeToken = /^[A-Za-z0-9][A-Za-z0-9._:\/-]*$/;
+  for (const flag of ["model", "effort", "session"]) {
+    if (opts[flag] !== null && !safeToken.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
   return opts;
 }
 
@@ -139,6 +146,9 @@ function readBrief(opts) {
   if (opts.brief) {
     if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
     return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
   }
   // No --brief: read from stdin (fd 0). Empty stdin is an error.
   let stdin = "";
@@ -340,7 +350,7 @@ function makeResultWriter(opts, version, run) {
 function reportUnavailable(writeResult, resultPath) {
   const result = writeResult({ status: "grok_unavailable", exitCode: 127, sessionId: null, finalMessage: "", usage: null, touchedFiles: null });
   printSummary(result, resultPath);
-  process.stderr.write("relay: `grok` not found on PATH. Install it (curl -fsSL https://x.ai/cli/install.sh | bash, or npm i -g @xai-official/grok) and run `grok login`.\n");
+  process.stderr.write("relay: `grok` not found on PATH. Install it with `npm i -g @xai-official/grok` and run `grok login`.\n");
   process.exit(127);
 }
 
@@ -390,7 +400,10 @@ function dispatchToGrok(opts, run, writeResult) {
     return message;
   };
 
+  let settled = false;
   child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
     const result = writeResult({
       status: "failed",
       exitCode: 1,
@@ -405,6 +418,8 @@ function dispatchToGrok(opts, run, writeResult) {
   });
 
   child.on("close", (code) => {
+    if (settled) return;
+    settled = true;
     const finalMessage = assembleFinal();
     const result = writeResult({
       status: code === 0 ? "completed" : "failed",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a third delegation skill, **`grok-delegate`**, that drives [Grok Build](https://x.ai/cli) (`grok`) in headless mode as the implementer — same loop as `codex-delegate` / `opencode-delegate`: write brief → dispatch via `relay.mjs` → review → land yourself.

## What's included

- `skills/grok-delegate/SKILL.md` — frontmatter + 5-step loop + autonomy model
- `skills/grok-delegate/scripts/relay.mjs` — Node built-ins only; shells out to `grok` + `git`; never commits
- Four references: writing-the-brief, dispatch-and-poll, review-and-land, multi-task-queues
- `skills.sh.json` + README updated (skills list, trust section, repo shape, verification status)

## Autonomy mapping

Grok's default permission mode is `ask` (hangs a headless pipe), so the relay always sets autonomy explicitly:

| Relay flag | Grok flags |
| --- | --- |
| *(default)* | `--always-approve --sandbox workspace` |
| `--read-only` | `--sandbox read-only --permission-mode plan` |
| `--full-access` | `--always-approve --sandbox off` |

## Needs your testing (left intentionally open)

1. **Prompt delivery** — default is `-p <brief>` in argv; `--prompt-stdin` is an experimental alternate (`-p -` + pipe). A/B these on a real `grok` and lock in the winner.
2. **streaming-json event shape** — session id + final-message extractor is tolerant of several plausible field names; tighten against a real event stream.
3. **Authenticated end-to-end run** — relay mechanics are smoke-tested with a stub `grok`; a real beta-gated run is not claimed in Verification status yet.

## Smoke-tested here

- `--help`, empty brief → exit 2, missing `grok` → `grok_unavailable` / 127
- `--session` + `--resume-last` mutual exclusion
- Stub `grok`: argv assembly for default / `--read-only` / `--full-access` / `--resume-last` / `--session` / `--prompt-stdin`
- `npx skills add . --list` lists `grok-delegate`
- Description under 1024 chars

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5d79-dd2c-79be-82bf-3e35a205b44b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5d79-dd2c-79be-82bf-3e35a205b44b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `grok-delegate` skill for delegating bounded coding tasks to Grok.
  * Introduced a Grok headless relay workflow with background execution/polling, session continuation, and structured artifacts (`result.json`, streamed events).
  * Added multi-task queue support with orchestration-friendly verification/landing behavior.

* **Documentation**
  * Updated installation, requirements, feature overview, and repository layout to include `grok-delegate`.
  * Added `grok-delegate` specification and reference guides for brief writing, dispatch/polling, review-and-land verification, and multi-task queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->