### PR TITLE
Add kimi-delegate skill for the Kimi Code CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Two skills ship today: `codex-delegate` (OpenAI Codex) and `opencode-delegate`
-(OpenCode); siblings like `gemini-delegate` can be added later without renaming the repo.
+and land the result. Three skills ship today: `codex-delegate` (OpenAI Codex), `opencode-delegate`
+(OpenCode), and `kimi-delegate` (Kimi Code); siblings like `gemini-delegate` can be added later without
+renaming the repo.
 
 ## Vocabulary
 
@@ -14,7 +15,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the worker agent (Codex, OpenCode) | "worker", "sub-agent", "executor" |
+| **implementer** | the worker agent (Codex, OpenCode, Kimi) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -22,12 +23,13 @@ jargon. Use these terms; don't invent synonyms.
 | **relay** / `relay.mjs` | the dispatch **script** only | never a *category* of skills |
 | `exec`, `sandbox`, `resume`, `session` | Codex's own terms — use verbatim | don't paraphrase them |
 | `run`, `agent` (`build`/`plan`), `session` | OpenCode's own terms — use verbatim | "sandbox" (OpenCode has no sandbox enum; autonomy is the agent) |
+| `session`, `--continue`, `model alias`, `auto permission mode`, `plan mode`, `--yolo` | Kimi Code's own terms — use verbatim when discussing `kimi` | don't paraphrase them |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
 version-neutral); and claims that can't be verified ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`codex` /
-`opencode`) and the skill's `relay.mjs`.
+`opencode` / `kimi`) and the skill's `relay.mjs`.
 
 ## Conventions
 
@@ -43,18 +45,20 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - **Progressive disclosure:** keep `SKILL.md` lean; push depth into `references/*.md` that load only
   when needed.
 - **Executables:** keep them minimal and inspectable. Today there is one per skill —
-  `skills/codex-delegate/scripts/relay.mjs` and `skills/opencode-delegate/scripts/relay.mjs` — each
-  Node built-ins only, no dependencies, no network calls of its own, no credentials, no telemetry. New
-  scripts must hold the same line, and the README's trust section must stay accurate.
+  `skills/codex-delegate/scripts/relay.mjs`, `skills/opencode-delegate/scripts/relay.mjs`, and
+  `skills/kimi-delegate/scripts/relay.mjs` — each Node built-ins only, no dependencies, no network
+  calls of its own, no credentials, no telemetry. New scripts must hold the same line, and the README's
+  trust section must stay accurate.
 
 ## Before publishing a change
 
 - Validate the package locally: `npx skills add . --list`.
 - Smoke-test any changed script directly (e.g. `node skills/<skill>/scripts/relay.mjs --help`, and a
-  `--read-only` run against a throwaway repo) before relying on it.
+  no-write or read-only run against a throwaway repo) before relying on it.
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
   PowerShell/cmd, not just Git Bash/WSL): both the `codex` and `opencode` launches need `shell:true` on
-  win32 to resolve the `.cmd` shim.
+  win32 to resolve the `.cmd` shim; `kimi` uses a native binary and still needs its own native Windows
+  smoke before claiming support.
 - Keep the README's "Verification status" honest — claim only what's been run.
 
 ## Local Claude Code config

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, hands it to an implementer CLI, then reviews the diff and
 commits — staying the reviewer the whole way.
 
-Two skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, and **`opencode-delegate`**
-drives the OpenCode CLI. Same loop, different implementer.
+Three skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, **`opencode-delegate`**
+drives the OpenCode CLI, and **`kimi-delegate`** drives the Kimi Code CLI. Same loop, different
+implementer.
 
 ## Install
 
@@ -23,6 +24,7 @@ Install the package, or just one skill:
 npx skills add amElnagdy/delegate-skills
 npx skills add amElnagdy/delegate-skills --skill codex-delegate
 npx skills add amElnagdy/delegate-skills --skill opencode-delegate
+npx skills add amElnagdy/delegate-skills --skill kimi-delegate
 ```
 
 Install for a specific agent, or globally:
@@ -47,6 +49,7 @@ The loop:
 ```text
 Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
 Use $codex-delegate to run this queue of migration tasks through Codex while I review each one.
