### PR TITLE
README: five-skill refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, hands it to an implementer CLI, then reviews the diff and
 commits — staying the reviewer the whole way.
 
-Five skills ship today: **`codex-delegate`** drives the OpenAI Codex CLI, **`opencode-delegate`**
-drives the OpenCode CLI, **`agy-delegate`** drives the Google Antigravity CLI, **`grok-delegate`**
-drives the Grok Build CLI, and **`kimi-delegate`** drives the Kimi Code CLI. Same loop, different
-implementer.
+Five skills ship today — same loop, different implementer:
+
+| Skill | Drives | Autonomy | Resume |
+| --- | --- | --- | --- |
+| `codex-delegate` | [OpenAI Codex CLI](https://github.com/openai/codex) | Codex `--sandbox` enum (`workspace-write` default) | `--resume-last` |
+| `opencode-delegate` | [OpenCode CLI](https://opencode.ai) | agent: `build` (write) / `plan` (read-only) | `--resume-last`, `--session <id>` |
+| `agy-delegate` | Google Antigravity CLI (`agy`) | Antigravity's own permission policy; bypass is opt-in | `--resume-last`, `--conversation <id>` |
+| `grok-delegate` | Grok Build CLI (`grok`) | explicit: default workspace-scoped, `--read-only` best-effort with violation detection, `--full-access` opt-in | `--resume-last`, `--session <id>` |
+| `kimi-delegate` | Kimi Code CLI (`kimi`) | headless runs always use Kimi's auto permission mode | `--resume-last`, `--session <id>` |
 
 ## Install
 
@@ -19,15 +24,11 @@ Browse first:
 npx skills add amElnagdy/delegate-skills --list
 ```
 
-Install the package, or just one skill:
+Install the package, or just one skill (any name from the table above):
 
 ```bash
 npx skills add amElnagdy/delegate-skills
 npx skills add amElnagdy/delegate-skills --skill codex-delegate
-npx skills add amElnagdy/delegate-skills --skill opencode-delegate
-npx skills add amElnagdy/delegate-skills --skill agy-delegate
-npx skills add amElnagdy/delegate-skills --skill grok-delegate
-npx skills add amElnagdy/delegate-skills --skill kimi-delegate
 ```
 
 Install for a specific agent, or globally:
@@ -51,16 +52,62 @@ The loop:
 
 ```text
 Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
+Use $kimi-delegate to have Kimi implement the UI cleanup, then review and commit it.
 Use $codex-delegate to run this queue of migration tasks through Codex while I review each one.
-Use $agy-delegate to have Antigravity implement the UI cleanup, then review and commit it.
-Use $kimi-delegate to have Kimi implement the login-form refactor, then review and commit it.
 ```
+
+Every relay speaks the same `delegate-relay.result.v1` contract: `status`, `exitCode`, `signal`
+(with a host-killed hint when the OOM killer ends a run), the implementer's own final report,
+`touchedFiles`, and a session/conversation id for delta briefs. Learn the loop once, swap the
+implementer freely.
+
+## The skills
+
+### codex-delegate
+
+Drive the OpenAI Codex CLI as a background implementer. Ships four references (writing the brief,
+dispatch/poll, review/land, multi-task queues) loaded only when needed, and one small helper script.
+
+**You'll feel it when:** a bounded task — a migration, a mechanical refactor, a removal sweep — gets
+handed to Codex, comes back as a clean diff with a structured report, and you commit it after re-running
+the gates yourself instead of typing it all by hand.
+
+### opencode-delegate
+
+Same loop for the OpenCode CLI. Autonomy is set by the **agent** rather than a sandbox enum — `build`
+(write-capable) by default, `plan` (read-only) for review/diagnosis — and the brief is piped to
+`opencode run` on stdin so multi-line XML briefs need no quoting. `--model` is required: OpenCode has
+no safe default, so you name a model you actually pay for.
+
+### agy-delegate
+
+Same loop for the Google Antigravity CLI (`agy`). Fresh runs start a new Antigravity project and
+explicitly add the target repo as the workspace; Antigravity's permission bypass
+(`--dangerously-skip-permissions`) is opt-in, never the default, and combining it with `--sandbox`
+must be treated as full access.
+
+### grok-delegate
+
+Same loop for the Grok Build CLI. Autonomy is always set explicitly because Grok's headless default
+would hang a pipe: workspace-scoped by default, `--full-access` as the opt-in, and `--read-only` as
+**best-effort** — Grok cannot be prevented from writing headlessly, so the relay snapshots the tree
+and flags `readOnlyViolation: true` when a read-only run wrote anyway.
+
+### kimi-delegate
+
+Same loop for the Kimi Code CLI (`kimi`). Headless `kimi -p` always runs in Kimi's auto permission
+mode (it rejects `--yolo`/`--auto`/`--plan` outright), so the skill is blunt about it: there is no
+CLI-enforced read-only mode — `touchedFiles` and the diff, not a flag, are the guarantee.
+
+### gemini-delegate
+
+*Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
+Reserved so the umbrella can grow without a rename.
 
 ## How this differs from the OpenAI Codex plugin
 
-The official openai-codex Claude Code plugin is excellent and
-**complementary** — this skill builds on the same `codex` CLI, it doesn't replace the plugin. They
-point in different directions:
+The official openai-codex Claude Code plugin is excellent and **complementary** — `codex-delegate`
+builds on the same `codex` CLI, it doesn't replace the plugin. They point in different directions:
 
 - The plugin's `codex:codex-rescue` agent is a **forwarder**: it hands one task to Codex and returns
   the output. It deliberately does not poll, review, or commit.
@@ -73,78 +120,13 @@ point in different directions:
 If you have the plugin installed, its companion CLI is an optional alternative dispatch backend; the
 bundled `relay.mjs` is the default because it needs nothing but the `codex` binary.
 
-## The skills
-
-### codex-delegate
-
-Drive the OpenAI Codex CLI as a background implementer: write the brief, dispatch via `relay.mjs`,
-review the diff, commit it yourself. Ships four references (writing the brief, dispatch/poll, review/
-land, multi-task queues) loaded only when needed, and one small helper script.
-
-**You'll feel it when:** a bounded task — a migration, a mechanical refactor, a removal sweep — gets
-handed to Codex, comes back as a clean diff with a structured report, and you commit it after re-running
-the gates yourself instead of typing it all by hand.
-
-### opencode-delegate
-
-Drive the OpenCode CLI as a background implementer: write the brief, dispatch via `relay.mjs`, review
-the diff, commit it yourself. Same four references and loop as `codex-delegate`. Autonomy is set by the
-**agent** rather than a sandbox enum — `build` (write-capable) by default, `plan` (read-only) for
-review/diagnosis — and the brief is piped to `opencode run` on stdin so multi-line XML briefs need no
-quoting.
-
-**You'll feel it when:** a bounded task gets handed to OpenCode, comes back as a clean diff with a
-structured report and the run's cost, and you commit it after re-running the gates yourself.
-
-### agy-delegate
-
-Drive the Google Antigravity CLI (`agy`) as a background implementer: write the brief, dispatch via
-`relay.mjs`, review the diff, commit it yourself. Same four references and loop as the other delegate
-skills. Fresh runs start a new Antigravity project and explicitly add the target repo as the workspace;
-Antigravity's permission bypass is opt-in, not the default.
-
-**You'll feel it when:** a bounded task gets handed to Antigravity, comes back as a clean diff with a
-structured report and a conversation id, and you commit it after re-running the gates yourself.
-
-### grok-delegate
-
-Drive the Grok Build CLI (`grok`) as a background implementer: write the brief, dispatch via
-`relay.mjs`, review the diff, commit it yourself. Same four references and loop as the siblings.
-Autonomy is set explicitly because Grok's default is `ask` (which would hang a headless pipe) —
-default is `--always-approve --sandbox workspace`, `--read-only` uses `--sandbox read-only`, and
-`--full-access` is the unrestricted opt-in.
-
-**You'll feel it when:** a bounded task gets handed to Grok Build, comes back as a clean diff with a
-structured report, and you commit it after re-running the gates yourself.
-
-### kimi-delegate
-
-Drive the Kimi Code CLI (`kimi`) as a background implementer: write the brief, dispatch via
-`relay.mjs`, review the diff, and commit it yourself. Same four references and loop as the other
-delegate skills. Headless Kimi always uses auto permission mode, so the relay passes no autonomy flags;
-the child cwd pins the workspace, and `touchedFiles` shows what changed.
-
-**You'll feel it when:** a bounded task gets handed to Kimi, comes back as a clean diff with a
-structured report and session id, and you commit it after re-running the gates yourself.
-
-### gemini-delegate
-
-*Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
-Reserved so the umbrella can grow without a rename.
-
 ## Requirements
 
-- For `codex-delegate`: the [`codex` CLI](https://github.com/openai/codex) installed and authenticated
-  (`codex login`).
-- For `opencode-delegate`: the [`opencode` CLI](https://opencode.ai) installed and authenticated
-  (`opencode auth login`).
-- For `agy-delegate`: the [`agy` CLI](https://antigravity.google/docs/cli/getting-started) installed
-  and authenticated through Antigravity's first-launch setup.
-- For `grok-delegate`: the [`grok` CLI](https://x.ai/cli) (Grok Build) installed and authenticated
-  (`grok login`, or `XAI_API_KEY`; beta access needs an eligible xAI subscription).
-- For `kimi-delegate`: the [`kimi` CLI](https://moonshotai.github.io/kimi-code/en/) installed via
-  Homebrew (`brew install kimi-code`) or the official native installer, and authenticated via
-  `kimi login`.
+- The implementer CLI for the skill you install, authenticated as you would at the terminal:
+  [`codex`](https://github.com/openai/codex) (`codex login`) · [`opencode`](https://opencode.ai)
+  (`opencode auth login`) · `agy` (Antigravity's first-launch setup) ·
+  `grok` (`npm i -g @xai-official/grok`, then `grok login`) ·
+  [`kimi`](https://moonshotai.github.io/kimi-code/en/) (`brew install kimi-code`, then `kimi login`).
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -155,71 +137,34 @@ This package is intentionally inspectable:
 
 - All skill content is Markdown, plus exactly **one** executable per skill — each a `scripts/relay.mjs`.
 - Each `relay.mjs` makes no network calls, reads or writes no credentials, sends no telemetry, and has
-  no dependencies (Node built-ins only). It shells out only to its implementer CLI (`codex` /
-  `opencode` / `agy` / `grok` / `kimi`) and `git`. That CLI authenticates exactly as you do at the
-  terminal. Read the script before you run it.
+  no dependencies (Node built-ins only). It shells out only to its implementer CLI and `git`. That CLI
+  authenticates exactly as you do at the terminal. Read the script before you run it.
 - None of the relays ever commit — committing is always the orchestrator's job, after review.
 
-**Verification status:** each relay's mechanics are verified — argument handling, exit codes,
-`result.json`, resume, and implementer-specific guards. `opencode-delegate` requires `--model`, since
-OpenCode has no safe default. `agy-delegate` is verified end-to-end on macOS against `agy` 1.0.16: a
-headless `agy --print` run edits the working tree, the brief is delivered via `--print=` (never split
-across argv), the workspace is pinned with an absolute `--add-dir`, and `result.json` carries the
-conversation id and touched files; the pre-run brief-size guard and the resume/project
-mutual-exclusion guards are exercised. `grok-delegate` is verified end-to-end on macOS against
-**grok 0.2.101**: a headless run streams `--output-format streaming-json`, the relay reconstructs
-`finalMessage` from the `text` events and the session id + token `usage` from the end event, default
-autonomy (`--always-approve --sandbox workspace`) edits the working tree headlessly, and
-`--resume-last` continues a prior session. **One caveat, confirmed by testing:** `--read-only` is
-*best-effort*, not enforced — grok's read-only sandbox restricts out-of-workspace access, not its own
-edit tool, so a headless run can still write the tree; the relay flags such runs with
-`readOnlyViolation`, and the diff, not the flag, is the guarantee. Windows launch is pending a native
-PowerShell/cmd smoke for both `agy-delegate` and `grok-delegate`. The full delegate → review → commit
-loop is designed for and run on Claude Code but not yet formally verified end-to-end here. Other
-orchestrators (Cursor, …) are designed-for but unproven. This line gets upgraded to "verified
-end-to-end" with evidence, not assumption.
+**Verification status** — claims here are backed by runs, not assumptions:
 
-`kimi-delegate`'s relay mechanics are verified against `kimi` 0.24.0 on macOS (headless `-p` edit
-run, stream-json parsing, `--session`/`--continue` resume, unavailable/127); Windows launch is pending
-a native smoke.
+- Every relay's mechanics are verified: argument handling, exit codes, `result.json`, resume, signal
+  reporting, and the implementer-specific guards.
+- `agy-delegate` — verified end-to-end on macOS against `agy` 1.0.16 (headless edit run, `--print=`
+  delivery, absolute `--add-dir` workspace pin).
+- `grok-delegate` — verified end-to-end on macOS against `grok` 0.2.101 (streaming-json report capture,
+  file-based brief delivery, resume; read-only is best-effort by measurement, hence the violation flag).
+- `kimi-delegate` — verified end-to-end on macOS against `kimi` 0.24.0 (headless `-p` edit run,
+  stream-json parsing, `--session`/`--continue` resume).
+- `opencode-delegate` — requires `--model`, since OpenCode has no safe default.
+- Windows: the codex/opencode launches handle the `.cmd` shim (`shell:true` + quoting); native Windows
+  launch smokes for `agy`/`grok`/`kimi` are still pending.
+- The full delegate → review → commit loop is designed for and run on Claude Code; other orchestrators
+  (Cursor, …) are designed-for but unproven.
 
 ## Repository shape
 
+Every skill has the same shape — a lean `SKILL.md`, four references that load only when needed, and
+one inspectable script:
+
 ```text
 skills/
-├── codex-delegate/
-│   ├── SKILL.md
-│   ├── scripts/relay.mjs
-│   └── references/
-│       ├── writing-the-brief.md
-│       ├── dispatch-and-poll.md
-│       ├── review-and-land.md
-│       └── multi-task-queues.md
-├── opencode-delegate/
-│   ├── SKILL.md
-│   ├── scripts/relay.mjs
-│   └── references/
-│       ├── writing-the-brief.md
-│       ├── dispatch-and-poll.md
-│       ├── review-and-land.md
-│       └── multi-task-queues.md
-├── agy-delegate/
-│   ├── SKILL.md
-│   ├── scripts/relay.mjs
-│   └── references/
-│       ├── writing-the-brief.md
-│       ├── dispatch-and-poll.md
-│       ├── review-and-land.md
-│       └── multi-task-queues.md
-├── grok-delegate/
-│   ├── SKILL.md
-│   ├── scripts/relay.mjs
-│   └── references/
-│       ├── writing-the-brief.md
-│       ├── dispatch-and-poll.md
-│       ├── review-and-land.md
-│       └── multi-task-queues.md
-└── kimi-delegate/
+└── <name>-delegate/
     ├── SKILL.md
     ├── scripts/relay.mjs
     └── references/
@@ -228,8 +173,6 @@ skills/
         ├── review-and-land.md
         └── multi-task-queues.md
 ```
-
-The `SKILL.md` stays small so it loads cheaply; the references load only when the task needs them.
 
 ## License
 


### PR DESCRIPTION
The intro's skill enumeration becomes a comparison table; install collapses to one pattern; per-skill sections keep only what's distinctive; the verification section becomes a per-skill evidence list; the repo-shape tree collapses to the generic subtree all five skills share. Net −57 lines with more information surfaced.