### PR TITLE
codex/opencode relays: decode stdout/stderr across chunk boundaries

### DIFF
--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -56,6 +56,7 @@ import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
 
 const SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 
@@ -262,8 +263,13 @@ function dispatchToCodex(opts, brief, run, writeResult) {
   let stdoutBuf = "";
   const stderrTail = [];
 
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
   child.stdout.on("data", (chunk) => {
-    stdoutBuf += chunk.toString();
+    stdoutBuf += stdoutDecoder.write(chunk);
     let nl;
     while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
       const line = stdoutBuf.slice(0, nl);
@@ -275,8 +281,8 @@ function dispatchToCodex(opts, brief, run, writeResult) {
   });
 
   child.stderr.on("data", (chunk) => {
-    const text = chunk.toString();
-    process.stderr.write(text); // surface Codex progress live for the orchestrator
+    process.stderr.write(chunk); // surface Codex progress live for the orchestrator
+    const text = stderrDecoder.write(chunk);
     for (const line of text.split("\n")) {
       if (line.trim()) stderrTail.push(line.trimEnd());
     }

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -65,6 +65,7 @@ import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -353,15 +354,19 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
     }
   });
 
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
   child.stdout.on("data", (chunk) => {
-    const text = chunk.toString();
-    appendFileSync(run.eventsPath, text, "utf8"); // faithful raw record of the event stream
-    scan(text);
+    appendFileSync(run.eventsPath, chunk); // faithful raw record of the event stream
+    scan(stdoutDecoder.write(chunk));
   });
 
   child.stderr.on("data", (chunk) => {
-    const text = chunk.toString();
-    process.stderr.write(text); // surface OpenCode progress live for the orchestrator
+    process.stderr.write(chunk); // surface OpenCode progress live for the orchestrator
+    const text = stderrDecoder.write(chunk);
     for (const line of text.split("\n")) {
       if (line.trim()) stderrTail.push(line.trimEnd());
     }


### PR DESCRIPTION
Cherry-pick of the boundary-safe UTF-8 decoding that landed for the grok/agy/kimi relays in #13/#14/#17: a multibyte character split between two data events decoded as U+FFFD and corrupted the captured report. In-memory parsing now goes through a StringDecoder per stream; artifact files get raw bytes. (The original commit was pushed to the #15 branch minutes after that PR had already been merged, hence this follow-up.)