### PR TITLE
Add agy-delegate skill for the Google Antigravity CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Two skills ship today: `codex-delegate` (OpenAI Codex) and `opencode-delegate`
-(OpenCode); siblings like `gemini-delegate` can be added later without renaming the repo.
+and land the result. Three skills ship today: `codex-delegate` (OpenAI Codex), `opencode-delegate`
+(OpenCode), and `agy-delegate` (Google Antigravity); siblings like `gemini-delegate` can be added later
+without renaming the repo.
 
 ## Vocabulary
 
@@ -14,7 +15,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the worker agent (Codex, OpenCode) | "worker", "sub-agent", "executor" |
+| **implementer** | the worker agent (Codex, OpenCode, Antigravity) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -22,6 +23,7 @@ jargon. Use these terms; don't invent synonyms.
 | **relay** / `relay.mjs` | the dispatch **script** only | never a *category* of skills |
 | `exec`, `sandbox`, `resume`, `session` | Codex's own terms — use verbatim | don't paraphrase them |
 | `run`, `agent` (`build`/`plan`), `session` | OpenCode's own terms — use verbatim | "sandbox" (OpenCode has no sandbox enum; autonomy is the agent) |
+| `project`, `conversation`, `model`, `permissions`, `sandbox`, `TUI`, `tasks`, `subagents` | Antigravity's own terms — use verbatim when discussing `agy` | don't use `subagents` as a generic synonym for implementer |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -43,18 +45,20 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - **Progressive disclosure:** keep `SKILL.md` lean; push depth into `references/*.md` that load only
   when needed.
 - **Executables:** keep them minimal and inspectable. Today there is one per skill —
-  `skills/codex-delegate/scripts/relay.mjs` and `skills/opencode-delegate/scripts/relay.mjs` — each
-  Node built-ins only, no dependencies, no network calls of its own, no credentials, no telemetry. New
-  scripts must hold the same line, and the README's trust section must stay accurate.
+  `skills/codex-delegate/scripts/relay.mjs`, `skills/opencode-delegate/scripts/relay.mjs`, and
+  `skills/agy-delegate/scripts/relay.mjs` — each Node built-ins only, no dependencies, no network calls
+  of its own, no credentials, no telemetry. New scripts must hold the same line, and the README's trust
+  section must stay accurate.
 
 ## Before publishing a change
 
 - Validate the package locally: `npx skills add . --list`.
 - Smoke-test any changed script directly (e.g. `node skills/<skill>/scripts/relay.mjs --help`, and a
-  `--read-only` run against a throwaway repo) before relying on it.
+  no-write or read-only run against a throwaway repo) before relying on it.
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
   PowerShell/cmd, not just Git Bash/WSL): both the `codex` and `opencode` launches need `shell:true` on
-  win32 to resolve the `.cmd` shim.
+  win32 to resolve the `.cmd` shim; `agy` is documented as a native binary, but still needs its own
+  Windows smoke before claiming support.
 - Keep the README's "Verification status" honest — claim only what's been run.
 
 ## Local Claude Code config

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, hands it to an implementer CLI, then reviews the diff and
 commits — staying the reviewer the whole way.
 
-Two skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, and **`opencode-delegate`**
-drives the OpenCode CLI. Same loop, different implementer.
+Three skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, **`opencode-delegate`**
+drives the OpenCode CLI, and **`agy-delegate`** drives the Google Antigravity CLI. Same loop, different
+implementer.
 
 ## Install
 
@@ -23,6 +24,7 @@ Install the package, or just one skill:
 npx skills add amElnagdy/delegate-skills
 npx skills add amElnagdy/delegate-skills --skill codex-delegate
 npx skills add amElnagdy/delegate-skills --skill opencode-delegate
+npx skills add amElnagdy/delegate-skills --skill agy-delegate
 ```
 
 Install for a specific agent, or globally:
@@ -47,6 +49,7 @@ The loop:
 ```text
 Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
 Use $codex-delegate to run this queue of migration tasks through Codex while I review each one.
