### PR TITLE
Report the signal that killed the implementer child (codex + opencode relays)

### DIFF
--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -50,7 +50,8 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
 - `status` — `completed` | `failed` | `codex_unavailable`
-- `exitCode` — mirrors Codex's exit code; `127` if `codex` isn't on PATH
+- `exitCode` — mirrors Codex's exit code; `128` plus the signal number if the child was killed; `127` if `codex` isn't on PATH
+- `signal` — the signal that killed the child, otherwise `null`
 - `codexVersion` — the binary that actually ran
 - `threadId` — feed this to a later `codex exec resume <id>` (or use `--resume-last`)
 - `finalMessage` — Codex's own final report (the `<structured_output_contract>` you asked for)
@@ -87,6 +88,9 @@ process has exited and `result.json` is written — not when a status line says 
   Common causes: an auth lapse, an invalid `--model`, or a sandbox that blocked something the task
   needed. Fix the cause and re-dispatch; don't paper over it by doing the work yourself unless that's
   what the user wants.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
 - **Empty `finalMessage`:** Codex exited before producing a final message. Treat as a failed run;
   the events log usually shows where it stopped.
 

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -38,13 +38,15 @@
  *   -h, --help              Show this help.
  *
  * Result: written to <out-dir>/result.json and summarized on stdout —
- *   status, exitCode, codexVersion, threadId (for a later resume), finalMessage
+ *   status, exitCode, signal, codexVersion, threadId (for a later resume), finalMessage
  *   (Codex's own report), touchedFiles (git porcelain, null if git can't report), and the paths to
  *   events.jsonl and final.txt.
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `codex` binary exits 127;
  * otherwise the exit code mirrors Codex's own (0 success, non-zero failure).
+ * If the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome —
  * completed, failed, or codex_unavailable. An orchestrator that polls for the
  * file must therefore also treat a non-zero exit with no file as a usage error.
@@ -53,7 +55,7 @@
 import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
-import { tmpdir } from "node:os";
+import { constants, tmpdir } from "node:os";
 
 const SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 
