### PR TITLE
Add `grok-delegate` for Grok Build headless implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ orchestrator) writes a self-contained brief, hands it to an implementer CLI, the
 commits — staying the reviewer the whole way.
 
 Three skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, **`opencode-delegate`** drives
-the OpenCode CLI, and **`grok-delegate`** drives Grok Build headlessly. Same loop, different implementer.
+the OpenCode CLI, and **`grok-delegate`** drives Grok Build. Same loop, different implementer.
 
 ## Install
 
@@ -47,17 +47,23 @@ The loop:
 
 ```text
 Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
-Use $grok-delegate to have Grok Build implement the migration, then review the diff and land it yourself.
+Use $codex-delegate to run this queue of migration tasks through Codex while I review each one.
+Use $grok-delegate to have Grok Build implement the migration, then review and commit it.
 ```
 
 ## How this differs from the OpenAI Codex plugin
 
-The official openai-codex Claude Code plugin is excellent and **complementary** — this skill builds on
-the same `codex` CLI, it doesn't replace the plugin. They point in different directions:
+The official openai-codex Claude Code plugin is excellent and
+**complementary** — this skill builds on the same `codex` CLI, it doesn't replace the plugin. They
+point in different directions:
 
-- The plugin's `codex:codex-rescue` agent is a **forwarder**: it hands one task to Codex and returns the output.
+- The plugin's `codex:codex-rescue` agent is a **forwarder**: it hands one task to Codex and returns
+  the output. It deliberately does not poll, review, or commit.
 - The plugin's review command and stop-review gate run the **inverse** direction: **Codex reviews your work**.
-- `codex-delegate` is the orchestration loop in the other direction: brief → dispatch → poll → review → commit.
+- `codex-delegate` is the **orchestration loop in the other direction**: *you* drive Codex to
+  implement across one task or a queue, and *you* review and land each result. That loop — brief →
+  dispatch → poll → review → commit, with the orchestrator owning the commit — is what the plugin
+  leaves to you, and what this skill encodes.
 
 If you have the plugin installed, its companion CLI is an optional alternative dispatch backend; the
 bundled `relay.mjs` is the default because it needs nothing but the `codex` binary.
@@ -67,29 +73,47 @@ bundled `relay.mjs` is the default because it needs nothing but the `codex` bina
 ### codex-delegate
 
 Drive the OpenAI Codex CLI as a background implementer: write the brief, dispatch via `relay.mjs`,
-review the diff, commit it yourself.
+review the diff, commit it yourself. Ships four references (writing the brief, dispatch/poll, review/
+land, multi-task queues) loaded only when needed, and one small helper script.
+
+**You'll feel it when:** a bounded task — a migration, a mechanical refactor, a removal sweep — gets
+handed to Codex, comes back as a clean diff with a structured report, and you commit it after re-running
+the gates yourself instead of typing it all by hand.
 
 ### opencode-delegate
 
-Drive the OpenCode CLI as a background implementer. Autonomy is selected through the OpenCode agent:
-`build` for implementation and `plan` for read-only review.
+Drive the OpenCode CLI as a background implementer: write the brief, dispatch via `relay.mjs`, review
+the diff, commit it yourself. Same four references and loop as `codex-delegate`. Autonomy is set by the
+**agent** rather than a sandbox enum — `build` (write-capable) by default, `plan` (read-only) for
+review/diagnosis — and the brief is piped to `opencode run` on stdin so multi-line XML briefs need no
+quoting.
+
+**You'll feel it when:** a bounded task gets handed to OpenCode, comes back as a clean diff with a
+structured report and the run's cost, and you commit it after re-running the gates yourself.
 
 ### grok-delegate
 
-Drive Grok Build through its documented headless mode with newline-delimited `streaming-json` output,
-session resume/continue support, and a stable relay `result.json`. Implementation runs auto-approve tool
-calls by default; read-only runs remove write/edit tools, avoid auto-approval, and detect working-tree
-status changes. Raw events are retained so CLI output changes remain diagnosable.
+Drive Grok Build as a headless implementer through its documented `streaming-json` mode: write the
+brief, dispatch via `relay.mjs`, resume the same session for corrections, review the diff, and commit it
+yourself. The relay preserves raw events, records a stable `result.json`, and adds a guarded read-only
+review mode that detects working-tree status changes.
+
+**You'll feel it when:** Grok handles a bounded implementation pass unattended, returns a reviewable
+working-tree diff and structured report, and you remain the party that verifies and lands it.
 
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
+Reserved so the umbrella can grow without a rename.
 
 ## Requirements
 