+Use $agy-delegate to have Antigravity implement the UI cleanup, then review and commit it.
 ```
 
 ## How this differs from the OpenAI Codex plugin
@@ -89,6 +92,16 @@ quoting.
 **You'll feel it when:** a bounded task gets handed to OpenCode, comes back as a clean diff with a
 structured report and the run's cost, and you commit it after re-running the gates yourself.
 
+### agy-delegate
+
+Drive the Google Antigravity CLI (`agy`) as a background implementer: write the brief, dispatch via
+`relay.mjs`, review the diff, commit it yourself. Same four references and loop as the other delegate
+skills. Fresh runs start a new Antigravity project and explicitly add the target repo as the workspace;
+Antigravity's permission bypass is opt-in, not the default.
+
+**You'll feel it when:** a bounded task gets handed to Antigravity, comes back as a clean diff with a
+structured report and a conversation id, and you commit it after re-running the gates yourself.
+
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
@@ -100,6 +113,8 @@ Reserved so the umbrella can grow without a rename.
   (`codex login`).
 - For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai) installed and authenticated
   (`opencode auth login`).
+- For `agy-delegate`: the [`agy` CLI](https://antigravity.google/docs/cli/getting-started) installed
+  and authenticated through Antigravity's first-launch setup.
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -111,16 +126,20 @@ This package is intentionally inspectable:
 - All skill content is Markdown, plus exactly **one** executable per skill — each a `scripts/relay.mjs`.
 - Each `relay.mjs` makes no network calls, reads or writes no credentials, sends no telemetry, and has
   no dependencies (Node built-ins only). It shells out only to its implementer CLI (`codex` /
-  `opencode`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the script
-  before you run it.
-- Neither ever commits — committing is always the orchestrator's job, after review.
+  `opencode` / `agy`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the
+  script before you run it.
+- None of the relays ever commit — committing is always the orchestrator's job, after review.
 
 **Verification status:** each relay's mechanics are verified — argument handling, exit codes,
-`result.json`, resume, and (for `opencode-delegate`) the required-model guard, since OpenCode has no safe
-default. The full delegate → review → commit loop is designed for and run on Claude Code but not yet
-formally verified end-to-end here (OpenCode's cold start is slow in constrained shells, so exercise a
-real run in a normal terminal). Other orchestrators (Cursor, …) are designed-for but unproven. This line
-gets upgraded to "verified end-to-end" with evidence, not assumption.
+`result.json`, resume, and implementer-specific guards. `opencode-delegate` requires `--model`, since
+OpenCode has no safe default. `agy-delegate` is verified end-to-end on macOS against `agy` 1.0.16: a
+headless `agy --print` run edits the working tree, the brief is delivered via `--print=` (never split
+across argv), the workspace is pinned with an absolute `--add-dir`, and `result.json` carries the
+conversation id and touched files; the pre-run brief-size guard and the resume/project
+mutual-exclusion guards are exercised. Windows launch is pending a native PowerShell/cmd smoke. The full delegate → review → commit loop is designed
+for and run on Claude Code but not yet formally verified end-to-end here. Other orchestrators (Cursor,
+…) are designed-for but unproven. This line gets upgraded to "verified end-to-end" with evidence, not
+assumption.
 
 ## Repository shape
 
@@ -134,7 +153,15 @@ skills/
 │       ├── dispatch-and-poll.md
 │       ├── review-and-land.md
 │       └── multi-task-queues.md
-└── opencode-delegate/
+├── opencode-delegate/
+│   ├── SKILL.md
+│   ├── scripts/relay.mjs
+│   └── references/
+│       ├── writing-the-brief.md
+│       ├── dispatch-and-poll.md
+│       ├── review-and-land.md
+│       └── multi-task-queues.md
+└── agy-delegate/
     ├── SKILL.md
     ├── scripts/relay.mjs
     └── references/

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -6,7 +6,8 @@
       "description": "Delegate a coding task to a CLI implementer agent, then review the diff and commit it yourself.",
       "skills": [
         "codex-delegate",
-        "opencode-delegate"
+        "opencode-delegate",
+        "agy-delegate"
       ]
     }
   ]

--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: agy-delegate
+description: >-
+  Delegate a coding task to the Google Antigravity CLI (`agy`) as a background implementer, then review
+  its diff and land it yourself. Use this whenever the user wants to hand implementation work to
+  Antigravity or agy - phrasings like "have Antigravity do X", "delegate this to agy", "run it through
+  agy", or "use Antigravity to implement/fix/refactor" - or wants to run a queue of coding tasks
+  through agy while staying the reviewer. DO NOT USE for tasks small enough to do inline, or when the
+  user wants the code written directly without delegating.
+license: MIT
+compatibility: Requires the `agy` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows). Windows launch is not yet verified for this relay.
+metadata:
+  version: 0.1.0
+---
+
+# Antigravity Delegate
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** - the Google Antigravity CLI (`agy`) - then review what it produced and land it
+yourself. You write the brief and own the judgment; Antigravity does the typing in its own
+conversation; you verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so any comparable agent can drive it. It is designed for and run on Claude
+Code; treat other orchestrators as designed-for, not yet proven.
+
+## When NOT to use this
+
+- The task is small enough to just do inline - delegation overhead is not worth it.
+- The `agy` CLI is not installed or not authenticated. Install it from Antigravity's CLI docs and run
+  the first-launch setup.
+- You want to write the code yourself, or you only need a review without edits. This relay does not
+  expose a proven CLI-enforced read-only mode yet.
+
+## Prerequisites (check once)
+
+1. `agy help` succeeds. If not, install the Antigravity CLI and complete first-launch setup.
+2. `agy models` succeeds. That proves the CLI can authenticate and list the available model labels.
+3. You are in (or will point `--cd` at) the target git repository.
+
+## Choose the implementer model
+
+`agy` has a configured default model, so `--model` is optional. Use it when the human has a preferred
+Antigravity model label for the task. Otherwise let Antigravity use its own current default rather than
+guessing.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Antigravity sees only the text you send plus what it can inspect in the workspace - no chat history, no
+shared context. Everything the task needs goes in the brief: the goal, the current state, what to
+change, what to leave untouched, the project's **actual** gate commands, and a report contract. Tell
+Antigravity it will **not** commit (you will). Keep one task per brief. Full guidance and a template:
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to Antigravity with the bundled helper. It wraps `agy --print`, captures the run, and
+writes a structured `result.json` - so your only job is "run a command, read a file." (`<skill-dir>`
+below is this skill's installed directory - the folder containing this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model label:                 add --model "<label from agy models>"
+# enable Antigravity terminal sandbox:  add --sandbox
+# resume the most recent conversation:  add --resume-last  (delta brief only)
+# see all options:                      node .../relay.mjs --help
+```
+
+The helper starts a fresh Antigravity project by default and passes `--add-dir <repo>` (the `--cd`
+path, absolute) so `agy` has an explicit workspace. It does **not** pass `--dangerously-skip-permissions` by default.
+Mechanics, flags, and the `result.json` shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Antigravity finishes, so back it with whatever your orchestrator offers and
+resume when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file.
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line.
+
+### 4. Review - do not trust the self-report
+
+Antigravity's `result.json` includes its own final message and any gate claims. **Re-verify, don't
+accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1).
+- **Read the diff** against the brief: did Antigravity do what was asked, nothing more and nothing less?
+  `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Only after the gates pass and the
+diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--resume-last` and review again.
+
+## Permission model
+
+Antigravity owns its own permission policy. The relay does not bypass it by default. Use
+`--dangerously-skip-permissions` only when the human explicitly accepts that Antigravity may
+auto-approve tool permission requests. Use `--sandbox` when you want Antigravity's terminal sandbox
+enabled for the run.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits on that mandate: **surface, don't
+absorb** (report Antigravity's design decisions, defensible-but-unasked turns, and non-blocking
+nitpicks rather than silently keeping them) and **stop for scope changes** (if correct completion needs
+going beyond the brief, ask - don't expand the mandate yourself). The full treatment is in
+[references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - how to write a brief Antigravity
+  can execute blind: structure, XML blocks, the report contract, and real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) - the review checklist, the commit
+  boundary, and the rework cycle via `--resume-last`.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.

--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -112,7 +112,9 @@ diff holds:
 Antigravity owns its own permission policy. The relay does not bypass it by default. Use
 `--dangerously-skip-permissions` only when the human explicitly accepts that Antigravity may
 auto-approve tool permission requests. Use `--sandbox` when you want Antigravity's terminal sandbox
-enabled for the run.
+enabled for the run. Antigravity's own help says `--dangerously-skip-permissions` auto-approves all
+tool permission requests without prompting, including a request to act outside the sandbox. Do not
+treat `--sandbox` as an enforced boundary when the flags are combined; treat the run as full access.
 
 ## Authorization model
 

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -37,7 +37,7 @@ Options:
 | `--sandbox` | Enable Antigravity's terminal sandbox for the run. |
 | `--dangerously-skip-permissions` | Pass Antigravity's permission-bypass flag. Never use this unless the human explicitly accepts it. |
 | `--print-timeout <duration>` | Timeout for print mode (default: `30m`). |
-| `--add-dir <dir>` | Add an extra workspace directory. Repeatable. Fresh runs always add the `--cd` repo (absolute path) as a workspace dir. |
+| `--add-dir <dir>` | Add an extra workspace directory. Repeatable; relative paths resolve against `--cd`. Fresh runs always add the `--cd` repo (absolute path) as a workspace dir. Edits inside extra workspaces are not reported in `touchedFiles`. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
 
 Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
@@ -50,7 +50,8 @@ touched-files report shows only Antigravity's edits and nothing of the helper's 
 - `schema` - the result-format version (currently `delegate-relay.result.v1`)
 - `tool` - `agy`
 - `status` - `completed` | `failed` | `agy_unavailable`
-- `exitCode` - mirrors Antigravity's exit code; `127` if `agy` is not on PATH
+- `exitCode` - mirrors Antigravity's exit code; `128` plus the signal number if the child was killed; `127` if `agy` is not on PATH
+- `signal` - the signal that killed the child, otherwise `null`
 - `agyVersion` - inferred from `agy changelog` when available
 - `projectId` / `conversationId` - parsed from the Antigravity log when present
 - `finalMessage` - Antigravity's stdout response
@@ -85,6 +86,9 @@ process has exited and `result.json` is written.
 
 - **`status: agy_unavailable` (exit 127):** `agy` is not on PATH. Install the Antigravity CLI and run
   its first-launch setup, then re-dispatch.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child - commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
 - **`status: failed`:** read `result.json`'s `stderrTail`, `stderrPath`, and `logPath` for the cause.
   Common causes: auth lapse, an unknown model label, timeout, or a permission the run needed.
 - **A run stalls on permissions:** either configure Antigravity permissions for the actions the task

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,117 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `agy --print`, runs the brief in Antigravity,
+captures the final response, and writes a structured `result.json`. Your job collapses to: run one
+command, then read one file.
+
+## Before the first run: check the binary
+
+```bash
+command -v agy
+agy help
+agy models
+```
+
+`agy models` proves the CLI can authenticate and list available model labels. The relay records the
+version it can infer from `agy changelog` into `result.json`.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed - the folder containing its `SKILL.md`.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin before passing it to `agy --print`. |
+| `--cd <dir>` | Working root for Antigravity (default: current directory). |
+| `--model <name>` | Antigravity model label. Optional; a fresh run can use Antigravity's configured default. |
+| `--project <id>` | Use an existing Antigravity project. |
+| `--new-project` | Force a fresh Antigravity project. This is the default for fresh dispatches. |
+| `--resume-last` | Continue the most recent Antigravity conversation; send only the delta brief. |
+| `--conversation <id>` | Continue a specific Antigravity conversation; send only the delta brief. |
+| `--sandbox` | Enable Antigravity's terminal sandbox for the run. |
+| `--dangerously-skip-permissions` | Pass Antigravity's permission-bypass flag. Never use this unless the human explicitly accepts it. |
+| `--print-timeout <duration>` | Timeout for print mode (default: `30m`). |
+| `--add-dir <dir>` | Add an extra workspace directory. Repeatable. Fresh runs always add the `--cd` repo (absolute path) as a workspace dir. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only Antigravity's edits and nothing of the helper's own.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` - the result-format version (currently `delegate-relay.result.v1`)
+- `tool` - `agy`
+- `status` - `completed` | `failed` | `agy_unavailable`
+- `exitCode` - mirrors Antigravity's exit code; `127` if `agy` is not on PATH
+- `agyVersion` - inferred from `agy changelog` when available
+- `projectId` / `conversationId` - parsed from the Antigravity log when present
+- `finalMessage` - Antigravity's stdout response
+- `touchedFiles` - `git status --porcelain` lines in the working root: your review starting point.
+  `null` (not `[]`) when git cannot report; `[]` means git ran and the tree is clean
+- `briefPath` / `finalPath` / `logPath` / `stderrPath` - the exact brief, final message, Antigravity
+  log, and stderr capture
+- `workdir`, `model`, `project` (the `--project` you passed, vs `projectId` parsed from the log),
+  `sandbox`, `dangerouslySkipPermissions`, `resumed` (true for a `--resume-last` or `--conversation`
+  run), `startedAt`, `finishedAt`
+- `stderrTail` - last ~20 stderr lines; present only on a failed run
+- `error` - present only if Antigravity failed to launch
+
+The helper also prints a summary to stdout and exits with Antigravity's exit code, so a wrapping script
+can branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until Antigravity finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll. A run is done
+  when `result.json` exists with a `status`. A pre-run usage error exits with code 2 before writing any
+  file, so check the exit code too. A missing `agy` binary exits 127 and writes `result.json` with
+  `status: agy_unavailable`.
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written.
+
+## When a run misbehaves
+
+- **`status: agy_unavailable` (exit 127):** `agy` is not on PATH. Install the Antigravity CLI and run
+  its first-launch setup, then re-dispatch.
+- **`status: failed`:** read `result.json`'s `stderrTail`, `stderrPath`, and `logPath` for the cause.
+  Common causes: auth lapse, an unknown model label, timeout, or a permission the run needed.
+- **A run stalls on permissions:** either configure Antigravity permissions for the actions the task
+  needs, or ask the human whether to re-run with `--dangerously-skip-permissions`. Pair risky runs with
+  `--sandbox` when terminal restrictions are appropriate.
+- **Empty `finalMessage`:** Antigravity finished without emitting a closing text summary. The edits may
+  still be correct - check `touchedFiles` and the diff. To get a report next time, add a
+  `<structured_output_contract>` block (see [writing-the-brief.md](writing-the-brief.md)).
+
+## What the helper is doing
+
+Under the hood the helper runs roughly:
+
+```bash
+agy --new-project --add-dir <repo> --print-timeout 30m --print=<brief>
+agy --continue --print-timeout 30m --print=<delta brief>
+agy --conversation <id> --print-timeout 30m --print=<delta brief>
+```
+
+`agy --print` requires the prompt as a flag argument, so keep briefs focused. The relay still accepts
+stdin or `--brief <file>` for your convenience; it reads the text first, then passes it to `agy` as
+`--print=<brief>` (the `=` form so a brief that begins with a bare flag like `--help` still runs).
+Two consequences of the brief riding the command line: it is visible in the host process list (`ps`),
+so on a shared machine keep secrets out of it; and a brief over ~120 KB is rejected up front (the OS
+caps a single argument), so have `agy` read large context from the workspace instead of inlining it.
+
+## The commit boundary
+
+The helper never commits - by design, not omission. The robust contract is: Antigravity edits the
+working tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/agy-delegate/references/multi-task-queues.md
+++ b/skills/agy-delegate/references/multi-task-queues.md
@@ -1,0 +1,59 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that is where delegation pays off most - a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each (review + gates + commit) before
+dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential.
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan did not have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, fold it into that
+task's brief as an explicit line. A fresh Antigravity conversation has no memory of the earlier run, so
+a constraint that emerged in task 2 must be restated in task 5's brief or it will not hold.
+
+## Keep a progress file
+
+For anything longer than two or three tasks - especially a run the human steps away from - maintain a
+single progress file alongside the work:
+
+- **Status table** - each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** - what landed, what you verified, the gate outcome.
+- **Needs your eyes** - design decisions Antigravity made, non-blocking nitpicks, anything you want the
+  human to overrule or confirm.
+- **End-of-run checklist** - what happens after the last task.
+
+Update it as each task lands, not in a batch at the end.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it does not prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree.
+- Do a repo-wide check for the thing the queue was about.
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief's scope.
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already done.
+
+Then report where you are, what is committed, and what the open question is - and wait.

--- a/skills/agy-delegate/references/review-and-land.md
+++ b/skills/agy-delegate/references/review-and-land.md
@@ -1,0 +1,92 @@
+# Review and land
+
+Antigravity did the typing; you own the judgment. Verify against reality, never against the self-report
+- and read the diff as generated code, which fails in ways a green gate cannot see.
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* - before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** Flag them, don't
+  absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as
+  failing until proven otherwise.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened,
+  tolerance widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries Antigravity's own claims. Treat them as claims, not evidence - re-run the
+project's actual test/lint/build commands in the working tree and read the output. Passing is necessary,
+not sufficient.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them and check for drift.
+- **Removals / renames:** grep the codebase for dangling references.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Scope creep** - did Antigravity change things the brief said to leave untouched?
+- **Scope shortfall** - did it do the whole task, including edge cases and cleanup?
+- **Quiet judgment calls** - did it make a defensible but unasked decision you need to understand?
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to. Walk these against every
+diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work.
+- **Catch-all error handling that returns a default** instead of propagating or recovering explicitly.
+- **Unverified imports and API calls** - confirm new dependencies, methods, and signatures exist in the
+  installed version.
+- **Dead weight** - unused imports, helpers nothing calls, unreachable branches, scaffolding comments.
+- **A second way to do what the file already does** - new client, error idiom, or logging style beside
+  an existing one.
+- **New tests that assert internals** instead of behavior.
+- **Near-duplicate test bodies** differing by one value.
+- **Speculative surface** - optional parameters, config flags, or abstractions with no caller.
+- **Guards for impossible cases** that bury validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to Antigravity as a delta brief or gets fixed in the tree before
+commit - and either way is reported to the user.
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** - the orchestrator, never the implementer. Write
+a clear message describing what landed. If your project attributes co-authorship, that is the place for
+it.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same Antigravity
+conversation with just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+`--resume-last` keeps Antigravity's conversation context from the first run, so a short delta is enough.
+Then review again - rework gets the same gate-rerun, test check, diff-read, and sweep as the original,
+no shortcuts.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract. But
+keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** Antigravity made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past - see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/agy-delegate/references/writing-the-brief.md
+++ b/skills/agy-delegate/references/writing-the-brief.md
@@ -1,0 +1,115 @@
+# Writing the brief
+
+A brief is the entire task as Antigravity will see it. It runs in a separate conversation with **no
+memory of your conversation, no access to your prior notes, and no shared context** - only the text you
+send and whatever it can inspect in the workspace. If a constraint is not in the brief or discoverable
+in the repo, it does not exist for Antigravity.
+
+## Model choice
+
+`agy` has a configured default model, so a fresh dispatch does not require `--model`. Pass `--model`
+only when the human has named a preferred Antigravity model label for this task. `agy models` shows the
+available labels.
+
+A resumed run keeps the conversation context. Send only the delta brief.
+
+## The shape that works
+
+Antigravity responds well to compact, block-structured prompts with XML tags rather than long prose.
+State the task, what "done" looks like, how to behave by default, and the few constraints that actually
+matter. Add a block only when the task needs it.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps Antigravity
+from wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for extra blocks when the task profile
+calls for them:
+
+- **Debugging / open-ended fixes** - add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Research / recommendations** - add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Always ask for the report explicitly
+
+The relay captures `agy --print` stdout as `finalMessage`. If Antigravity finishes without a closing
+summary, the result is not useful to review. The `<structured_output_contract>` block is what guarantees
+a report you can read.
+
+## Discover the real gates
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you an implementer that guesses - or skips.
+
+## Honor the repo's conventions
+
+If the project has house rules in `AGENTS.md`, `CLAUDE.md`, or a similar file, restate the load-bearing
+ones in the brief. Antigravity can inspect the workspace, but compliance is more reliable when the
+important rules are directly in front of it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and suggest
+a roadmap" produces a muddled run; split it into separate dispatches. One brief -> one Antigravity run
+-> one commit keeps review and rollback clean.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -56,6 +56,8 @@
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `agy` binary exits 127;
  * otherwise the exit code mirrors Antigravity's own (0 success, non-zero failure).
+ * If the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome -
  * completed, failed, or agy_unavailable. An orchestrator that polls for the
  * file must therefore also treat a non-zero exit with no file as a usage error.
@@ -64,7 +66,7 @@
 import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
-import { tmpdir } from "node:os";
+import { constants, tmpdir } from "node:os";
 
 const DEFAULT_PRINT_TIMEOUT = "30m";
 
@@ -112,7 +114,7 @@ function parseArgs(argv) {
       case "--sandbox": opts.sandbox = true; break;
       case "--dangerously-skip-permissions": opts.dangerouslySkipPermissions = true; break;
       case "--print-timeout": opts.printTimeout = next(); break;
-      case "--add-dir": opts.addDirs.push(resolve(next())); break;
+      case "--add-dir": opts.addDirs.push(next()); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
         fail(`unknown option: ${arg}`);
@@ -130,6 +132,10 @@ function parseArgs(argv) {
   if (opts.newProject && (opts.resumeLast || opts.conversation)) {
     fail("--new-project cannot be combined with --resume-last or --conversation");
   }
+  // agy requires absolute --add-dir paths; resolve a relative one against --cd
+  // (not the relay's own cwd) - and only after the loop, since --add-dir may
+  // appear before --cd on the command line. resolve() passes absolutes through.
+  opts.addDirs = opts.addDirs.map((dir) => resolve(opts.cd, dir));
   return opts;
 }
 
@@ -303,7 +309,7 @@ function makeResultWriter(opts, version, run) {
 }
 
 function reportUnavailable(writeResult, resultPath) {
-  const result = writeResult({ status: "agy_unavailable", exitCode: 127, finalMessage: "", touchedFiles: null });
+  const result = writeResult({ status: "agy_unavailable", exitCode: 127, signal: null, finalMessage: "", touchedFiles: null });
   printSummary(result, resultPath);
   process.stderr.write("relay: `agy` not found on PATH. Install the Antigravity CLI and complete first-launch setup.\n");
   process.exit(127);
@@ -361,6 +367,7 @@ function dispatchToAgy(opts, brief, run, writeResult) {
     const result = writeResult({
       status: "failed",
       exitCode: 1,
+      signal: null,
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
       error: String(err && err.message ? err.message : err),
@@ -369,19 +376,24 @@ function dispatchToAgy(opts, brief, run, writeResult) {
     process.exit(1);
   });
 
-  child.on("close", (code) => {
+  child.on("close", (code, signal) => {
     if (settled) return;
     settled = true;
     clearTimeout(watchdogTimer);
     if (sigkillTimer) clearTimeout(sigkillTimer);
     const finalMessage = stdout.trim();
     if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
+    // A timed-out run is failed even if agy handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const result = writeResult({
-      status: code === 0 ? "completed" : "failed",
-      exitCode: code === null ? 1 : code,
+      status: succeeded ? "completed" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
-      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `agy did not exit within --print-timeout ${opts.printTimeout} plus 60s grace; killed by the relay watchdog` } : {}),
     });
     printSummary(result, run.resultPath);
@@ -418,7 +430,8 @@ function main() {
 function printSummary(result, resultPath) {
   const lines = [];
   lines.push("");
-  lines.push(`relay: ${result.status} (exit ${result.exitCode})  ·  agy ${result.agyVersion ?? "?"}`);
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  agy ${result.agyVersion ?? "?"}`);
+  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an agy error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.resumed) lines.push("mode: resumed an existing conversation");
   if (result.projectId) lines.push(`project id: ${result.projectId}`);
   if (result.conversationId) lines.push(`conversation id (resume with: --conversation ${result.conversationId}): ${result.conversationId}`);

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -67,6 +67,7 @@ import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_PRINT_TIMEOUT = "30m";
 