@@ -118,6 +120,9 @@ function readBrief(opts) {
     return readFileSync(opts.brief, "utf8");
   }
   // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
   let stdin = "";
   try {
     stdin = readFileSync(0, "utf8");
@@ -240,7 +245,7 @@ function makeResultWriter(opts, version, run) {
 }
 
 function reportUnavailable(writeResult, resultPath) {
-  const result = writeResult({ status: "codex_unavailable", exitCode: 127, threadId: null, finalMessage: "", touchedFiles: null });
+  const result = writeResult({ status: "codex_unavailable", exitCode: 127, signal: null, threadId: null, finalMessage: "", touchedFiles: null });
   printSummary(result, resultPath);
   process.stderr.write("relay: `codex` not found on PATH. Install it (npm i -g @openai/codex) and run `codex login`.\n");
   process.exit(127);
@@ -278,13 +283,18 @@ function dispatchToCodex(opts, brief, run, writeResult) {
     while (stderrTail.length > 20) stderrTail.shift();
   });
 
+  let settled = false;
   child.on("error", (err) => {
-    const result = writeResult({ status: "failed", exitCode: 1, threadId, finalMessage: "", touchedFiles: gitTouchedFiles(opts.cd), error: String(err && err.message ? err.message : err) });
+    if (settled) return;
+    settled = true;
+    const result = writeResult({ status: "failed", exitCode: 1, signal: null, threadId, finalMessage: "", touchedFiles: gitTouchedFiles(opts.cd), error: String(err && err.message ? err.message : err) });
     printSummary(result, run.resultPath);
     process.exit(1);
   });
 
-  child.on("close", (code) => {
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
     if (stdoutBuf.trim()) {
       const tid = recordEventLine(run.eventsPath, stdoutBuf);
       if (tid) threadId = tid;
@@ -292,7 +302,8 @@ function dispatchToCodex(opts, brief, run, writeResult) {
     const finalMessage = existsSync(run.finalPath) ? readFileSync(run.finalPath, "utf8").trim() : "";
     const result = writeResult({
       status: code === 0 ? "completed" : "failed",
-      exitCode: code === null ? 1 : code,
+      exitCode: code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1),
+      signal: signal ?? null,
       threadId,
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
@@ -329,7 +340,8 @@ function main() {
 function printSummary(result, resultPath) {
   const lines = [];
   lines.push("");
-  lines.push(`relay: ${result.status} (exit ${result.exitCode})  ·  codex ${result.codexVersion ?? "?"}`);
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  codex ${result.codexVersion ?? "?"}`);
+  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a codex error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.resumeLast) lines.push("mode: resumed most recent session");
   if (result.threadId) lines.push(`thread id (resume with: codex exec resume ${result.threadId}): ${result.threadId}`);
   const touched = result.touchedFiles;

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -51,7 +51,8 @@ touched-files report shows only OpenCode's edits and nothing of the helper's own
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
 - `tool` — `opencode`
 - `status` — `completed` | `failed` | `opencode_unavailable`
-- `exitCode` — mirrors OpenCode's exit code; `127` if `opencode` isn't on PATH
+- `exitCode` — mirrors OpenCode's exit code; `128` plus the signal number if the child was killed; `127` if `opencode` isn't on PATH
+- `signal` — the signal that killed the child, otherwise `null`
 - `opencodeVersion` — the binary that actually ran
 - `agent` — the agent used (`build`, `plan`, …), or a note that it was inherited from a resumed session
 - `sessionId` — feed this to a later `--session <id>` (or use `--resume-last`)
@@ -95,6 +96,9 @@ process has exited and `result.json` is written — not when a status line says 
   Common causes: an auth lapse, an unknown `--model` or `--agent`, or a permission the run needed but
   the agent didn't grant. Fix the cause and re-dispatch; don't paper over it by doing the work yourself
   unless that's what the user wants.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
 - **Empty `finalMessage`:** OpenCode finished without emitting a closing text summary (common when it
   completes purely through tool calls). The edits may still be correct — check `touchedFiles` and the
   diff. To get a report next time, add a `<structured_output_contract>` block (see

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -47,13 +47,15 @@
  *   -h, --help              Show this help.
  *
  * Result: written to <out-dir>/result.json and summarized on stdout —
- *   status, exitCode, opencodeVersion, sessionId (for a later resume), finalMessage
+ *   status, exitCode, signal, opencodeVersion, sessionId (for a later resume), finalMessage
  *   (OpenCode's own report), touchedFiles (git porcelain, null if git can't report), and the
  *   paths to events.jsonl and final.txt.
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `opencode` binary exits 127;
  * otherwise the exit code mirrors OpenCode's own (0 success, non-zero failure).
+ * If the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome —
  * completed, failed, or opencode_unavailable. An orchestrator that polls for the
  * file must therefore also treat a non-zero exit with no file as a usage error.
@@ -62,7 +64,7 @@
 import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
-import { tmpdir } from "node:os";
+import { constants, tmpdir } from "node:os";
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -129,6 +131,9 @@ function readBrief(opts) {
     return readFileSync(opts.brief, "utf8");
   }
   // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
   let stdin = "";
   try {
     stdin = readFileSync(0, "utf8");
@@ -297,7 +302,7 @@ function makeResultWriter(opts, version, run) {
 }
 
 function reportUnavailable(writeResult, resultPath) {
-  const result = writeResult({ status: "opencode_unavailable", exitCode: 127, sessionId: null, finalMessage: "", touchedFiles: null, cost: null });
+  const result = writeResult({ status: "opencode_unavailable", exitCode: 127, signal: null, sessionId: null, finalMessage: "", touchedFiles: null, cost: null });
   printSummary(result, resultPath);
   process.stderr.write("relay: `opencode` not found on PATH. Install it (npm i -g opencode-ai) and run `opencode auth login`.\n");
   process.exit(127);
@@ -369,17 +374,23 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
     return message;
   };
 
+  let settled = false;
   child.on("error", (err) => {
-    const result = writeResult({ status: "failed", exitCode: 1, sessionId, finalMessage: assembleFinal(), touchedFiles: gitTouchedFiles(opts.cd), cost: sawCost ? totalCost : null, error: String(err && err.message ? err.message : err) });
+    if (settled) return;
+    settled = true;
+    const result = writeResult({ status: "failed", exitCode: 1, signal: null, sessionId, finalMessage: assembleFinal(), touchedFiles: gitTouchedFiles(opts.cd), cost: sawCost ? totalCost : null, error: String(err && err.message ? err.message : err) });
     printSummary(result, run.resultPath);
     process.exit(1);
   });
 
-  child.on("close", (code) => {
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
     const finalMessage = assembleFinal();
     const result = writeResult({
       status: code === 0 ? "completed" : "failed",
-      exitCode: code === null ? 1 : code,
+      exitCode: code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1),
+      signal: signal ?? null,
       sessionId,
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
@@ -427,7 +438,8 @@ function main() {
 function printSummary(result, resultPath) {
   const lines = [];
   lines.push("");
-  lines.push(`relay: ${result.status} (exit ${result.exitCode})  ·  opencode ${result.opencodeVersion ?? "?"}`);
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  opencode ${result.opencodeVersion ?? "?"}`);
+  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an opencode error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.resumeLast || result.agent === "(inherited from resumed session)") lines.push("mode: resumed existing session");
   if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
   if (typeof result.cost === "number") lines.push(`cost: $${result.cost}`);


### PR DESCRIPTION
## Summary

Fixes the failure mode behind #10 ("Codex background task keep killed"): when the host ends the implementer child — most commonly the OOM killer — the relay dropped the killing signal and wrote a generic `exitCode: 1` to `result.json`, so neither the orchestrator nor the user could tell "codex crashed" from "the host killed codex".

Applies to both relays on master (`codex-delegate`, `opencode-delegate`); the grok/agy relays on the open PRs get the same treatment as a follow-up once those land.

## Changes

- **Signal surfacing**: `child.on("close", (code, signal) => …)`; `result.json` gains a `signal` field (`"SIGKILL"`, else `null` — including on the `*_unavailable` shape, so the contract stays uniform); signal deaths map to the shell convention `128 + signal number` (SIGKILL → 137); the run summary prints `killed by SIGKILL` plus a hint that the host ended the process (OOM killer / supervisor timeout), with the remedy: free host memory or split the task into smaller briefs.
- **TTY fail-fast**: `readBrief` with no `--brief` and an interactive stdin now exits 2 immediately instead of blocking forever on the fd-0 read.
- **Settle-once**: the child `error`/`close` handlers can both fire for one failed spawn; they now settle exactly once, so `result.json` can't be written twice with racing exits.
- Docs: each `dispatch-and-poll.md` documents the `signal` field and the SIGKILL recovery bullet; the relay headers extend the exit-code contract.

## Verification (macOS, Node 22)

- SIGKILL end-to-end on both relays with a stubbed implementer killed mid-run: relay exits **137**, `result.json` = `status: "failed"`, `exitCode: 137`, `signal: "SIGKILL"`, hint line printed. Run twice independently for the codex relay.
- `node --check` clean on both; empty-brief and TTY-stdin usage errors still exit 2 with no result file; `npx skills add . --list` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of terminated delegate processes, including accurate exit codes and signal details.
  * Prevented duplicate completion reporting and preserved final output when processes close unexpectedly.
  * Added clearer errors when no task brief is provided in an interactive terminal.
  * Enhanced failure summaries with specific guidance for `SIGKILL` terminations.

* **Documentation**
  * Documented the new signal information in result reports.
  * Added troubleshooting guidance for host termination, memory pressure, and supervisor timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->