+Use $kimi-delegate to have Kimi implement the UI cleanup, then review and commit it.
 ```
 
 ## How this differs from the OpenAI Codex plugin
@@ -89,6 +92,16 @@ quoting.
 **You'll feel it when:** a bounded task gets handed to OpenCode, comes back as a clean diff with a
 structured report and the run's cost, and you commit it after re-running the gates yourself.
 
+### kimi-delegate
+
+Drive the Kimi Code CLI (`kimi`) as a background implementer: write the brief, dispatch via
+`relay.mjs`, review the diff, and commit it yourself. Same four references and loop as the other
+delegate skills. Headless Kimi always uses auto permission mode, so the relay passes no autonomy flags;
+the child cwd pins the workspace, and `touchedFiles` shows what changed.
+
+**You'll feel it when:** a bounded task gets handed to Kimi, comes back as a clean diff with a
+structured report and session id, and you commit it after re-running the gates yourself.
+
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
@@ -100,6 +113,9 @@ Reserved so the umbrella can grow without a rename.
   (`codex login`).
 - For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai) installed and authenticated
   (`opencode auth login`).
+- For `kimi-delegate`: the [`kimi` CLI](https://moonshotai.github.io/kimi-code/en/) installed via
+  Homebrew (`brew install kimi-code`) or the official native installer, and authenticated via
+  `kimi login`.
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -111,9 +127,9 @@ This package is intentionally inspectable:
 - All skill content is Markdown, plus exactly **one** executable per skill — each a `scripts/relay.mjs`.
 - Each `relay.mjs` makes no network calls, reads or writes no credentials, sends no telemetry, and has
   no dependencies (Node built-ins only). It shells out only to its implementer CLI (`codex` /
-  `opencode`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the script
-  before you run it.
-- Neither ever commits — committing is always the orchestrator's job, after review.
+  `opencode` / `kimi`) and `git`. That CLI authenticates exactly as you do at the terminal. Read the
+  script before you run it.
+- None ever commits — committing is always the orchestrator's job, after review.
 
 **Verification status:** each relay's mechanics are verified — argument handling, exit codes,
 `result.json`, resume, and (for `opencode-delegate`) the required-model guard, since OpenCode has no safe
@@ -121,6 +137,10 @@ default. The full delegate → review → commit loop is designed for and run on
 formally verified end-to-end here (OpenCode's cold start is slow in constrained shells, so exercise a
 real run in a normal terminal). Other orchestrators (Cursor, …) are designed-for but unproven. This line
 gets upgraded to "verified end-to-end" with evidence, not assumption.
+
+`kimi-delegate`'s relay mechanics are verified against `kimi` 0.24.0 on macOS (headless `-p` edit
+run, stream-json parsing, `--session`/`--continue` resume, unavailable/127); Windows launch is pending
+a native smoke.
 
 ## Repository shape
 
@@ -134,7 +154,15 @@ skills/
 │       ├── dispatch-and-poll.md
 │       ├── review-and-land.md
 │       └── multi-task-queues.md
-└── opencode-delegate/
+├── opencode-delegate/
+│   ├── SKILL.md
+│   ├── scripts/relay.mjs
+│   └── references/
+│       ├── writing-the-brief.md
+│       ├── dispatch-and-poll.md
+│       ├── review-and-land.md
+│       └── multi-task-queues.md
+└── kimi-delegate/
     ├── SKILL.md
     ├── scripts/relay.mjs
     └── references/

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -6,7 +6,8 @@
       "description": "Delegate a coding task to a CLI implementer agent, then review the diff and commit it yourself.",
       "skills": [
         "codex-delegate",
-        "opencode-delegate"
+        "opencode-delegate",
+        "kimi-delegate"
       ]
     }
   ]

--- a/skills/kimi-delegate/SKILL.md
+++ b/skills/kimi-delegate/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: kimi-delegate
+description: >-
+  Delegate a coding task to the Kimi Code CLI (`kimi`) as a background implementer, then review its
+  diff and land it yourself. Use this whenever the user wants to hand implementation work to Kimi -
+  phrasings like "have Kimi implement X", "delegate this to Kimi", "run it through Kimi Code", or
+  "use Kimi to implement/fix/refactor" - or wants to run a queue of coding tasks through Kimi while
+  staying the reviewer. DO NOT USE for tasks small enough to do inline, or when the user wants the code
+  written directly without delegating.
+license: MIT
+metadata:
+  version: 0.1.0
+---
+
+# Kimi Delegate
+
+You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** - the Kimi Code
+CLI - then review what it produced and land it yourself. You write the brief and own the judgment;
+Kimi does the typing in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `kimi` CLI is not installed or authenticated.
+- You need a CLI-enforced read-only implementer. Headless Kimi has no read-only mode.
+
+## Prerequisites (check once)
+
+1. Install Kimi Code with `brew install kimi-code` on macOS/Linux, or use the native installer from
+   the [official Kimi Code documentation](https://moonshotai.github.io/kimi-code/en/).
+2. Authenticate with `kimi login` (device-code flow, no TUI), or use `/login` in the TUI.
+3. Confirm `kimi --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model alias
+
+Kimi uses `default_model` from its `config.toml` when `--model` is omitted. To choose another model
+alias, pass `--model <alias from your kimi config>`. Model aliases are user-defined config keys; use
+one the human has configured rather than inventing one.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Kimi sees only the text you send plus what it can inspect in the workspace - no chat history or shared
+context. Include the goal, current state, what to change, what to leave untouched, the project's
+**actual** gates, and a report contract. Tell Kimi not to commit. Keep one task per brief. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled helper. It wraps Kimi's headless prompt mode, captures the structured event stream,
+and writes `result.json`. (`<skill-dir>` is the installed folder containing this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a configured model alias:       add --model <alias from your kimi config>
+# resume the most recent session:        add --resume-last  (delta brief only)
+# resume a specific session:             add --session <id> (delta brief only)
+# see all options:                       node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. Use repeatable `--add-dir` flags only for extra workspace
+directories. The relay writes artifacts under the system temp dir by default and never commits. See
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Kimi finishes. Run it with the orchestrator's background-command facility, or
+background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `kimi` exits 127 and writes `status: "kimi_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process exited
+and `result.json` exists.
+
+### 4. Review - do not trust the self-report
+
+Treat Kimi's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates pass
+and the diff holds. If rework is needed, send a delta brief with `--resume-last` or `--session <id>`,
+then review again.
+
+## Autonomy and permissions
+
+In headless `-p` mode, Kimi always runs in **auto permission mode** and never asks for approval. Kimi
+rejects `--prompt` combined with `--yolo`, `--auto`, or `--plan`, so the relay passes none of them and
+offers no `--read-only` or `--full-access` option. There is no CLI-enforced read-only mode: inspect
+`touchedFiles` and the diff after every run. That diff, not a flag, is the guarantee of what changed.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't absorb**
+(report Kimi's design decisions, defensible-but-unasked turns, and non-blocking nitpicks) and **stop
+for scope changes** (if correct completion needs going beyond the brief, ask instead of expanding the
+mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, report contract,
+  real gates, argv delivery, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist, commit boundary,
+  and rework through Kimi sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues, constraint
+  carry-forward, progress tracking, and the final coherence pass.

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -30,7 +30,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | `--model <alias>` | Kimi model alias for this run (default: Kimi's own `default_model`). |
 | `--session <id>` | Resume a specific Kimi session; send only the delta brief. |
 | `--resume-last` | Resume the most recent Kimi session for this cwd (`kimi --continue`); send only the delta brief. |
-| `--add-dir <dir>` | Add an extra workspace directory. Repeatable. |
+| `--add-dir <dir>` | Add an extra workspace directory. Repeatable. Edits there are not reported in `touchedFiles`. |
 | `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Kimi has no timeout flag. |
 | `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
 | `-h`, `--help` | Print the relay's header help. |
@@ -44,7 +44,8 @@ Headless `-p` mode always uses Kimi's auto permission mode. Kimi rejects `--prom
 
 ## Artifacts and result fields
 
-Artifacts live outside the repo by default, so the relay itself never shows up in `touchedFiles`:
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an `--out-dir`
+inside the worktree can make the artifacts appear there:
 
 - `brief.txt` - the exact brief.
 - `events.jsonl` - raw Kimi stdout events.
@@ -61,10 +62,11 @@ Artifacts live outside the repo by default, so the relay itself never shows up i
 - `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
 - `finalMessage` - assistant `content` strings joined with `"\n\n"`; tool calls and tool results are
   excluded.
-- `touchedFiles` - `git status --porcelain` lines for the **final working tree**, not an attribution
-  of Kimi's edits: anything already dirty before dispatch shows up too. Dispatch from a clean tree
-  when you want the list to read as "what Kimi changed". `null` means git could not report; `[]`
-  means git ran and the tree is clean.
+- `touchedFiles` - `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of Kimi's edits: anything already dirty before dispatch shows up too, and edits
+  Kimi makes inside `--add-dir` workspaces do not show up at all - inspect those trees yourself.
+  Dispatch from a clean tree when you want the list to read as "what Kimi changed". `null` means git
+  could not report; `[]` means git ran and the tree is clean.
 - `stderrTail` - the last 20 non-empty stderr lines on failure.
 - `error` - present for launch failures or when the relay watchdog fires.
 

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -44,7 +44,7 @@ Headless `-p` mode always uses Kimi's auto permission mode. Kimi rejects `--prom
 
 ## Artifacts and result fields
 
-Artifacts live outside the repo by default, keeping `touchedFiles` limited to implementer edits:
+Artifacts live outside the repo by default, so the relay itself never shows up in `touchedFiles`:
 
 - `brief.txt` - the exact brief.
 - `events.jsonl` - raw Kimi stdout events.
@@ -61,8 +61,10 @@ Artifacts live outside the repo by default, keeping `touchedFiles` limited to im
 - `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
 - `finalMessage` - assistant `content` strings joined with `"\n\n"`; tool calls and tool results are
   excluded.
-- `touchedFiles` - `git status --porcelain` lines. `null` means git could not report; `[]` means git
-  ran and the tree is clean.
+- `touchedFiles` - `git status --porcelain` lines for the **final working tree**, not an attribution
+  of Kimi's edits: anything already dirty before dispatch shows up too. Dispatch from a clean tree
+  when you want the list to read as "what Kimi changed". `null` means git could not report; `[]`
+  means git ran and the tree is clean.
 - `stderrTail` - the last 20 non-empty stderr lines on failure.
 - `error` - present for launch failures or when the relay watchdog fires.
 

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,110 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps Kimi's headless prompt mode, captures its structured stream, and writes a
+`result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v kimi
+kimi --version
+kimi login
+```
+
+Install with `brew install kimi-code` on macOS/Linux or use a native installer from the
+[official Kimi Code documentation](https://moonshotai.github.io/kimi-code/en/). `kimi login` uses a
+device-code flow without opening the TUI; `/login` is also available inside the TUI.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--model <alias>` | Kimi model alias for this run (default: Kimi's own `default_model`). |
+| `--session <id>` | Resume a specific Kimi session; send only the delta brief. |
+| `--resume-last` | Resume the most recent Kimi session for this cwd (`kimi --continue`); send only the delta brief. |
+| `--add-dir <dir>` | Add an extra workspace directory. Repeatable. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Kimi has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The child cwd pins the primary workspace;
+`--add-dir` adds extra workspaces only.
+
+Headless `-p` mode always uses Kimi's auto permission mode. Kimi rejects `--prompt` combined with
+`--yolo`, `--auto`, or `--plan`, so the relay passes no autonomy flags and has no `--read-only` or
+`--full-access` option. Inspect `touchedFiles` and the diff after every run.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, keeping `touchedFiles` limited to implementer edits:
+
+- `brief.txt` - the exact brief.
+- `events.jsonl` - raw Kimi stdout events.
+- `final.txt` - assistant text joined with a blank line between chunks; absent if none was emitted.
+- `stderr.txt` - complete stderr.
+- `result.json` - the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"kimi"`), `status` (`completed` | `failed` | `kimi_unavailable`), `exitCode`, and
+  `signal` (`null` unless the child died on a signal).
+- `workdir`, `model` (the model alias or `null`), `resumed`, `kimiVersion`, `sessionId`, `startedAt`,
+  and `finishedAt`.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `finalMessage` - assistant `content` strings joined with `"\n\n"`; tool calls and tool results are
+  excluded.
+- `touchedFiles` - `git status --porcelain` lines. `null` means git could not report; `[]` means git
+  ran and the tree is clean.
+- `stderrTail` - the last 20 non-empty stderr lines on failure.
+- `error` - present for launch failures or when the relay watchdog fires.
+
+Kimi's stream carries no token usage, so `result.json` has no `usage` field.
+
+## Waiting for completion
+
+The helper blocks. Use the orchestrator's background-command facility, or background it in a shell and
+poll for `result.json`. The run is done only when the process exits and the file contains a `status`.
+
+A pre-run usage error exits 2 and writes no result. A missing `kimi` exits 127 and writes
+`status: "kimi_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "kimi_unavailable"` (exit 127):** install the native Kimi Code CLI, authenticate with
+  `kimi login`, and re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. A common
+  cause is an unconfigured model alias: `error: failed to run prompt: config.invalid: Model "<x>" is not configured in config.toml…`
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through the
+  OOM killer or a supervisor timeout. This is not a Kimi error; check host memory and re-dispatch, or
+  split the task into smaller briefs.
+- **Watchdog failure:** `error` reads
+  `kimi did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout` or
+  split the task. The relay sends SIGTERM, waits 10 seconds, then sends SIGKILL if needed.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## What the relay runs
+
+The argv is equivalent to:
+
+```bash
+kimi --output-format stream-json [--model <alias>] [--session <id> | --continue] \
+  [--add-dir <dir> ...] --prompt=<brief>
+```
+
+The prompt rides argv and is visible in the host process list. The relay rejects briefs over 120 KB
+before launch because the OS caps a single argument. It spawns the native `kimi` binary directly with
+the selected `--cd` as cwd; no shell or Kimi timeout flag is involved.
+
+## The commit boundary
+
+The relay never commits. Kimi edits the working tree; the orchestrator reviews, re-runs the gates, and
+commits. See [review-and-land.md](review-and-land.md).

--- a/skills/kimi-delegate/references/multi-task-queues.md
+++ b/skills/kimi-delegate/references/multi-task-queues.md
@@ -1,0 +1,58 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is the
+default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh Kimi sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture location,
+or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed Kimi session only for rework on the same task. Send a delta brief with `--resume-last`,
+or with `--session <id>` from that task's `result.json`. Start unrelated queue items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** - queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** - what landed, what you verified, and gate outcomes.
+- **Needs your eyes** - design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** - the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/kimi-delegate/references/review-and-land.md
+++ b/skills/kimi-delegate/references/review-and-land.md
@@ -1,0 +1,81 @@
+# Review and land
+
+Kimi did the typing; you own the judgment. Verify against reality, never the self-report, and read the
+diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries Kimi's claims, not evidence. Re-run the project's actual test, lint, and build
+commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** - changes the brief excluded.
+- **Scope shortfall** - missed behavior, edges, or cleanup.
+- **Quiet judgment calls** - defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to Kimi as a delta brief, or fix it in the tree, and report either choice
+to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer. Write a
+clear message describing what landed.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json`. Kimi itself
+rejects combining `--continue` and `--session`; the relay rejects `--resume-last` plus `--session`
+before launch. Rework gets the same gate rerun, test review, diff review, and implementer sweep.
+
+Headless Kimi always uses auto permission mode and has no CLI-enforced read-only mode. Confirm
+`touchedFiles` after every fresh or resumed run.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep them
+in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/kimi-delegate/references/writing-the-brief.md
+++ b/skills/kimi-delegate/references/writing-the-brief.md
@@ -1,0 +1,123 @@
+# Writing the brief
+
+A brief is the entire task as Kimi will see it. It runs in a separate session with **no memory of your
+conversation, no access to prior notes, and no shared context** - only the text you send and whatever
+it can inspect in the workspace. If a constraint is not in the brief or discoverable in the repo, it
+does not exist for Kimi.
+
+## Model choice and resumed sessions
+
+Kimi uses `default_model` from its `config.toml`, so a fresh dispatch does not require `--model`. Pass
+`--model <alias from your kimi config>` only when the human wants one of their configured model
+aliases. Do not invent an alias.
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report Kimi must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** - add `<completeness_contract>` (resolve fully, not just the first
+  plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is unknown).
+- **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences, and
+  open questions).
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from assistant text in Kimi's structured stream. Without a closing
+summary, the edits may exist but the result is hard to review. The `<structured_output_contract>`
+block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy the
+actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Kimi can inspect the workspace, but the important
+constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one Kimi run -> one reviewed commit keeps the diff and rollback
+clean. Split mixed implementation, review, documentation, and roadmap requests into separate
+dispatches.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Argv delivery limits
+
+Kimi headless mode requires the brief as a command-line argument. The relay reads a file or stdin for
+convenience, then passes the text with `--prompt=<brief>`. The equals form binds a brief that starts
+with `-` instead of treating it as another flag.
+
+This has two consequences:
+
+- The brief is visible in the host process list (`ps`, `/proc`). Keep secrets out of it on shared
+  machines; reference workspace files or environment variables instead.
+- A brief over 120 KB is rejected before launch because operating systems cap a single argv value.
+  Put large context in the workspace and tell Kimi which file to read.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -66,6 +66,7 @@ import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
 
@@ -311,16 +312,21 @@ function dispatchToKimi(opts, brief, run, writeResult) {
     }
   });
 
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
   child.stdout.on("data", (chunk) => {
-    const text = chunk.toString();
-    appendFileSync(run.eventsPath, text, "utf8");
-    scan(text);
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
   });
 
   child.stderr.on("data", (chunk) => {
-    const text = chunk.toString();
-    process.stderr.write(text);
-    appendFileSync(run.stderrPath, text, "utf8");
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
     for (const line of text.split("\n")) {
       if (line.trim()) stderrTail.push(line.trimEnd());
     }

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -104,7 +104,7 @@ function parseArgs(argv) {
       case "--model": opts.model = next(); break;
       case "--session": opts.session = next(); break;
       case "--resume-last": opts.resumeLast = true; break;
-      case "--add-dir": opts.addDirs.push(resolve(next())); break;
+      case "--add-dir": opts.addDirs.push(next()); break;
       case "--timeout": opts.timeout = next(); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
@@ -113,6 +113,15 @@ function parseArgs(argv) {
   }
   if (opts.resumeLast && opts.session) {
     fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  // kimi resolves a relative --add-dir against ITS cwd, so resolve against --cd
+  // (not the relay's own cwd) - and only after the loop, since --add-dir may
+  // appear before --cd on the command line. resolve() passes absolutes through.
+  opts.addDirs = opts.addDirs.map((dir) => resolve(opts.cd, dir));
+  // The watchdog is relay-only (kimi has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent 30m fallback would be wrong.
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
   }
   return opts;
 }
@@ -155,15 +164,10 @@ function kimiVersion() {
 }
 
 function parseDuration(duration) {
-  let milliseconds = 0;
-  let matched = false;
-  for (const match of duration.matchAll(/(\d+)h|(\d+)m|(\d+)s/g)) {
-    matched = true;
-    if (match[1]) milliseconds += Number(match[1]) * 60 * 60 * 1000;
-    if (match[2]) milliseconds += Number(match[2]) * 60 * 1000;
-    if (match[3]) milliseconds += Number(match[3]) * 1000;
-  }
-  return matched ? milliseconds : null;
+  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
 function gitTouchedFiles(cwd) {
@@ -369,15 +373,19 @@ function dispatchToKimi(opts, brief, run, writeResult) {
     settled = true;
     clearTimeout(watchdogTimer);
     if (sigkillTimer) clearTimeout(sigkillTimer);
-    const exitCode = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    // A timed-out run is failed even if kimi handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
     const result = writeResult({
-      status: code === 0 ? "completed" : "failed",
+      status: succeeded ? "completed" : "failed",
       exitCode,
       signal: signal ?? null,
       sessionId,
       finalMessage: assembleFinal(),
       touchedFiles: gitTouchedFiles(opts.cd),
-      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `kimi did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
     });
     printSummary(result, run.resultPath);

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -1,0 +1,441 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · kimi-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Kimi Code CLI (`kimi -p`), capture
+ * the run, and write a structured result the orchestrating agent can review.
+ * The orchestrator runs this one command and reads the result JSON - every
+ * Kimi-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against kimi CLI 0.24.0 on macOS.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `kimi` and `git`. The `kimi` process it launches
+ * does authenticate - exactly as you do at the terminal. Read this file before
+ * you run it.
+ *
+ * Note: `kimi -p` takes the prompt as a command-line argument, so the brief is
+ * visible in the host process list (`ps`, /proc). On a shared machine keep
+ * secrets out of the brief - reference them by a path or environment variable
+ * the workspace can read.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * - after it reviews the diff and re-runs the project gates.
+ *
+ * Headless `-p` mode always uses Kimi's auto permission mode. Kimi rejects
+ * `--yolo`, `--auto`, and `--plan` when combined with `--prompt`, so this relay
+ * passes no autonomy flags and offers no read-only mode. The diff reported in
+ * `touchedFiles`, not a flag, is the guarantee of what changed.
+ *
+ * Kimi's supported Homebrew and official-installer distributions provide a
+ * native binary on every platform. The npm-installed `kimi` on Windows is a
+ * `.cmd` shim this relay does not launch; use the native install there.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for Kimi (default: current directory).
+ *   --model <alias>         Kimi model alias (default: Kimi's own default_model).
+ *   --session <id>          Resume a specific Kimi session; send only the delta brief.
+ *   --resume-last           Resume the most recent Kimi session for this cwd;
+ *                           send only the delta brief.
+ *   --add-dir <dir>         Add an extra workspace directory. Repeatable.
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). Kimi has no
+ *                           timeout flag; durations use h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout -
+ *   status, exitCode, signal, kimiVersion, sessionId, finalMessage (Kimi's own
+ *   report), touchedFiles (git porcelain, null if git cannot report), and paths
+ *   to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `kimi` binary exits 127;
+ * otherwise the exit code mirrors Kimi's own (0 success, non-zero failure). If
+ * the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome - completed, failed, or kimi_unavailable.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { constants, tmpdir } from "node:os";
+
+const DEFAULT_TIMEOUT = "30m";
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    session: null,
+    resumeLast: false,
+    addDirs: [],
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--add-dir": opts.addDirs.push(resolve(next())); break;
+      case "--timeout": opts.timeout = next(); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to kimi -p\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function kimiVersion() {
+  try {
+    const out = execFileSync("kimi", ["--version"], { encoding: "utf8" }).trim();
+    return out || "unknown";
+  } catch (err) {
+    // Only a missing binary means "unavailable"; any other version-probe
+    // failure must not masquerade as exit 127.
+    if (err && err.code === "ENOENT") return null;
+    return "unknown";
+  }
+}
+
+function parseDuration(duration) {
+  let milliseconds = 0;
+  let matched = false;
+  for (const match of duration.matchAll(/(\d+)h|(\d+)m|(\d+)s/g)) {
+    matched = true;
+    if (match[1]) milliseconds += Number(match[1]) * 60 * 60 * 1000;
+    if (match[2]) milliseconds += Number(match[2]) * 60 * 1000;
+    if (match[3]) milliseconds += Number(match[3]) * 1000;
+  }
+  return matched ? milliseconds : null;
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git cannot report - git missing, or a non-repo run - so
+  // the caller can tell "git unavailable" apart from "Kimi changed nothing."
+  // [] means git ran and the working tree is clean.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, brief) {
+  const argv = ["--output-format", "stream-json"];
+  if (opts.model) argv.push("-m", opts.model);
+  if (opts.session) argv.push("--session", opts.session);
+  else if (opts.resumeLast) argv.push("--continue");
+  for (const dir of opts.addDirs) argv.push("--add-dir", dir);
+  // Use --prompt=<brief>, not a separate ["--prompt", brief] pair: the equals
+  // form binds a brief that starts with "-" instead of letting it parse as a flag.
+  argv.push(`--prompt=${brief}`);
+  return argv;
+}
+
+function makeEventScanner(onObject) {
+  // stream-json is newline-delimited JSON, but this brace-aware scan also
+  // tolerates junk prefixes and concatenated objects if the format drifts.
+  let buf = "";
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    buf += chunk;
+    for (let i = 0; i < buf.length; i += 1) {
+      const ch = buf[i];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (ch === "\\") escaped = true;
+        else if (ch === '"') inString = false;
+        continue;
+      }
+      if (ch === '"') { if (depth > 0) inString = true; continue; }
+      if (ch === "{") {
+        if (depth === 0) start = i;
+        depth += 1;
+      } else if (ch === "}") {
+        if (depth > 0) {
+          depth -= 1;
+          if (depth === 0 && start !== -1) {
+            const slice = buf.slice(start, i + 1);
+            try { onObject(JSON.parse(slice)); } catch { /* ignore non-objects */ }
+            start = -1;
+          }
+        }
+      }
+    }
+    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
+    start = -1;
+    depth = 0;
+    inString = false;
+    escaped = false;
+  };
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "kimi",
+      workdir: opts.cd,
+      model: opts.model,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      kimiVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "kimi_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `kimi` not found on PATH. Install Kimi Code and run `kimi login`.\n");
+  process.exit(127);
+}
+
+function dispatchToKimi(opts, brief, run, writeResult) {
+  const child = spawn("kimi", buildArgv(opts, brief), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let sessionId = null;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (event.role === "assistant" && typeof event.content === "string") {
+      textChunks.push(event.content);
+    }
+    if (event.role === "meta" && event.type === "session.resume_hint" && typeof event.session_id === "string") {
+      sessionId = event.session_id;
+    }
+  });
+
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    appendFileSync(run.eventsPath, text, "utf8");
+    scan(text);
+  });
+
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    process.stderr.write(text);
+    appendFileSync(run.stderrPath, text, "utf8");
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    child.kill("SIGTERM");
+    sigkillTimer = setTimeout(() => {
+      if (!settled) child.kill("SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    const exitCode = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const result = writeResult({
+      status: code === 0 ? "completed" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `kimi did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // kimi --prompt takes the prompt as a CLI argument, so the brief rides argv.
+  // The OS caps one argument (~128KB on Linux via MAX_ARG_STRLEN); reject a
+  // huge brief early instead of allowing an opaque E2BIG spawn failure.
+  const briefBytes = Buffer.byteLength(brief, "utf8");
+  const MAX_BRIEF_BYTES = 120 * 1024;
+  if (briefBytes > MAX_BRIEF_BYTES) {
+    fail(`brief is ${Math.round(briefBytes / 1024)}KB; kimi passes the prompt as a CLI argument, which the OS caps (~128KB on Linux). Trim it, or have kimi read large context from the workspace instead of inlining it.`);
+  }
+
+  const version = kimiVersion();
+  const run = prepareRunDir(opts, brief);
+  const writeResult = makeResultWriter(opts, version, run);
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  dispatchToKimi(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  kimi ${result.kimiVersion ?? "?"}`);
+  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a kimi error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- kimi final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds **`kimi-delegate`**, a delegation skill driving the [Kimi Code CLI](https://moonshotai.github.io/kimi-code/en/) (`kimi`) as a background implementer — same loop as the other delegate skills: write brief → dispatch via `relay.mjs` → review the diff → land it yourself.

## What's included

- `skills/kimi-delegate/SKILL.md` — frontmatter + 5-step loop + permission/authorization model
- `skills/kimi-delegate/scripts/relay.mjs` — Node built-ins only; shells out to `kimi` + `git`; never commits
- Four references: writing-the-brief, dispatch-and-poll, review-and-land, multi-task-queues
- `README.md` + `AGENTS.md` + `skills.sh.json` registration (skill entry, requirements, repo shape, trust/verification, vocabulary row for Kimi Code's own terms)

## Autonomy / permission model

Headless `kimi -p` always runs in Kimi's **auto permission mode** and rejects `--yolo`/`--auto`/`--plan` outright, so the relay passes no autonomy flags and offers no read-only pretense. The skill says it plainly: there is no CLI-enforced read-only mode headlessly — `touchedFiles` and the diff, not a flag, are the guarantee.

## Relay details

- Brief delivered as `--prompt=<brief>` (equals form, so a dash-leading brief can't parse as a flag), with an argv size guard and a process-list-visibility note.
- `--output-format stream-json` parsed with a brace-aware scanner; `finalMessage` assembles the assistant text events; `sessionId` comes from the stream's `session.resume_hint` meta event. Kimi's stream carries no token usage, and the docs say so.
- `--resume-last` maps to `kimi --continue`; `--session <id>` resumes a specific session; mutually exclusive pre-run.
- Kimi has no timeout flag, so the relay ships its own `--timeout` watchdog (default 30m; SIGTERM → 10s → SIGKILL, captured pipes closed so an orphaned grandchild can't hold `close` open).
- Full hardening set from the sibling relays baked in from day one: TTY fail-fast on stdin, settle-once child handlers, signal surfacing (`signal` field, 128+signal-number exit codes, host-killed hint), ENOENT-only `kimi_unavailable`/127.
- Native-binary launch (no `shell:true` anywhere); the npm `.cmd` shim on Windows is documented as unsupported pending a native Windows smoke.

## Verification (macOS, `kimi` 0.24.0)

- **Live end-to-end through the relay:** a headless edit run created the requested file (`status: completed`, correct `touchedFiles`, session id captured), and a `--resume-last` delta run continued the same session (`resumed: true`, same session id, edit applied).
- Deterministic paths: every usage error (empty brief, TTY stdin, resume-flag conflict, unknown flag, oversized brief) exits 2 with no result file; stripped PATH → `kimi_unavailable`/127; a SIGKILLed child reports `exitCode 137, signal SIGKILL` with the hint; the watchdog killed a wedged stub at its configured timeout (`exit 143, SIGTERM`, watchdog error recorded); captured real event streams reproduce byte-for-byte through the scanner.
- Grounded against the real CLI: flag-conflict rejections, unconfigured-model failure mode, `--continue`/`--session` semantics, and headless auto-mode tree writes were all probed live before the relay was written.
- **Pending:** a native Windows launch smoke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `kimi-delegate` as a new delegate skill for Kimi-based implementation, including structured relay results, timeout handling, and touched-file detection.
  * Supports safe sequential execution of multi-task queues with per-task review and orchestrator-led commit/gates.
* **Documentation**
  * Added and expanded `kimi-delegate` documentation (setup, requirements, brief writing, dispatch & polling, review/land, and multi-task queues).
  * Updated trust/validation and repository layout listings to include `kimi-delegate`, with macOS verification notes.
* **Chores**
  * Updated `AGENTS.md`, including updated Windows smoke-test guidance for the new delegate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->