@@ -343,14 +344,19 @@ function dispatchToAgy(opts, brief, run, writeResult) {
     }, 10_000);
   }, timeoutMs + 60_000);
 
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
   child.stdout.on("data", (chunk) => {
-    stdout += chunk.toString();
+    stdout += stdoutDecoder.write(chunk);
   });
 
   child.stderr.on("data", (chunk) => {
-    const text = chunk.toString();
-    process.stderr.write(text);
-    appendFileSync(run.stderrPath, text, "utf8");
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
     for (const line of text.split("\n")) {
       if (line.trim()) stderrTail.push(line.trimEnd());
     }

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -1,0 +1,404 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · agy-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Google Antigravity CLI (`agy --print`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON -
+ * every Antigravity-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against agy CLI 1.0.16 on macOS.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `agy` and `git`. The `agy` process it launches
+ * does authenticate - exactly as you do at the terminal. Read this file before
+ * you run it.
+ *
+ * Note: `agy --print` takes the prompt as a command-line argument, so the brief is
+ * visible in the host process list (`ps`, /proc). On a shared machine keep secrets
+ * out of the brief - reference them by a path or env var the workspace can read.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job -
+ * after it reviews the diff and re-runs the project gates.
+ *
+ * Antigravity owns its own permission policy. This helper does not pass
+ * --dangerously-skip-permissions by default; opt into that flag only when the
+ * human explicitly accepts it. Pass --sandbox to enable Antigravity's terminal
+ * sandbox for the run.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for Antigravity (default: current directory).
+ *   --model <name>          Antigravity model label (default: agy's configured default).
+ *   --project <id>          Use an existing Antigravity project.
+ *   --new-project           Force a fresh Antigravity project (default for fresh runs).
+ *   --resume-last           Continue the most recent Antigravity conversation; send only the delta brief.
+ *   --conversation <id>     Continue a specific Antigravity conversation; send only the delta brief.
+ *   --sandbox               Enable Antigravity's terminal sandbox for this run.
+ *   --dangerously-skip-permissions
+ *                           Auto-approve Antigravity tool permission requests. Use only with human approval.
+ *   --print-timeout <dur>   Timeout for print mode (default: 30m).
+ *   --add-dir <dir>         Add an extra workspace directory. Repeatable.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout -
+ *   status, exitCode, agyVersion, projectId, conversationId, finalMessage
+ *   (Antigravity's own report), touchedFiles (git porcelain, null if git can't report), and the
+ *   paths to brief.txt, final.txt, agy.log, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `agy` binary exits 127;
+ * otherwise the exit code mirrors Antigravity's own (0 success, non-zero failure).
+ * Once the brief validates, `result.json` is written on every outcome -
+ * completed, failed, or agy_unavailable. An orchestrator that polls for the
+ * file must therefore also treat a non-zero exit with no file as a usage error.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { tmpdir } from "node:os";
+
+const DEFAULT_PRINT_TIMEOUT = "30m";
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    project: null,
+    newProject: false,
+    resumeLast: false,
+    conversation: null,
+    sandbox: false,
+    dangerouslySkipPermissions: false,
+    printTimeout: DEFAULT_PRINT_TIMEOUT,
+    addDirs: [],
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--project": opts.project = next(); break;
+      case "--new-project": opts.newProject = true; break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--conversation": opts.conversation = next(); break;
+      case "--sandbox": opts.sandbox = true; break;
+      case "--dangerously-skip-permissions": opts.dangerouslySkipPermissions = true; break;
+      case "--print-timeout": opts.printTimeout = next(); break;
+      case "--add-dir": opts.addDirs.push(resolve(next())); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  if (opts.resumeLast && opts.conversation) {
+    fail("--resume-last and --conversation are mutually exclusive; pass only one");
+  }
+  if (opts.project && (opts.resumeLast || opts.conversation)) {
+    fail("--project cannot be combined with --resume-last or --conversation");
+  }
+  if (opts.project && opts.newProject) {
+    fail("--project and --new-project are mutually exclusive");
+  }
+  if (opts.newProject && (opts.resumeLast || opts.conversation)) {
+    fail("--new-project cannot be combined with --resume-last or --conversation");
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to agy --print\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function agyVersion() {
+  try {
+    const out = execFileSync("agy", ["changelog"], { encoding: "utf8" }).trim();
+    const firstLine = out.split("\n").find(Boolean) || "";
+    const match = firstLine.match(/^([^:\s]+):/);
+    return match ? match[1] : firstLine || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git can't report - git missing, or a non-repo run - so the
+  // caller can tell "git unavailable" apart from "Antigravity changed nothing."
+  // [] means git ran and the working tree is clean.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    logPath: join(outDir, "agy.log"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function buildArgv(opts, brief, run) {
+  const argv = [];
+  if (opts.project) {
+    argv.push("--project", opts.project);
+  } else if (opts.conversation) {
+    argv.push("--conversation", opts.conversation);
+  } else if (opts.resumeLast) {
+    argv.push("--continue");
+  } else {
+    argv.push("--new-project");
+  }
+
+  if (!opts.resumeLast && !opts.conversation) {
+    // The disposable smoke showed that relying on cwd alone can produce a false
+    // "I created the file" response, so pin the workspace explicitly. agy requires
+    // an absolute path here (it rejects "." as non-absolute); opts.cd is already
+    // resolve()d, and an argv-array element carries spaces fine without a shell.
+    argv.push("--add-dir", opts.cd);
+    for (const dir of opts.addDirs) argv.push("--add-dir", dir);
+  }
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.sandbox) argv.push("--sandbox");
+  if (opts.dangerouslySkipPermissions) argv.push("--dangerously-skip-permissions");
+  if (opts.printTimeout) argv.push("--print-timeout", opts.printTimeout);
+  argv.push("--log-file", run.logPath);
+  // Use the --print=<brief> form, not a separate ["--print", brief] pair: agy's flag
+  // parser intercepts a value that is exactly a bare flag (a brief consisting only of
+  // "--help" or "-h" prints usage instead of running). The = form always binds the value.
+  argv.push(`--print=${brief}`);
+  return argv;
+}
+
+function parseIdsFromLog(logPath) {
+  if (!existsSync(logPath)) return { projectId: null, conversationId: null };
+  const text = readFileSync(logPath, "utf8");
+  const projectMatches = [
+    /project: created project "[^"]*" \(id=([0-9a-f-]+)\)/i,
+    /Conversation using project ID: ([0-9a-f-]+)/i,
+    /Backend project ID updated dynamically to: ([0-9a-f-]+)/i,
+  ];
+  const conversationMatches = [
+    /Print mode: conversation=([0-9a-f-]+)/i,
+    /Created conversation ([0-9a-f-]+)/i,
+  ];
+  const firstMatch = (patterns) => {
+    for (const pattern of patterns) {
+      const match = text.match(pattern);
+      if (match) return match[1];
+    }
+    return null;
+  };
+  return {
+    projectId: firstMatch(projectMatches),
+    conversationId: firstMatch(conversationMatches),
+  };
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const ids = parseIdsFromLog(run.logPath);
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "agy",
+      workdir: opts.cd,
+      model: opts.model,
+      project: opts.project,
+      sandbox: opts.sandbox,
+      dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
+      resumed: Boolean(opts.resumeLast || opts.conversation),
+      agyVersion: version,
+      projectId: ids.projectId,
+      conversationId: ids.conversationId,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      logPath: existsSync(run.logPath) ? run.logPath : null,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "agy_unavailable", exitCode: 127, finalMessage: "", touchedFiles: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `agy` not found on PATH. Install the Antigravity CLI and complete first-launch setup.\n");
+  process.exit(127);
+}
+
+function dispatchToAgy(opts, brief, run, writeResult) {
+  const argv = buildArgv(opts, brief, run);
+  // Antigravity's installer provides a native `agy` binary. Launch directly so
+  // multi-line briefs and paths with spaces are passed as argv, not shell text.
+  const child = spawn("agy", argv, {
+    cwd: opts.cd,
+    env: { ...process.env, PWD: opts.cd },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  const stderrTail = [];
+
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString();
+  });
+
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    process.stderr.write(text);
+    appendFileSync(run.stderrPath, text, "utf8");
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  child.on("error", (err) => {
+    const finalMessage = stdout.trim();
+    if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code) => {
+    const finalMessage = stdout.trim();
+    if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
+    const result = writeResult({
+      status: code === 0 ? "completed" : "failed",
+      exitCode: code === null ? 1 : code,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // agy --print takes the prompt as a CLI argument, so the brief rides argv. The OS caps a
+  // single argument (~128KB on Linux via MAX_ARG_STRLEN), so a huge brief would fail to spawn
+  // with an opaque E2BIG. Reject it early with a clear message instead of a generic failure.
+  const briefBytes = Buffer.byteLength(brief, "utf8");
+  const MAX_BRIEF_BYTES = 120 * 1024;
+  if (briefBytes > MAX_BRIEF_BYTES) {
+    fail(`brief is ${Math.round(briefBytes / 1024)}KB; agy passes the prompt as a CLI argument, which the OS caps (~128KB on Linux). Trim it, or have agy read large context from the workspace instead of inlining it.`);
+  }
+
+  const version = agyVersion();
+  const run = prepareRunDir(opts, brief);
+  const writeResult = makeResultWriter(opts, version, run);
+
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+
+  dispatchToAgy(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode})  ·  agy ${result.agyVersion ?? "?"}`);
+  if (result.resumed) lines.push("mode: resumed an existing conversation");
+  if (result.projectId) lines.push(`project id: ${result.projectId}`);
+  if (result.conversationId) lines.push(`conversation id (resume with: --conversation ${result.conversationId}): ${result.conversationId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- agy final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -24,7 +24,8 @@
  * Antigravity owns its own permission policy. This helper does not pass
  * --dangerously-skip-permissions by default; opt into that flag only when the
  * human explicitly accepts it. Pass --sandbox to enable Antigravity's terminal
- * sandbox for the run.
+ * sandbox for the run. Combining both flags must be treated as full access because
+ * permission requests to act outside the sandbox may be auto-approved.
  *
  * Usage:
  *   node relay.mjs --brief <file> [options]
@@ -145,6 +146,9 @@ function readBrief(opts) {
     if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
     return readFileSync(opts.brief, "utf8");
   }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
   let stdin = "";
   try {
     stdin = readFileSync(0, "utf8");
@@ -160,9 +164,24 @@ function agyVersion() {
     const firstLine = out.split("\n").find(Boolean) || "";
     const match = firstLine.match(/^([^:\s]+):/);
     return match ? match[1] : firstLine || null;
-  } catch {
-    return null;
+  } catch (err) {
+    // Only a missing binary means "unavailable"; any other changelog failure
+    // (permissions, a broken subcommand) must not masquerade as exit 127.
+    if (err && err.code === "ENOENT") return null;
+    return "unknown";
   }
+}
+
+function parseDuration(duration) {
+  let milliseconds = 0;
+  let matched = false;
+  for (const match of duration.matchAll(/(\d+)h|(\d+)m|(\d+)s/g)) {
+    matched = true;
+    if (match[1]) milliseconds += Number(match[1]) * 60 * 60 * 1000;
+    if (match[2]) milliseconds += Number(match[2]) * 60 * 1000;
+    if (match[3]) milliseconds += Number(match[3]) * 1000;
+  }
+  return matched ? milliseconds : null;
 }
 
 function gitTouchedFiles(cwd) {
@@ -292,6 +311,7 @@ function reportUnavailable(writeResult, resultPath) {
 
 function dispatchToAgy(opts, brief, run, writeResult) {
   const argv = buildArgv(opts, brief, run);
+  const timeoutMs = parseDuration(opts.printTimeout) ?? parseDuration(DEFAULT_PRINT_TIMEOUT);
   // Antigravity's installer provides a native `agy` binary. Launch directly so
   // multi-line briefs and paths with spaces are passed as argv, not shell text.
   const child = spawn("agy", argv, {
@@ -302,6 +322,20 @@ function dispatchToAgy(opts, brief, run, writeResult) {
 
   let stdout = "";
   const stderrTail = [];
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    child.kill("SIGTERM");
+    sigkillTimer = setTimeout(() => {
+      if (!settled) child.kill("SIGKILL");
+    }, 10_000);
+  }, timeoutMs + 60_000);
 
   child.stdout.on("data", (chunk) => {
     stdout += chunk.toString();
@@ -318,6 +352,10 @@ function dispatchToAgy(opts, brief, run, writeResult) {
   });
 
   child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
     const finalMessage = stdout.trim();
     if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
     const result = writeResult({
@@ -332,6 +370,10 @@ function dispatchToAgy(opts, brief, run, writeResult) {
   });
 
   child.on("close", (code) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
     const finalMessage = stdout.trim();
     if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
     const result = writeResult({
@@ -340,6 +382,7 @@ function dispatchToAgy(opts, brief, run, writeResult) {
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
       ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `agy did not exit within --print-timeout ${opts.printTimeout} plus 60s grace; killed by the relay watchdog` } : {}),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);


### PR DESCRIPTION
## Summary

Adds **`agy-delegate`**, the third delegation skill, driving the [Google Antigravity CLI](https://antigravity.google/docs/cli/getting-started) (`agy`) as a background implementer — same loop as `codex-delegate` / `opencode-delegate`: write brief → dispatch via `relay.mjs` → review the diff → land it yourself.

## What's included

- `skills/agy-delegate/SKILL.md` — frontmatter + 5-step loop + permission/authorization model
- `skills/agy-delegate/scripts/relay.mjs` — Node built-ins only; shells out to `agy` + `git`; never commits
- Four references: writing-the-brief, dispatch-and-poll, review-and-land, multi-task-queues
- `README.md` + `AGENTS.md` + `skills.sh.json` updated (skill entry, requirements, repo shape, trust/verification, vocabulary)

## Autonomy / permission model

`agy` owns its own permission policy. The relay does **not** pass `--dangerously-skip-permissions` by default — it's opt-in, accepted only when the human explicitly allows auto-approval. `--sandbox` enables Antigravity's terminal sandbox for a run. `agy` has no proven CLI-enforced read-only mode, so the skill is honest about that: verify `touchedFiles`, don't assume.

## Verification (end-to-end, macOS, `agy` 1.0.16)

- A headless `agy --print` run **edits the working tree** and reports back; `result.json` carries the conversation id, `touchedFiles`, and a `resumed` flag.
- Brief delivered via **`--print=<brief>`** so a brief that begins with a bare flag still runs (the two-token form lets `agy` intercept e.g. a literal `--help`).
- Workspace pinned with an **absolute `--add-dir`** — `agy` rejects a relative `.`, which the two-token form silently tripped.
- Deterministic paths exercised: `--help`, empty brief → exit 2, missing `agy` → `agy_unavailable`/127, the pre-run brief-size guard, and the resume/project mutual-exclusion guards.
- **Pending:** a native Windows (PowerShell/cmd) launch smoke.

## Review notes

The skill was reviewed against the real `agy` 1.0.16 interface and hardened before this PR: absolute `--add-dir` (was a silently-rejected `.`), `--print=` delivery, a brief-size guard, an added `--new-project` + resume/conversation mutual-exclusion guard, a `resumed` result field covering both resume paths, a process-list-exposure note in the trust posture, and doc/vocabulary drift fixes. The single-model backends never needed the model-choice decision, so that's documented too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `agy-delegate` skill for delegating bounded coding tasks to the Google Antigravity CLI.
  * Introduced a new relay helper that dispatches briefs, waits for completion, and writes structured `result.json` with robust timeout and failure handling.
* **Documentation**
  * Updated the skill catalog and README, plus `AGENTS.md` guidance and expanded Windows smoke-testing instructions.
  * Added reference guides covering dispatch/polling, writing effective briefs, review/land expectations, and multi-task queue workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->