-- For `codex-delegate`: the [`codex` CLI](https://github.com/openai/codex), authenticated with `codex login`.
-- For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai), authenticated with `opencode auth login`.
-- For `grok-delegate`: the [Grok Build CLI](https://docs.x.ai/build/cli/headless-scripting), authenticated with `grok login`.
+- For `codex-delegate`: the [`codex` CLI](https://github.com/openai/codex) installed and authenticated
+  (`codex login`).
+- For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai) installed and authenticated
+  (`opencode auth login`).
+- For `grok-delegate`: the [Grok Build CLI](https://docs.x.ai/build/cli/headless-scripting) installed and
+  authenticated (`grok login`; use `grok login --device-auth` on a headless host).
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -99,22 +123,23 @@ status changes. Raw events are retained so CLI output changes remain diagnosable
 This package is intentionally inspectable:
 
 - All skill content is Markdown, plus exactly **one** executable per skill — each a `scripts/relay.mjs`.
-- Each relay uses Node built-ins only, makes no network calls itself, reads or writes no credentials, and
-  shells out only to its implementer CLI and `git`.
-- Relays never commit — committing is always the orchestrator's job after review.
+- Each `relay.mjs` makes no network calls, reads or writes no credentials, sends no telemetry, and has
+  no dependencies (Node built-ins only). It shells out only to its implementer CLI (`codex` /
+  `opencode` / `grok`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the
+  script before you run it.
+- None ever commits — committing is always the orchestrator's job, after review.
 
-**Verification status:** Codex and OpenCode retain their existing verification status. The new Grok relay
-has implementation-level validation for argument handling, result generation, missing-binary behavior,
-signal reporting, raw event preservation, and read-only git-status detection. A real authenticated Grok
-run remains required before claiming end-to-end verification against a specific Grok CLI version.
+**Verification status:** the Codex and OpenCode relays retain their existing verification status. The
+Grok relay's mechanics are implementation-reviewed, but a real authenticated Grok run is still required
+before claiming end-to-end verification against a specific CLI version. The full delegate → review →
+commit loop is designed for and run on Claude Code but not yet formally verified across other
+orchestrators (Cursor, …), which are designed-for but unproven.
 
 ## Repository shape
 
 ```text
 skills/
 ├── codex-delegate/
-├── opencode-delegate/
-├── grok-delegate/
 │   ├── SKILL.md
 │   ├── scripts/relay.mjs
 │   └── references/
@@ -122,10 +147,25 @@ skills/
 │       ├── dispatch-and-poll.md
 │       ├── review-and-land.md
 │       └── multi-task-queues.md
-└── gemini-delegate/ (planned)
+├── opencode-delegate/
+│   ├── SKILL.md
+│   ├── scripts/relay.mjs
+│   └── references/
+│       ├── writing-the-brief.md
+│       ├── dispatch-and-poll.md
+│       ├── review-and-land.md
+│       └── multi-task-queues.md
+└── grok-delegate/
+    ├── SKILL.md
+    ├── scripts/relay.mjs
+    └── references/
+        ├── writing-the-brief.md
+        ├── dispatch-and-poll.md
+        ├── review-and-land.md
+        └── multi-task-queues.md
 ```
 
-The `SKILL.md` stays small so it loads cheaply; references load only when needed.
+The `SKILL.md` stays small so it loads cheaply; the references load only when the task needs them.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, hands it to an implementer CLI, then reviews the diff and
 commits — staying the reviewer the whole way.
 
-Two skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, and **`opencode-delegate`**
-drives the OpenCode CLI. Same loop, different implementer.
+Three skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, **`opencode-delegate`** drives
+the OpenCode CLI, and **`grok-delegate`** drives Grok Build headlessly. Same loop, different implementer.
 
 ## Install
 
@@ -23,6 +23,7 @@ Install the package, or just one skill:
 npx skills add amElnagdy/delegate-skills
 npx skills add amElnagdy/delegate-skills --skill codex-delegate
 npx skills add amElnagdy/delegate-skills --skill opencode-delegate
+npx skills add amElnagdy/delegate-skills --skill grok-delegate
 ```
 
 Install for a specific agent, or globally:
@@ -46,22 +47,17 @@ The loop:
 
 ```text
 Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
-Use $codex-delegate to run this queue of migration tasks through Codex while I review each one.
+Use $grok-delegate to have Grok Build implement the migration, then review the diff and land it yourself.
 ```
 
 ## How this differs from the OpenAI Codex plugin
 
-The official openai-codex Claude Code plugin is excellent and
-**complementary** — this skill builds on the same `codex` CLI, it doesn't replace the plugin. They
-point in different directions:
+The official openai-codex Claude Code plugin is excellent and **complementary** — this skill builds on
+the same `codex` CLI, it doesn't replace the plugin. They point in different directions:
 
-- The plugin's `codex:codex-rescue` agent is a **forwarder**: it hands one task to Codex and returns
-  the output. It deliberately does not poll, review, or commit.
+- The plugin's `codex:codex-rescue` agent is a **forwarder**: it hands one task to Codex and returns the output.
 - The plugin's review command and stop-review gate run the **inverse** direction: **Codex reviews your work**.
-- `codex-delegate` is the **orchestration loop in the other direction**: *you* drive Codex to
-  implement across one task or a queue, and *you* review and land each result. That loop — brief →
-  dispatch → poll → review → commit, with the orchestrator owning the commit — is what the plugin
-  leaves to you, and what this skill encodes.
+- `codex-delegate` is the orchestration loop in the other direction: brief → dispatch → poll → review → commit.
 
 If you have the plugin installed, its companion CLI is an optional alternative dispatch backend; the
 bundled `relay.mjs` is the default because it needs nothing but the `codex` binary.
@@ -71,35 +67,29 @@ bundled `relay.mjs` is the default because it needs nothing but the `codex` bina
 ### codex-delegate
 
 Drive the OpenAI Codex CLI as a background implementer: write the brief, dispatch via `relay.mjs`,
-review the diff, commit it yourself. Ships four references (writing the brief, dispatch/poll, review/
-land, multi-task queues) loaded only when needed, and one small helper script.
-
-**You'll feel it when:** a bounded task — a migration, a mechanical refactor, a removal sweep — gets
-handed to Codex, comes back as a clean diff with a structured report, and you commit it after re-running
-the gates yourself instead of typing it all by hand.
+review the diff, commit it yourself.
 
 ### opencode-delegate
 
-Drive the OpenCode CLI as a background implementer: write the brief, dispatch via `relay.mjs`, review
-the diff, commit it yourself. Same four references and loop as `codex-delegate`. Autonomy is set by the
-**agent** rather than a sandbox enum — `build` (write-capable) by default, `plan` (read-only) for
-review/diagnosis — and the brief is piped to `opencode run` on stdin so multi-line XML briefs need no
-quoting.
+Drive the OpenCode CLI as a background implementer. Autonomy is selected through the OpenCode agent:
+`build` for implementation and `plan` for read-only review.
 
-**You'll feel it when:** a bounded task gets handed to OpenCode, comes back as a clean diff with a
-structured report and the run's cost, and you commit it after re-running the gates yourself.
+### grok-delegate
+
+Drive Grok Build through its documented headless mode with newline-delimited `streaming-json` output,
+session resume/continue support, and a stable relay `result.json`. Implementation runs auto-approve tool
+calls by default; read-only runs remove write/edit tools, avoid auto-approval, and detect working-tree
+status changes. Raw events are retained so CLI output changes remain diagnosable.
 
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
-Reserved so the umbrella can grow without a rename.
 
 ## Requirements
 
-- For `codex-delegate`: the [`codex` CLI](https://github.com/openai/codex) installed and authenticated
-  (`codex login`).
-- For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai) installed and authenticated
-  (`opencode auth login`).
+- For `codex-delegate`: the [`codex` CLI](https://github.com/openai/codex), authenticated with `codex login`.
+- For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai), authenticated with `opencode auth login`.
+- For `grok-delegate`: the [Grok Build CLI](https://docs.x.ai/build/cli/headless-scripting), authenticated with `grok login`.
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -109,24 +99,22 @@ Reserved so the umbrella can grow without a rename.
 This package is intentionally inspectable:
 
 - All skill content is Markdown, plus exactly **one** executable per skill — each a `scripts/relay.mjs`.
-- Each `relay.mjs` makes no network calls, reads or writes no credentials, sends no telemetry, and has
-  no dependencies (Node built-ins only). It shells out only to its implementer CLI (`codex` /
-  `opencode`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the script
-  before you run it.
-- Neither ever commits — committing is always the orchestrator's job, after review.
+- Each relay uses Node built-ins only, makes no network calls itself, reads or writes no credentials, and
+  shells out only to its implementer CLI and `git`.
+- Relays never commit — committing is always the orchestrator's job after review.
 
-**Verification status:** each relay's mechanics are verified — argument handling, exit codes,
-`result.json`, resume, and (for `opencode-delegate`) the required-model guard, since OpenCode has no safe
-default. The full delegate → review → commit loop is designed for and run on Claude Code but not yet
-formally verified end-to-end here (OpenCode's cold start is slow in constrained shells, so exercise a
-real run in a normal terminal). Other orchestrators (Cursor, …) are designed-for but unproven. This line
-gets upgraded to "verified end-to-end" with evidence, not assumption.
+**Verification status:** Codex and OpenCode retain their existing verification status. The new Grok relay
+has implementation-level validation for argument handling, result generation, missing-binary behavior,
+signal reporting, raw event preservation, and read-only git-status detection. A real authenticated Grok
+run remains required before claiming end-to-end verification against a specific Grok CLI version.
 
 ## Repository shape
 
 ```text
 skills/
 ├── codex-delegate/
+├── opencode-delegate/
+├── grok-delegate/
 │   ├── SKILL.md
 │   ├── scripts/relay.mjs
 │   └── references/
@@ -134,17 +122,10 @@ skills/
 │       ├── dispatch-and-poll.md
 │       ├── review-and-land.md
 │       └── multi-task-queues.md
-└── opencode-delegate/
-    ├── SKILL.md
-    ├── scripts/relay.mjs
-    └── references/
-        ├── writing-the-brief.md
-        ├── dispatch-and-poll.md
-        ├── review-and-land.md
-        └── multi-task-queues.md
+└── gemini-delegate/ (planned)
 ```
 
-The `SKILL.md` stays small so it loads cheaply; the references load only when the task needs them.
+The `SKILL.md` stays small so it loads cheaply; references load only when needed.
 
 ## License
 

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: grok-delegate
+description: >-
+  Delegate a bounded coding task to the Grok Build CLI as a headless implementer, then independently
+  review its diff and land it yourself. Use when the user asks to have Grok Build implement, fix,
+  migrate, or refactor code, or to run a queue of implementation tasks through Grok while the
+  orchestrator remains reviewer and commit owner. Covers writing a self-contained brief, dispatching
+  through the bundled relay.mjs, resuming a session with corrective feedback, reviewing the resulting
+  working tree, and committing only after independent verification.
+license: MIT
+compatibility: Requires the `grok` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.1.0
+---
+
+# Grok Delegate
+
+You are the **orchestrator**. Grok Build is a separate **implementer**. You provide a bounded brief,
+Grok edits the working tree headlessly, and you inspect the actual diff, rerun the project gates, and
+commit only verified work.
+
+## When not to use this
+
+- The task is small enough to complete inline.
+- `grok version` fails or Grok is not authenticated (`grok login`).
+- The user wants Grok only to review existing work; use `--read-only` with a review brief instead.
+
+## Prerequisites
+
+1. Run `grok version` and confirm the expected binary is on `PATH`.
+2. Authenticate with `grok login` (`grok login --device-auth` in a headless environment).
+3. Point `--cd` at a git repository and discover its actual test/lint/build commands.
+
+## The loop
+
+### 1. Write a self-contained brief
+
+Grok sees the brief and the working tree, not the orchestrator's conversation. State the goal, scope,
+constraints, files or subsystems involved, acceptance criteria, real project gate commands, and a final
+report contract. Explicitly tell Grok not to commit or push. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only review:          add --read-only
+# resume latest session:    add --resume-last
+# resume a known session:   add --session <id>
+# inspect every option:     node .../relay.mjs --help
+```
+
+The relay launches Grok with headless `streaming-json`, records raw events and the final report, writes
+`result.json`, and never commits. By default it auto-approves implementation tool calls so an unattended
+run cannot stall on a permission prompt. `--read-only` disables write/edit tools, does not auto-approve,
+and fails if the git working-tree status changes. Details:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Treat completion as process state
+
+The relay blocks until Grok exits. A run is complete only when the process has exited and `result.json`
+exists. A usage error exits 2 before writing a result. A missing Grok binary exits 127 and writes
+`status: grok_unavailable`.
+
+### 4. Review independently
+
+Do not accept Grok's report as evidence. Inspect `git diff`, compare every edit with the brief, rerun the
+project's own gates, check for scope creep and dangling references, and use applicable guard skills.
+Start with `touchedFiles`, but trust the working tree itself. See
+[references/review-and-land.md](references/review-and-land.md).
+
+### 5. Correct or land
+
+When changes are required, send only the review delta back into the same session with `--session <id>`
+or `--resume-last`, then repeat the review. When the diff and all gates pass, the orchestrator creates
+the commit. One task should produce one reviewed commit.
+
+## Non-negotiables
+
+- The orchestrator reruns gates and owns the commit.
+- Grok must never commit or push.
+- A self-report is a claim, not evidence.
+- Stop rather than silently broaden the task beyond the brief.
+- Keep raw `events.jsonl` available when output parsing or a failed run needs diagnosis.
+
+## Trust posture
+
+`scripts/relay.mjs` uses Node built-ins only, makes no network calls itself, reads no credentials, and
+shells out only to `grok` and `git`. Authentication remains inside the installed Grok CLI. The helper
+stores run artifacts under the system temp directory unless `--out-dir` is supplied.
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md)
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md)
+- [references/review-and-land.md](references/review-and-land.md)
+- [references/multi-task-queues.md](references/multi-task-queues.md)

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,54 @@
+# Dispatch and result contract
+
+## Common commands
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+node "<skill-dir>/scripts/relay.mjs" --brief review.txt --cd /path/to/repo --read-only
+node "<skill-dir>/scripts/relay.mjs" --brief fixes.txt --cd /path/to/repo --session <session-id>
+```
+
+The relay uses Grok Build headless mode with `--output-format streaming-json` and
+`--no-auto-update`. Fresh implementation runs pass `--always-approve` by default so they cannot block
+on an unattended permission prompt. Use `--no-auto-approve` when local permission policy should remain
+in control.
+
+`--read-only` removes the `write` and `edit` tools, adds an explicit non-mutation rule, avoids automatic
+approval, and compares git porcelain before and after the run. This is defense in depth, not a claim that
+all future Grok tool names or shell behavior are sandboxed: independently inspect the working tree.
+
+## Artifacts
+
+Unless `--out-dir` is supplied, artifacts are stored under the system temp directory:
+
+- `brief.txt` — exact dispatched brief
+- `events.jsonl` — raw stdout event stream, preserved even when an event cannot be parsed
+- `stderr.txt` — Grok stderr
+- `final.txt` — last assistant text extracted from the stream
+- `result.json` — stable relay result
+
+## `result.json`
+
+The result uses schema `delegate-relay.result.v1` and includes:
+
+- `tool: "grok"`
+- `status`: `completed`, `failed`, or `grok_unavailable`
+- `exitCode` and `signal`
+- `grokVersion`
+- `sessionId` when discovered or supplied
+- `finalMessage`
+- `touchedFiles` from `git status --porcelain`, or `null` when git cannot report
+- `readOnlyViolation`
+- paths to all run artifacts and start/finish timestamps
+
+A bad argument or empty brief exits 2 before a result is written. A missing Grok binary exits 127 and
+writes `grok_unavailable`. A read-only status change produces exit 3. Other exits mirror Grok; a signal
+uses the conventional `128 + signal number` code when available.
+
+## Recovery
+
+- Authentication failure: run `grok login` or `grok login --device-auth`, then redispatch.
+- Invalid model or effort: inspect `stderr.txt`, correct the option, and redispatch.
+- Empty final message: inspect `events.jsonl`; judge the working tree rather than assuming failure.
+- Killed process: inspect `signal` and host resources; split an oversized brief before retrying.
+- Parser mismatch after a Grok update: the raw stream is authoritative evidence for adapting the parser.

--- a/skills/grok-delegate/references/multi-task-queues.md
+++ b/skills/grok-delegate/references/multi-task-queues.md
@@ -1,0 +1,16 @@
+# Multi-task queues
+
+Run queues sequentially unless tasks are genuinely independent and isolated in separate worktrees.
+
+For each item:
+
+1. Confirm the previous item is reviewed, gate-passing, and committed.
+2. Write a fresh self-contained brief with one outcome and one commit boundary.
+3. Dispatch Grok and record the resulting session id and artifact directory.
+4. Review the actual diff and rerun the relevant project gates.
+5. Resume the same session for corrections, or commit the verified result and move on.
+
+Carry forward only verified repository state and explicit constraints. Do not let a previous Grok session
+become hidden shared context for a different task. At the end of the queue, run broader integration gates
+and inspect the commit series for duplicated abstractions, inconsistent naming, migration ordering, and
+cross-task regressions.

--- a/skills/grok-delegate/references/review-and-land.md
+++ b/skills/grok-delegate/references/review-and-land.md
@@ -1,0 +1,22 @@
+# Review and land
+
+The implementer's report is not evidence. The orchestrator owns verification.
+
+1. Read `result.json`, `stderr.txt`, and the raw events when the run was incomplete or ambiguous.
+2. Inspect `git status`, `git diff --stat`, and the full diff.
+3. Compare every changed file against the brief and explicit exclusions.
+4. Re-run the repository's real test, lint, typecheck, build, migration, or generation gates.
+5. Check architecture boundaries, migrations and reversibility, generated-file drift, and dangling references.
+6. Confirm Grok did not create commits or push branches.
+
+Reject the result when it is incomplete, broadens scope, relies on unverified assumptions, changes
+unrelated files, weakens tests, or reports gates that the orchestrator cannot reproduce.
+
+For corrections, write a small delta brief with concrete findings and resume the same session:
+
+```bash
+node relay.mjs --brief corrections.txt --cd /path/to/repo --session <session-id>
+```
+
+Review the entire accumulated diff again, not only the latest edits. Commit only after the diff and all
+required gates pass. The orchestrator authors the commit message and owns the landing decision.

--- a/skills/grok-delegate/references/writing-the-brief.md
+++ b/skills/grok-delegate/references/writing-the-brief.md
@@ -1,0 +1,33 @@
+# Writing the Grok brief
+
+Grok receives the brief and the repository, not the orchestrator's conversation. A useful brief is
+self-contained, bounded, and testable.
+
+```xml
+<task>
+  <goal>Describe the required outcome in one paragraph.</goal>
+  <context>Explain the current behavior and relevant architecture.</context>
+  <scope>
+    <change>List the requested changes.</change>
+    <do_not_change>List explicit exclusions and protected behavior.</do_not_change>
+  </scope>
+  <constraints>
+    <item>Follow repository instructions and established patterns.</item>
+    <item>Do not commit, amend, push, or modify git history.</item>
+    <item>Do not broaden scope without reporting a blocker.</item>
+  </constraints>
+  <acceptance_criteria>
+    <item>State observable completion conditions.</item>
+  </acceptance_criteria>
+  <verification>
+    <command>Use commands discovered from this repository, not guessed defaults.</command>
+  </verification>
+  <structured_output_contract>
+    Return: summary, changed files, decisions/assumptions, gates run with outcomes, and remaining risks.
+  </structured_output_contract>
+</task>
+```
+
+Keep one task per brief. Include exact paths only when known. For corrective work in a resumed session,
+send a delta brief containing the review findings, required corrections, and gates to rerun; do not
+repeat the entire original task.

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · grok-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to Grok Build in headless streaming-JSON mode,
+ * preserve the raw event stream, and write a stable result.json for an
+ * orchestrator to review. The helper never commits.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Read the brief from a file; otherwise read stdin.
+ *   --cd <dir>              Grok working directory (default: current directory).
+ *   --model <id>            Grok model id.
+ *   --effort <level>        Reasoning effort.
+ *   --max-turns <n>         Maximum agent turns.
+ *   --session <id>          Resume a specific Grok session.
+ *   --resume-last           Continue the latest session for --cd.
+ *   --read-only             Remove write/edit tools, avoid auto-approval, and
+ *                           fail if git status changes during the run.
+ *   --no-auto-approve       Do not pass --always-approve on implementation runs.
+ *   --no-subagents          Disable subagents.
+ *   --no-memory             Disable cross-session memory.
+ *   --no-web                Disable web search.
+ *   --out-dir <dir>         Artifact directory (default: system temp directory).
+ *   -h, --help              Show this help.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { constants, tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    maxTurns: null,
+    session: null,
+    resumeLast: false,
+    readOnly: false,
+    autoApprove: true,
+    noSubagents: false,
+    noMemory: false,
+    noWeb: false,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help": process.stdout.write(readHelp()); process.exit(0); break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--effort": opts.effort = next(); break;
+      case "--max-turns": opts.maxTurns = next(); break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--read-only": opts.readOnly = true; break;
+      case "--no-auto-approve": opts.autoApprove = false; break;
+      case "--no-subagents": opts.noSubagents = true; break;
+      case "--no-memory": opts.noMemory = true; break;
+      case "--no-web": opts.noWeb = true; break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default: fail(`unknown option: ${arg}`);
+    }
+  }
+  if (opts.session && opts.resumeLast) fail("use only one of --session or --resume-last");
+  if (opts.maxTurns !== null && (!/^\d+$/.test(opts.maxTurns) || Number(opts.maxTurns) < 1)) {
+    fail("--max-turns must be a positive integer");
+  }
+  return opts;
+}
+
+function readHelp() {
+  const source = readFileSync(new URL(import.meta.url), "utf8");
+  const match = source.match(/\/\*\*([\s\S]*?)\*\//);
+  return match ? `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n` : "relay.mjs\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8").trim();
+  }
+  if (process.stdin.isTTY) fail("pass --brief <file> or pipe a brief on stdin");
+  try { return readFileSync(0, "utf8").trim(); } catch { return ""; }
+}
+
+function grokVersion() {
+  try {
+    return execFileSync("grok", ["version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function gitStatus(cwd) {
+  try {
+    return execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" })
+      .split("\n").map(line => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function prepareRun(opts, brief) {
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    outDir,
+    briefPath: join(outDir, "brief.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    finalPath: join(outDir, "final.txt"),
+    resultPath: join(outDir, "result.json"),
+    startedAt: new Date().toISOString(),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function buildArgs(opts, brief) {
+  const rules = [
+    "Do not create commits, amend commits, push, or modify git history.",
+    "Stay inside the requested scope and return a concise final report with changed files and gates run.",
+  ];
+  if (opts.readOnly) {
+    rules.push("This is a read-only review. Do not modify, create, rename, or delete files and do not run mutating commands.");
+  }
+  const args = ["--no-auto-update", "--cwd", opts.cd, "--output-format", "streaming-json", "--rules", rules.join(" ")];
+  if (opts.session) args.push("--resume", opts.session);
+  else if (opts.resumeLast) args.push("--continue");
+  if (opts.model) args.push("--model", opts.model);
+  if (opts.effort) args.push("--effort", opts.effort);
+  if (opts.maxTurns) args.push("--max-turns", opts.maxTurns);
+  if (opts.noSubagents) args.push("--no-subagents");
+  if (opts.noMemory) args.push("--no-memory");
+  if (opts.noWeb) args.push("--disable-web-search");
+  if (opts.readOnly) args.push("--disallowed-tools", "write,edit");
+  else if (opts.autoApprove) args.push("--always-approve");
+  args.push("-p", brief);
+  return args;
+}
+
+function findString(object, keys) {
+  if (!object || typeof object !== "object") return null;
+  for (const key of keys) {
+    if (typeof object[key] === "string" && object[key].trim()) return object[key].trim();
+  }
+  for (const value of Object.values(object)) {
+    const found = findString(value, keys);
+    if (found) return found;
+  }
+  return null;
+}
+
+function extractText(event) {
+  const direct = findString(event, ["finalMessage", "final_message", "output", "text", "message"]);
+  return direct || null;
+}
+
+function makeLineScanner(onLine) {
+  let buffer = "";
+  return {
+    push(chunk) {
+      buffer += chunk;
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() || "";
+      for (const line of lines) if (line.trim()) onLine(line);
+    },
+    flush() { if (buffer.trim()) onLine(buffer); buffer = ""; },
+  };
+}
+
+function writeResult(opts, run, version, extra) {
+  const result = {
+    schema: "delegate-relay.result.v1",
+    tool: "grok",
+    grokVersion: version,
+    cd: opts.cd,
+    readOnly: opts.readOnly,
+    resumeLast: opts.resumeLast,
+    startedAt: run.startedAt,
+    finishedAt: new Date().toISOString(),
+    briefPath: run.briefPath,
+    eventsPath: run.eventsPath,
+    stderrPath: run.stderrPath,
+    finalPath: run.finalPath,
+    ...extra,
+  };
+  writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  return result;
+}
+
+function printSummary(result, resultPath) {
+  process.stdout.write(`\nrelay: ${result.status} (exit ${result.exitCode}${result.signal ? `, ${result.signal}` : ""}) · grok ${result.grokVersion || "?"}\n`);
+  if (result.sessionId) process.stdout.write(`session: ${result.sessionId}\n`);
+  if (Array.isArray(result.touchedFiles)) process.stdout.write(`working tree entries: ${result.touchedFiles.length}\n`);
+  process.stdout.write(`result: ${resultPath}\n`);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief) fail("brief is empty");
+  if (!existsSync(opts.cd)) fail(`working directory not found: ${opts.cd}`);
+
+  const run = prepareRun(opts, brief);
+  const beforeStatus = gitStatus(opts.cd);
+  const version = grokVersion();
+  if (!version) {
+    const result = writeResult(opts, run, null, {
+      status: "grok_unavailable", exitCode: 127, signal: null, sessionId: null,
+      finalMessage: "", touchedFiles: beforeStatus,
+    });
+    printSummary(result, run.resultPath);
+    process.stderr.write("relay: `grok` not found on PATH. Install Grok Build and run `grok login`.\n");
+    process.exit(127);
+  }
+
+  const child = spawn("grok", buildArgs(opts, brief), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
+
+  let sessionId = opts.session || null;
+  let finalMessage = "";
+  let settled = false;
+  const scanner = makeLineScanner(line => {
+    appendFileSync(run.eventsPath, `${line}\n`, "utf8");
+    try {
+      const event = JSON.parse(line);
+      sessionId ||= findString(event, ["sessionId", "session_id"]);
+      const text = extractText(event);
+      if (text) finalMessage = text;
+    } catch {
+      // Preserve unknown/non-JSON output in events.jsonl; schema changes remain diagnosable.
+    }
+  });
+  child.stdout.on("data", chunk => scanner.push(chunk.toString("utf8")));
+  child.stderr.on("data", chunk => appendFileSync(run.stderrPath, chunk.toString("utf8"), "utf8"));
+
+  child.on("error", error => {
+    if (settled) return;
+    settled = true;
+    const result = writeResult(opts, run, version, {
+      status: "failed", exitCode: 1, signal: null, sessionId, finalMessage,
+      touchedFiles: gitStatus(opts.cd), error: error.message,
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    scanner.flush();
+    const afterStatus = gitStatus(opts.cd);
+    const readOnlyViolation = opts.readOnly && beforeStatus !== null && afterStatus !== null
+      && JSON.stringify(beforeStatus) !== JSON.stringify(afterStatus);
+    if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
+    else writeFileSync(run.finalPath, "", "utf8");
+    const exitCode = code ?? (signal && constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const result = writeResult(opts, run, version, {
+      status: exitCode === 0 && !readOnlyViolation ? "completed" : "failed",
+      exitCode: readOnlyViolation && exitCode === 0 ? 3 : exitCode,
+      signal: signal || null,
+      sessionId,
+      finalMessage,
+      touchedFiles: afterStatus,
+      readOnlyViolation,
+      error: readOnlyViolation ? "read-only run changed the git working-tree status" : undefined,
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a third delegate skill, `grok-delegate`, that drives Grok Build through its documented headless scripting interface while preserving the repository's existing reviewer-owned landing model:

`brief → dispatch → structured result → independent review → corrective resume → orchestrator commit`

## What is included

- `skills/grok-delegate/SKILL.md`
- A dependency-free `scripts/relay.mjs` that:
  - invokes `grok` with `--no-auto-update` and `--output-format streaming-json`
  - supports model, effort, maximum turns, session resume, and continue-last
  - defaults implementation runs to `--always-approve` so unattended execution cannot block on a permission prompt
  - provides a guarded `--read-only` mode using disallowed write/edit tools, no auto-approval, explicit non-mutation rules, and before/after git-status detection
  - stores the exact brief, raw event stream, stderr, final message, and stable `delegate-relay.result.v1` result
  - records missing-binary, non-zero exit, and signal outcomes
  - never commits or pushes
- Four references matching the existing skill layout:
  - writing the brief
  - dispatch and result contract
  - review and landing
  - multi-task queues
- Minimal README updates for installation, requirements, trust posture, and repository shape

## Design notes

- The initial backend deliberately uses the official headless CLI rather than ACP. It keeps the relay small, inspectable, and aligned with the current Codex/OpenCode implementations.
- Raw `streaming-json` is retained even when an event cannot be parsed, so future Grok event-schema changes remain diagnosable instead of silently losing evidence.
- `--read-only` is documented as defense in depth, not as a claim that future Grok tool names or shell behavior are a perfect sandbox. The orchestrator must still inspect the working tree.
- The relay passes the prompt as a direct `spawn` argument, not through shell interpolation on POSIX.

## Source alignment

The feature branch was created directly from the current upstream `master` commit `a3b460502ab99fc29339cd238b03991dda6fb16b` and is currently **0 commits behind upstream**.

## Validation status

- Reviewed against the official xAI Grok Build headless and CLI reference documentation current as of July 2026.
- GitHub comparison confirms the branch is based on the latest upstream merge base and changes only the new skill plus README integration.
- An authenticated end-to-end Grok execution has **not** been claimed. The README and skill explicitly retain that as a required verification step against a concrete installed Grok CLI version.

## Reviewer focus

1. Confirm the Grok CLI argument mapping, especially the `write,edit` built-in tool identifiers used for guarded read-only mode.
2. Validate the event samples from a real `streaming-json` run and adjust final-message/session-id extraction if the installed version emits different field names.
3. Decide whether ACP should remain a future backend rather than expanding the initial contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for delegating bounded coding tasks to Grok Build.
  - Added resumable task execution, correction workflows, read-only review mode, and multi-task queue guidance.
  - Added structured run results and artifacts to support independent review and verification.
  - Added safeguards requiring review, quality checks, and orchestrator-controlled commits.

- **Documentation**
  - Added installation, authentication, usage, troubleshooting, task-brief, and review guidance for Grok delegation.
  - Updated repository documentation with Grok delegate setup and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->