### PR TITLE
add `bifrost` delegate agent

### DIFF
--- a/skills/bifrost-delegate/SKILL.md
+++ b/skills/bifrost-delegate/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Bifrost gateway. Use when an orchestrating agent needs a second opinion from Bedrock, NVIDIA, or another
   Bifrost-backed provider while keeping repository edits, gates, and final decisions with the orchestrator.
 license: MIT
-compatibility: Requires Node 18+, a reachable Bifrost gateway, and BIFROST_API_KEY in the environment.
+compatibility: Requires Node 18+ and a reachable Bifrost gateway.
 metadata:
   version: 0.1.0
 ---
@@ -25,14 +25,40 @@ gates, and deciding what to land.
 - `advise` — evaluate an implementation approach, edge cases, and simpler alternatives.
 - `review` — review supplied requirements, diff, and gate results.
 
+## Workflow
+
+1. Inspect the repository and collect only the context needed for the request.
+2. Choose the appropriate mode:
+   - `plan` before a non-trivial implementation.
+   - `advise` when the design or implementation approach is uncertain.
+   - `review` after implementation and project gates.
+3. Prepare a self-contained brief. Do not include credentials or unrelated repository content.
+4. Run the bundled relay script:
+
+   ```bash
+   node "<skill-dir>/scripts/relay.mjs" \
+     --mode "<plan|advise|review>" \
+     --brief "<brief-file>"
+   ```
+
+5. Read `result.json` and `final.txt` from the output directory.
+6. Treat the delegated response as advisory and verify relevant claims against the repository.
+7. Keep repository edits, project commands, gates, commits, and final decisions with the orchestrator.
+
+For a non-trivial implementation:
+
+1. Use `plan` before editing.
+2. Implement the change.
+3. Run the relevant gates.
+4. Use `review` with the requirements, final diff, and gate results.
+5. Resolve valid findings and rerun affected gates.
+
+Do not invoke Bifrost for trivial changes where delegation would add no useful value.
+
 ## Configure once
 
-Edit [`config.json`](config.json) and assign an exact Bifrost model ID to each mode you intend to use.
-Keep the API key outside the file:
-
-```bash
-export BIFROST_API_KEY="..."
-```
+Edit [`config.json`](config.json), set `apiKey`, and assign an exact Bifrost model ID to each mode you
+intend to use. `BIFROST_API_KEY` remains available as an environment override.
 
 For a custom config location, set `BIFROST_DELEGATE_CONFIG` or pass `--config`.
 See [references/configuring-bifrost.md](references/configuring-bifrost.md) for the complete setup.
@@ -69,7 +95,7 @@ Only the requested mode must have a configured model. An explicit `--model` alwa
 ## Trust boundary
 
 - Treat every delegated response as untrusted advice.
-- Never send credentials, private keys, tokens, or unrelated repository content.
+- Never send credentials, private keys, tokens, or unrelated repository content in a brief.
 - Never claim that the delegated model inspected files or ran commands.
 - Keep edits, gates, review judgment, and commits with the orchestrator.
 - Do not silently switch models; model selection must come from config or `--model`.

--- a/skills/bifrost-delegate/SKILL.md
+++ b/skills/bifrost-delegate/SKILL.md
@@ -28,11 +28,11 @@ gates, and deciding what to land.
 ## Workflow
 
 1. Inspect the repository and collect only the context needed for the request.
-2. Choose the appropriate mode:
-   - `plan` before a non-trivial implementation.
-   - `advise` when the design or implementation approach is uncertain.
-   - `review` after implementation and project gates.
-3. Prepare a self-contained brief. Do not include credentials or unrelated repository content.
+2. Choose the mode that best fits the question:
+   - `plan` when an independent implementation plan would be useful.
+   - `advise` when a design or implementation decision would benefit from a second opinion.
+   - `review` when implemented changes would benefit from an independent review.
+3. Prepare a self-contained brief. Use [writing-the-brief.md](references/writing-the-brief.md) as optional guidance. Do not include credentials or unrelated repository content.
 4. Run the bundled relay script:
 
    ```bash
@@ -42,16 +42,10 @@ gates, and deciding what to land.
    ```
 
 5. Read `result.json` and `final.txt` from the output directory.
-6. Treat the delegated response as advisory and verify relevant claims against the repository.
+6. Treat the delegated response as advisory. Use [reviewing-the-result.md](references/reviewing-the-result.md) as optional guidance when evaluating it.
 7. Keep repository edits, project commands, gates, commits, and final decisions with the orchestrator.
 
-For a non-trivial implementation:
-
-1. Use `plan` before editing.
-2. Implement the change.
-3. Run the relevant gates.
-4. Use `review` with the requirements, final diff, and gate results.
-5. Resolve valid findings and rerun affected gates.
+For a non-trivial implementation, one useful pattern is to consult `plan` before editing and `review` after the relevant project gates. Adapt or skip those steps when they do not fit the task or the project's normal development process.
 
 Do not invoke Bifrost for trivial changes where delegation would add no useful value.
 

--- a/skills/bifrost-delegate/SKILL.md
+++ b/skills/bifrost-delegate/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: bifrost-delegate
 description: >-
-  Delegate software-engineering planning, implementation advice, or code review to a model exposed by a
-  Bifrost gateway. Use when an orchestrating agent needs a second opinion from Bedrock, NVIDIA, or another
-  Bifrost-backed provider while keeping repository edits, gates, and final decisions with the orchestrator.
+	Delegate software-engineering planning, implementation advice, or code review to a model exposed by a
+	Bifrost gateway. Use when an orchestrating agent needs a second opinion from Bedrock, NVIDIA, or another
+	Bifrost-backed provider while keeping repository edits, gates, and final decisions with the orchestrator.
 license: MIT
 compatibility: Requires Node 18+ and a reachable Bifrost gateway.
 metadata:
-  version: 0.1.0
+	version: 0.1.0
 ---
 
 # Bifrost Delegate
@@ -29,9 +29,9 @@ gates, and deciding what to land.
 
 1. Inspect the repository and collect only the context needed for the request.
 2. Choose the mode that best fits the question:
-   - `plan` when an independent implementation plan would be useful.
-   - `advise` when a design or implementation decision would benefit from a second opinion.
-   - `review` when implemented changes would benefit from an independent review.
+	- `plan` when an independent implementation plan would be useful.
+	- `advise` when a design or implementation decision would benefit from a second opinion.
+	- `review` when implemented changes would benefit from an independent review.
 3. Prepare a self-contained brief. Use [writing-the-brief.md](references/writing-the-brief.md) as optional guidance. Do not include credentials or unrelated repository content.
 4. Run the bundled relay script:
 
@@ -48,6 +48,34 @@ gates, and deciding what to land.
 For a non-trivial implementation, one useful pattern is to consult `plan` before editing and `review` after the relevant project gates. Adapt or skip those steps when they do not fit the task or the project's normal development process.
 
 Do not invoke Bifrost for trivial changes where delegation would add no useful value.
+
+## Relay execution
+
+The bundled relay requires Node.js 18+ regardless of the target project's programming language.
+
+- Use `node` from the current shell when available.
+- If `node` is not on `PATH`, locate an existing compatible Node.js executable and use its absolute path.
+- Do not install Node.js or modify shell configuration unless the user requests it.
+- If no compatible Node.js executable is available, report the delegation failure and stop.
+
+## Project environment
+
+The relay runtime is independent from the project runtime. A delegated task may concern PHP, Python,
+Java, Node.js, or another stack.
+
+Use the project's existing tools and development workflow only when repository inspection, validation,
+or tests are needed. Do not install or reconfigure project runtimes merely to perform delegation.
+
+## Delegation success
+
+Treat delegation as successful only when:
+
+- the relay exits with status `0`;
+- `result.json` exists;
+- the result status is `completed`.
+
+Otherwise, report the actual failure and stop. Do not generate a substitute delegated response or claim
+that the configured model was used.
 
 ## Configure once
 

--- a/skills/bifrost-delegate/SKILL.md
+++ b/skills/bifrost-delegate/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: bifrost-delegate
 description: >-
-	Delegate software-engineering planning, implementation advice, or code review to a model exposed by a
-	Bifrost gateway. Use when an orchestrating agent needs a second opinion from Bedrock, NVIDIA, or another
-	Bifrost-backed provider while keeping repository edits, gates, and final decisions with the orchestrator.
+  Delegate software-engineering planning, implementation advice, or code review to a model exposed by a
+  Bifrost gateway. Use when an orchestrator needs a second opinion from Bedrock, NVIDIA, or another
+  Bifrost-backed provider while keeping repository edits, gates, and final decisions with the orchestrator.
 license: MIT
 compatibility: Requires Node 18+ and a reachable Bifrost gateway.
 metadata:
-	version: 0.1.0
+version: 0.1.0
 ---
 
 # Bifrost Delegate

--- a/skills/bifrost-delegate/SKILL.md
+++ b/skills/bifrost-delegate/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: bifrost-delegate
+description: >-
+  Delegate software-engineering planning, implementation advice, or code review to a model exposed by a
+  Bifrost gateway. Use when an orchestrating agent needs a second opinion from Bedrock, NVIDIA, or another
+  Bifrost-backed provider while keeping repository edits, gates, and final decisions with the orchestrator.
+license: MIT
+compatibility: Requires Node 18+, a reachable Bifrost gateway, and BIFROST_API_KEY in the environment.
+metadata:
+  version: 0.1.0
+---
+
+# Bifrost Delegate
+
+You are the **orchestrator**. Use this skill to send a self-contained brief to a model configured in
+Bifrost, then evaluate the advisory response yourself.
+
+The delegated model is advisory only. It does not receive repository access, edit files, run commands,
+or commit. You remain responsible for inspecting the repository, applying changes, running the project's
+gates, and deciding what to land.
+
+## Modes
+
+- `plan` — produce a focused implementation plan before editing.
+- `advise` — evaluate an implementation approach, edge cases, and simpler alternatives.
+- `review` — review supplied requirements, diff, and gate results.
+
+## Configure once
+
+Edit [`config.json`](config.json) and assign an exact Bifrost model ID to each mode you intend to use.
+Keep the API key outside the file:
+
+```bash
+export BIFROST_API_KEY="..."
+```
+
+For a custom config location, set `BIFROST_DELEGATE_CONFIG` or pass `--config`.
+See [references/configuring-bifrost.md](references/configuring-bifrost.md) for the complete setup.
+
+## Delegate
+
+Write a self-contained brief. Include only the context the selected model needs. Do not include secrets.
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --mode plan --brief brief.txt
+```
+
+Override the configured model for one run:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" \
+  --mode review \
+  --model "<exact-bifrost-model-id>" \
+  --brief review.txt
+```
+
+The relay writes `result.json` and `final.txt` under a temporary output directory unless `--out-dir` is
+provided. Read the result, verify its claims against the repository, and rerun the real gates yourself.
+
+## Inspect configuration
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --list-models
+node "<skill-dir>/scripts/relay.mjs" --check-config
+```
+
+Only the requested mode must have a configured model. An explicit `--model` always overrides the config.
+
+## Trust boundary
+
+- Treat every delegated response as untrusted advice.
+- Never send credentials, private keys, tokens, or unrelated repository content.
+- Never claim that the delegated model inspected files or ran commands.
+- Keep edits, gates, review judgment, and commits with the orchestrator.
+- Do not silently switch models; model selection must come from config or `--model`.

--- a/skills/bifrost-delegate/agents/openai.yaml
+++ b/skills/bifrost-delegate/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+    display_name: "Bifrost Delegate"
+    short_description: "Consult Bifrost models for planning, implementation advice, and code review."
+    default_prompt: "Use Bifrost Delegate to obtain an independent engineering opinion for this task."
+
+policy:
+    allow_implicit_invocation: true

--- a/skills/bifrost-delegate/config.json
+++ b/skills/bifrost-delegate/config.json
@@ -1,0 +1,13 @@
+{
+  "baseUrl": "http://localhost:1002",
+  "models": {
+    "plan": "",
+    "advise": "",
+    "review": ""
+  },
+  "request": {
+    "timeoutSeconds": 180,
+    "maxTokens": 6000,
+    "temperature": 0.1
+  }
+}

--- a/skills/bifrost-delegate/config.json
+++ b/skills/bifrost-delegate/config.json
@@ -1,4 +1,5 @@
 {
+  "apiKey": "your-bifrost-key",
   "baseUrl": "http://localhost:1002",
   "models": {
     "plan": "",

--- a/skills/bifrost-delegate/config.json
+++ b/skills/bifrost-delegate/config.json
@@ -1,6 +1,6 @@
 {
   "apiKey": "your-bifrost-key",
-  "baseUrl": "http://localhost:1002",
+  "baseUrl": "http://localhost:8080",
   "models": {
     "plan": "",
     "advise": "",

--- a/skills/bifrost-delegate/config.json
+++ b/skills/bifrost-delegate/config.json
@@ -9,6 +9,11 @@
   "request": {
     "timeoutSeconds": 180,
     "maxTokens": 6000,
-    "temperature": 0.1
+    "temperature": 0.1,
+    "cache": {
+      "enabled": false,
+      "key": "bifrost-delegate",
+      "ttl": 300
+    }
   }
 }

--- a/skills/bifrost-delegate/references/configuring-bifrost.md
+++ b/skills/bifrost-delegate/references/configuring-bifrost.md
@@ -1,84 +1,24 @@
 # Configure Bifrost Delegate
 
-Edit the skill-local [`config.json`](../config.json) before the first run.
+## Install Bifrost
 
-```json
-{
-  "baseUrl": "http://localhost:1002",
-  "models": {
-    "plan": "",
-    "advise": "",
-    "review": ""
-  },
-  "request": {
-    "timeoutSeconds": 180,
-    "maxTokens": 6000,
-    "temperature": 0.1
-  }
-}
+Bifrost runs the same way on Windows and Linux when Node.js is available.
+
+**Windows PowerShell or Command Prompt:**
+
+```powershell
+npx -y @maximhq/bifrost -port 1002
 ```
 
-## Set the API key
-
-Keep the Bifrost key outside the repository:
+**Linux, macOS, or WSL:**
 
 ```bash
-export BIFROST_API_KEY="..."
+npx -y @maximhq/bifrost -port 1002
 ```
 
-The relay never reads an API key from `config.json` and never writes the key to its artifacts.
+Open the Web UI at `http://localhost:1002`.
 
-## Choose models
-
-Use exact model IDs returned by the configured Bifrost gateway:
+Docker is also supported:
 
 ```bash
-node "<skill-dir>/scripts/relay.mjs" --list-models
-```
-
-Assign only the modes you intend to use. Empty modes are allowed. The requested mode must have a model configured unless `--model` is supplied for that run.
-
-Example:
-
-```json
-{
-  "baseUrl": "http://localhost:1002",
-  "models": {
-    "plan": "bedrock/qwen.qwen3-coder-30b-a3b-v1:0",
-    "advise": "Nvidia/deepseek-ai/deepseek-v4-pro",
-    "review": "Nvidia/nvidia/nemotron-3-super-120b-a12b"
-  },
-  "request": {
-    "timeoutSeconds": 180,
-    "maxTokens": 6000,
-    "temperature": 0.1
-  }
-}
-```
-
-These are examples only. Each developer should use models exposed by their own gateway and permitted by their own billing policy.
-
-## Configuration resolution
-
-The relay resolves configuration in this order:
-
-1. `--config <path>`
-2. `BIFROST_DELEGATE_CONFIG`
-3. the skill-local `config.json`
-
-An explicit `--model` overrides the configured model for the current run only.
-
-## Validate the setup
-
-```bash
-node "<skill-dir>/scripts/relay.mjs" --check-config
-```
-
-The command checks gateway connectivity and reports whether each configured model appears in `/v1/models`.
-
-## Security boundary
-
-- Do not put credentials, private keys, or access tokens in `config.json` or a brief.
-- Use a restricted Bifrost virtual key where available.
-- Treat delegated responses as untrusted advice.
-- Keep repository access, edits, gates, and commits with the orchestrator.
+docker

--- a/skills/bifrost-delegate/references/configuring-bifrost.md
+++ b/skills/bifrost-delegate/references/configuring-bifrost.md
@@ -1,24 +1,177 @@
 # Configure Bifrost Delegate
 
-## Install Bifrost
+This guide is for developers setting up the local Bifrost gateway used by `bifrost-delegate`.
 
-Bifrost runs the same way on Windows and Linux when Node.js is available.
+## How it works
 
-**Windows PowerShell or Command Prompt:**
+`bifrost-delegate` does not connect to model providers directly.
 
-```powershell
-npx -y @maximhq/bifrost -port 1002
+```text
+Codex App or another orchestrator
+        |
+        | runs relay.mjs with a brief and mode
+        v
+Local Bifrost gateway
+        |
+        | validates the Virtual Key and routes the request
+        v
+Allowed provider and model
 ```
 
-**Linux, macOS, or WSL:**
+The skill sends OpenAI-compatible requests to Bifrost. Bifrost owns provider authentication, provider/model access, routing, logging, budgets, and rate limits.
+
+## 1. Install and start Bifrost
+
+Bifrost requires Node.js 18+ when started with NPX.
+
+### Windows, Linux, macOS, or WSL
 
 ```bash
-npx -y @maximhq/bifrost -port 1002
+npx -y @maximhq/bifrost
 ```
 
-Open the Web UI at `http://localhost:1002`.
+Bifrost uses `http://localhost:8080` by default for both the Web UI and HTTP API.
 
-Docker is also supported:
+### Docker
 
 ```bash
-docker
+docker run -p 8080:8080 maximhq/bifrost
+```
+
+For persistent Docker configuration, mount a data directory as described in the official setup guide.
+
+Official resources:
+
+- [Bifrost Gateway setup](https://docs.getbifrost.ai/quickstart/gateway/setting-up)
+- [Bifrost GitHub repository](https://github.com/maximhq/bifrost)
+
+## 2. Configure providers
+
+Open the Bifrost Web UI:
+
+```text
+http://localhost:8080
+```
+
+Add each provider that the skill may use and configure its credentials or cloud authentication. For example, AWS Bedrock requires valid AWS authentication and region settings; API-based providers require their provider key.
+
+After adding a provider:
+
+1. Confirm that the provider is enabled.
+2. Confirm that its credentials or cloud authentication work.
+3. Confirm that the required models are enabled or discoverable.
+4. Test the provider from Bifrost before configuring the skill.
+
+Provider configuration reference:
+
+- [Bifrost provider setup](https://docs.getbifrost.ai/deployment-guides/config-json/providers)
+
+## 3. Create a Virtual Key
+
+The skill uses a Bifrost Virtual Key as its `apiKey`.
+
+In the Bifrost Web UI:
+
+1. Open **Virtual Keys**.
+2. Click **Add Virtual Key**.
+3. Give the key a clear name, such as `bifrost-delegate-local`.
+4. Add every provider the skill should be allowed to use.
+5. For each provider, allow the required provider key and models.
+6. Create the key and copy its `sk-bf-...` value.
+
+Important access rules:
+
+- A provider must first be configured in Bifrost and then explicitly allowed by the Virtual Key.
+- The Virtual Key must allow the provider key used for requests.
+- The Virtual Key must allow every model configured for `plan`, `advise`, or `review`.
+- An empty provider-key or model allowlist denies access.
+- Use `"*"` only when intentionally allowing every available key or model.
+
+Virtual Key reference:
+
+- [Bifrost Virtual Keys](https://docs.getbifrost.ai/features/governance/virtual-keys)
+
+## 4. Configure the skill
+
+Edit the skill-local [`config.json`](../config.json):
+
+```json
+{
+  "apiKey": "sk-bf-your-virtual-key",
+  "baseUrl": "http://localhost:8080",
+  "models": {
+    "plan": "provider/model-id",
+    "advise": "provider/model-id",
+    "review": "provider/model-id"
+  },
+  "request": {
+    "timeoutSeconds": 180,
+    "maxTokens": 6000,
+    "temperature": 0.1
+  }
+}
+```
+
+Use exact model IDs returned by your Bifrost gateway. Empty mode entries are allowed, but the requested mode must have a model configured unless `--model` is supplied for that run.
+
+If Bifrost is running on another host or port, update `baseUrl` accordingly.
+
+### API key resolution
+
+The relay resolves the Virtual Key in this order:
+
+1. `BIFROST_API_KEY`
+2. `config.apiKey`
+
+The environment variable is useful as a temporary override. The configured key is convenient for a local Codex App skill installation.
+
+### Configuration resolution
+
+The relay resolves the configuration file in this order:
+
+1. `--config <path>`
+2. `BIFROST_DELEGATE_CONFIG`
+3. the skill-local `config.json`
+
+An explicit `--model` overrides the configured model for the current run only.
+
+## 5. Discover and validate models
+
+List the models visible to the configured Virtual Key:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --list-models
+```
+
+Bifrost only returns providers and models allowed by that Virtual Key. Copy the exact IDs into `config.json`.
+
+Validate the connection and configured modes:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --check-config
+```
+
+Expected output:
+
+```text
+Bifrost connection: OK
+
+plan    provider/model-id  available
+advise  provider/model-id  available
+review  provider/model-id  available
+```
+
+A `missing` result usually means one of the following:
+
+- the model ID is incorrect;
+- the provider is not configured or enabled;
+- the Virtual Key does not allow the provider;
+- the Virtual Key does not allow the provider key or model.
+
+## 6. Operational notes
+
+- The delegated model is advisory and never receives direct repository access.
+- The relay does not write the API key to `result.json`, `final.txt`, or request logs it creates.
+- Do not include provider credentials or unrelated secrets in briefs.
+- Keep repository edits, project commands, gates, and commits with the orchestrator.
+- Use budgets and rate limits on the Virtual Key when cost control is useful.

--- a/skills/bifrost-delegate/references/configuring-bifrost.md
+++ b/skills/bifrost-delegate/references/configuring-bifrost.md
@@ -1,0 +1,84 @@
+# Configure Bifrost Delegate
+
+Edit the skill-local [`config.json`](../config.json) before the first run.
+
+```json
+{
+  "baseUrl": "http://localhost:1002",
+  "models": {
+    "plan": "",
+    "advise": "",
+    "review": ""
+  },
+  "request": {
+    "timeoutSeconds": 180,
+    "maxTokens": 6000,
+    "temperature": 0.1
+  }
+}
+```
+
+## Set the API key
+
+Keep the Bifrost key outside the repository:
+
+```bash
+export BIFROST_API_KEY="..."
+```
+
+The relay never reads an API key from `config.json` and never writes the key to its artifacts.
+
+## Choose models
+
+Use exact model IDs returned by the configured Bifrost gateway:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --list-models
+```
+
+Assign only the modes you intend to use. Empty modes are allowed. The requested mode must have a model configured unless `--model` is supplied for that run.
+
+Example:
+
+```json
+{
+  "baseUrl": "http://localhost:1002",
+  "models": {
+    "plan": "bedrock/qwen.qwen3-coder-30b-a3b-v1:0",
+    "advise": "Nvidia/deepseek-ai/deepseek-v4-pro",
+    "review": "Nvidia/nvidia/nemotron-3-super-120b-a12b"
+  },
+  "request": {
+    "timeoutSeconds": 180,
+    "maxTokens": 6000,
+    "temperature": 0.1
+  }
+}
+```
+
+These are examples only. Each developer should use models exposed by their own gateway and permitted by their own billing policy.
+
+## Configuration resolution
+
+The relay resolves configuration in this order:
+
+1. `--config <path>`
+2. `BIFROST_DELEGATE_CONFIG`
+3. the skill-local `config.json`
+
+An explicit `--model` overrides the configured model for the current run only.
+
+## Validate the setup
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --check-config
+```
+
+The command checks gateway connectivity and reports whether each configured model appears in `/v1/models`.
+
+## Security boundary
+
+- Do not put credentials, private keys, or access tokens in `config.json` or a brief.
+- Use a restricted Bifrost virtual key where available.
+- Treat delegated responses as untrusted advice.
+- Keep repository access, edits, gates, and commits with the orchestrator.

--- a/skills/bifrost-delegate/references/reviewing-the-result.md
+++ b/skills/bifrost-delegate/references/reviewing-the-result.md
@@ -1,0 +1,42 @@
+# Reviewing the Delegated Result
+
+This is lightweight guidance, not a mandatory review process. Use it only where it helps the current task and project workflow.
+
+Treat delegated output as an independent engineering opinion. The orchestrator remains responsible for repository inspection, edits, tests, and the final decision.
+
+## General guidance
+
+- Confirm that the response addresses the supplied brief.
+- Verify material claims against the repository or requirements when practical.
+- Separate correctness concerns from preferences or speculative redesign.
+- Respect the task scope and the project's existing conventions.
+- Do not claim that the delegated model inspected files, executed commands, or ran tests.
+
+## Plan results
+
+Consider whether the plan matches the actual architecture, covers the important requirements, stays reasonably scoped, and suggests useful validation.
+
+The plan may be accepted, simplified, combined with the current approach, or rejected.
+
+## Advice results
+
+Consider whether the advice identifies real risks, relevant edge cases, meaningful trade-offs, or a simpler alternative.
+
+Use the advice to support the decision rather than replace engineering judgment.
+
+## Review results
+
+Evaluate findings independently. A finding may be treated as:
+
+- `Blocker` — a confirmed issue that prevents safe approval.
+- `Important` — a confirmed issue that would normally be addressed before landing.
+- `Minor` — a low-risk quality, clarity, maintainability, or test improvement.
+- `Rejected` — unsupported, incorrect, preference-only, intentionally deferred, or outside the task scope.
+
+For accepted findings, apply an appropriate change and rerun affected gates when the project workflow calls for it.
+
+Avoid repeated delegation for minor stylistic suggestions or changes that do not materially affect the implementation.
+
+## Final decision
+
+The orchestrator may approve, approve with follow-up, request changes, or reject the delegated result as unreliable. The final decision always remains with the orchestrator.

--- a/skills/bifrost-delegate/references/writing-the-brief.md
+++ b/skills/bifrost-delegate/references/writing-the-brief.md
@@ -1,0 +1,10 @@
+# Writing the Delegation Brief
+
+This is lightweight guidance, not a required template. Adapt it to the task and the project's existing development process.
+
+The delegated model has no repository access. Include enough context for an independent opinion, but avoid unrelated content.
+
+## General guidance
+
+- State the goal and the question clearly.
+- Include only relevant architecture, files, code excerpts, or

--- a/skills/bifrost-delegate/references/writing-the-brief.md
+++ b/skills/bifrost-delegate/references/writing-the-brief.md
@@ -7,4 +7,48 @@ The delegated model has no repository access. Include enough context for an inde
 ## General guidance
 
 - State the goal and the question clearly.
-- Include only relevant architecture, files, code excerpts, or
+- Include only relevant architecture, files, code excerpts, or diffs.
+- Use exact names and paths when they help avoid ambiguity.
+- Separate confirmed facts from assumptions when practical.
+- Do not include credentials, tokens, private keys, or unrelated private content.
+- Keep the requested output clear and proportionate to the task.
+
+## Plan mode
+
+A useful plan brief may include:
+
+- the goal and current state;
+- relevant architecture or affected areas;
+- requirements and constraints;
+- known decisions or uncertainties;
+- expected validation.
+
+Ask for a focused implementation plan rather than a full redesign unless broader analysis is explicitly needed.
+
+## Advise mode
+
+A useful advice brief may include:
+
+- the proposed approach;
+- why it is being considered;
+- relevant current behavior;
+- constraints and alternatives already considered;
+- the specific decision or risk to evaluate.
+
+Ask the delegate to focus on correctness, edge cases, trade-offs, or simpler alternatives as relevant.
+
+## Review mode
+
+A useful review brief may include:
+
+- the original requirements;
+- a short implementation summary;
+- the relevant final diff or changed areas;
+- available test or gate results;
+- known limitations or intentionally deferred scope.
+
+Ask for blockers, important issues, minor improvements, and a recommendation when that format is useful.
+
+## Before sending
+
+Check that the selected mode fits the question, the necessary context is present, assumptions are visible, and no secrets are included.

--- a/skills/bifrost-delegate/scripts/relay.mjs
+++ b/skills/bifrost-delegate/scripts/relay.mjs
@@ -149,6 +149,20 @@ function loadConfig(path) {
     fail("config.request.temperature must be a number between 0 and 2");
   }
 
+  const cache = request.cache;
+  if (cache !== undefined) {
+    if (!cache || typeof cache !== "object" || Array.isArray(cache)) {
+      fail("config.request.cache must be an object");
+    }
+    if (cache.enabled !== undefined && typeof cache.enabled !== "boolean") {
+      fail("config.request.cache.enabled must be a boolean");
+    }
+    if (cache.key !== undefined && (typeof cache.key !== "string" || !cache.key.trim())) {
+      fail("config.request.cache.key must be a non-empty string");
+    }
+    validatePositiveInteger(cache.ttl, "config.request.cache.ttl", true);
+  }
+
   return config;
 }
 
@@ -167,6 +181,20 @@ function requireApiKey(config) {
 
 function endpoint(baseUrl, path) {
   return `${baseUrl.replace(/\/+$/, "")}${path}`;
+}
+
+function cacheHeaders(config, mode) {
+  const cache = config.request?.cache;
+  if (!cache?.enabled) return {};
+
+  const key = cache.key?.trim() || "bifrost-delegate";
+  const ttl = cache.ttl ?? 300;
+
+  return {
+    "x-bf-cache-key": `${key}:${mode}`,
+    "x-bf-cache-type": "direct",
+    "x-bf-cache-ttl": String(ttl),
+  };
 }
 
 async function bifrostRequest(url, apiKey, init, timeoutSeconds) {
@@ -327,6 +355,7 @@ async function run() {
       apiKey,
       {
         method: "POST",
+        headers: cacheHeaders(config, options.mode),
         body: JSON.stringify({
           model,
           messages: [

--- a/skills/bifrost-delegate/scripts/relay.mjs
+++ b/skills/bifrost-delegate/scripts/relay.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+const MODES = new Set(["plan", "advise", "review"]);
+const DEFAULT_CONFIG = resolve(dirname(fileURLToPath(import.meta.url)), "..", "config.json");
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const options = {
+    brief: null,
+    mode: null,
+    model: null,
+    config: null,
+    outDir: null,
+    timeoutSeconds: null,
+    maxTokens: null,
+    listModels: false,
+    checkConfig: false,
+  };
+
+  const nextValue = (index, flag) => {
+    const value = argv[index + 1];
+    if (value === undefined) fail(`${flag} requires a value`);
+    return value;
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "-h":
+      case "--help":
+        printHelp();
+        process.exit(0);
+        break;
+      case "--brief":
+        options.brief = nextValue(index, arg);
+        index += 1;
+        break;
+      case "--mode":
+        options.mode = nextValue(index, arg);
+        index += 1;
+        break;
+      case "--model":
+        options.model = nextValue(index, arg);
+        index += 1;
+        break;
+      case "--config":
+        options.config = nextValue(index, arg);
+        index += 1;
+        break;
+      case "--out-dir":
+        options.outDir = nextValue(index, arg);
+        index += 1;
+        break;
+      case "--timeout":
+        options.timeoutSeconds = Number(nextValue(index, arg));
+        index += 1;
+        break;
+      case "--max-tokens":
+        options.maxTokens = Number(nextValue(index, arg));
+        index += 1;
+        break;
+      case "--list-models":
+        options.listModels = true;
+        break;
+      case "--check-config":
+        options.checkConfig = true;
+        break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`bifrost-delegate relay\n\nUsage:\n  node relay.mjs --mode <plan|advise|review> --brief <file> [options]\n  cat brief.txt | node relay.mjs --mode plan [options]\n  node relay.mjs --list-models [--config <file>]\n  node relay.mjs --check-config [--config <file>]\n\nOptions:\n  --model <id>         Override the configured model for this run\n  --config <file>      Use a custom config file\n  --out-dir <dir>      Write artifacts to this directory\n  --timeout <seconds>  Override request timeout\n  --max-tokens <n>     Override max output tokens\n`);
+}
+
+function resolveConfigPath(options) {
+  return resolve(options.config || process.env.BIFROST_DELEGATE_CONFIG || DEFAULT_CONFIG);
+}
+
+function loadConfig(path) {
+  if (!existsSync(path)) fail(`config file not found: ${path}`);
+
+  let config;
+  try {
+    config = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    fail(`invalid JSON in config: ${error.message}`);
+  }
+
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    fail("config must be a JSON object");
+  }
+
+  if (typeof config.baseUrl !== "string" || !config.baseUrl.trim()) {
+    fail("config.baseUrl must be a non-empty string");
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(config.baseUrl);
+  } catch {
+    fail("config.baseUrl must be a valid URL");
+  }
+  if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+    fail("config.baseUrl must use http or https");
+  }
+
+  if (!config.models || typeof config.models !== "object" || Array.isArray(config.models)) {
+    fail("config.models must be an object");
+  }
+
+  for (const mode of MODES) {
+    const value = config.models[mode];
+    if (value !== undefined && typeof value !== "string") {
+      fail(`config.models.${mode} must be a string`);
+    }
+  }
+
+  const request = config.request || {};
+  validatePositiveInteger(request.timeoutSeconds, "config.request.timeoutSeconds", true);
+  validatePositiveInteger(request.maxTokens, "config.request.maxTokens", true);
+  if (request.temperature !== undefined &&
+      (typeof request.temperature !== "number" || request.temperature < 0 || request.temperature > 2)) {
+    fail("config.request.temperature must be a number between 0 and 2");
+  }
+
+  return config;
+}
+
+function validatePositiveInteger(value, name, optional = false) {
+  if (optional && value === undefined) return;
+  if (!Number.isInteger(value) || value <= 0) fail(`${name} must be a positive integer`);
+}
+
+function requireApiKey() {
+  const key = process.env.BIFROST_API_KEY;
+  if (!key) fail("BIFROST_API_KEY is not set");
+  return key;
+}
+
+function endpoint(baseUrl, path) {
+  return `${baseUrl.replace(/\/+$/, "")}${path}`;
+}
+
+async function bifrostRequest(url, apiKey, init, timeoutSeconds) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+
+  try {
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        ...(init.headers || {}),
+      },
+      signal: controller.signal,
+    });
+
+    const text = await response.text();
+    let body = null;
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = { raw: text.slice(0, 1000) };
+      }
+    }
+
+    if (!response.ok) {
+      const message = body?.error?.message || body?.message || `HTTP ${response.status}`;
+      const error = new Error(message);
+      error.statusCode = response.status;
+      throw error;
+    }
+
+    return { body, headers: response.headers };
+  } catch (error) {
+    if (error.name === "AbortError") {
+      const timeoutError = new Error(`request timed out after ${timeoutSeconds} seconds`);
+      timeoutError.type = "timeout";
+      throw timeoutError;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function listModels(config, apiKey, timeoutSeconds) {
+  const { body } = await bifrostRequest(
+    endpoint(config.baseUrl, "/v1/models"),
+    apiKey,
+    { method: "GET" },
+    timeoutSeconds,
+  );
+
+  const ids = Array.isArray(body?.data)
+    ? body.data.map((item) => item?.id).filter((id) => typeof id === "string")
+    : [];
+
+  return ids.sort((left, right) => left.localeCompare(right));
+}
+
+function modeInstruction(mode) {
+  const common = "You are an advisory software-engineering delegate. Base your answer only on the supplied brief. Do not claim to have inspected files, executed commands, edited code, or committed changes.";
+  const specific = {
+    plan: "Produce a focused implementation plan. State assumptions, affected areas, risks, and validation steps. Prefer the simplest sufficient design.",
+    advise: "Evaluate the proposed implementation. Focus on correctness, edge cases, trade-offs, and simpler alternatives.",
+    review: "Review the supplied requirements, diff, and gate results. Return sections named Blockers, Important issues, Minor improvements, and Recommendation. Do not invent unsupported findings.",
+  };
+  return `${common}\n\n${specific[mode]}`;
+}
+
+function readBrief(path) {
+  let brief;
+  if (path) {
+    if (!existsSync(path)) fail(`brief file not found: ${path}`);
+    brief = readFileSync(path, "utf8");
+  } else {
+    if (process.stdin.isTTY) fail("pass --brief <file> or pipe the brief on stdin");
+    brief = readFileSync(0, "utf8");
+  }
+
+  if (!brief.trim()) fail("brief must not be empty");
+  return brief;
+}
+
+function createRunDir(outDir) {
+  const resolved = outDir
+    ? resolve(outDir)
+    : join(tmpdir(), "delegate-relay", `bifrost-${new Date().toISOString().replace(/[:.]/g, "-")}`);
+  mkdirSync(resolved, { recursive: true });
+  return resolved;
+}
+
+function writeResult(runDir, result) {
+  const resultPath = join(runDir, "result.json");
+  writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  if (result.finalMessage) {
+    writeFileSync(join(runDir, "final.txt"), `${result.finalMessage}\n`, "utf8");
+  }
+  return resultPath;
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.listModels && options.checkConfig) fail("choose only one of --list-models or --check-config");
+
+  const configPath = resolveConfigPath(options);
+  const config = loadConfig(configPath);
+  const apiKey = requireApiKey();
+  const timeoutSeconds = options.timeoutSeconds ?? config.request?.timeoutSeconds ?? 180;
+  validatePositiveInteger(timeoutSeconds, "timeout");
+
+  if (options.listModels) {
+    const ids = await listModels(config, apiKey, timeoutSeconds);
+    process.stdout.write(`${ids.join("\n")}${ids.length ? "\n" : ""}`);
+    return;
+  }
+
+  if (options.checkConfig) {
+    const ids = new Set(await listModels(config, apiKey, timeoutSeconds));
+    process.stdout.write(`Bifrost connection: OK\nConfig: ${configPath}\n\n`);
+    for (const mode of MODES) {
+      const model = config.models[mode]?.trim();
+      const status = !model ? "not configured" : ids.has(model) ? "available" : "missing";
+      process.stdout.write(`${mode.padEnd(7)} ${model || "-"}  ${status}\n`);
+    }
+    return;
+  }
+
+  if (!MODES.has(options.mode)) fail("--mode must be one of: plan, advise, review");
+  const model = options.model || config.models[options.mode]?.trim();
+  if (!model) fail(`no model configured for mode: ${options.mode}; edit config.json or pass --model`);
+
+  const maxTokens = options.maxTokens ?? config.request?.maxTokens ?? 6000;
+  validatePositiveInteger(maxTokens, "max tokens");
+  const temperature = config.request?.temperature ?? 0.1;
+  const brief = readBrief(options.brief);
+  const runDir = createRunDir(options.outDir);
+  const startedAt = new Date().toISOString();
+
+  try {
+    const { body, headers } = await bifrostRequest(
+      endpoint(config.baseUrl, "/v1/chat/completions"),
+      apiKey,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          model,
+          messages: [
+            { role: "system", content: modeInstruction(options.mode) },
+            { role: "user", content: brief },
+          ],
+          stream: false,
+          temperature,
+          max_tokens: maxTokens,
+        }),
+      },
+      timeoutSeconds,
+    );
+
+    const finalMessage = body?.choices?.[0]?.message?.content;
+    if (typeof finalMessage !== "string" || !finalMessage.trim()) {
+      throw new Error("Bifrost response did not contain choices[0].message.content");
+    }
+
+    const result = {
+      schema: "delegate-relay.result.v1",
+      status: "completed",
+      exitCode: 0,
+      signal: null,
+      delegate: "bifrost",
+      mode: options.mode,
+      model,
+      configPath,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      finalMessage,
+      usage: body?.usage || null,
+      requestId: headers.get("x-request-id") || headers.get("x-bifrost-trace-id") || null,
+      touchedFiles: [],
+    };
+
+    const resultPath = writeResult(runDir, result);
+    process.stdout.write(`${JSON.stringify({ status: result.status, model, mode: options.mode, resultPath }, null, 2)}\n`);
+  } catch (error) {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      delegate: "bifrost",
+      mode: options.mode,
+      model,
+      configPath,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      finalMessage: "",
+      error: {
+        type: error.type || (error.statusCode ? "gateway_error" : "request_error"),
+        statusCode: error.statusCode || null,
+        message: error.message,
+      },
+      touchedFiles: [],
+    };
+    const resultPath = writeResult(runDir, result);
+    process.stderr.write(`relay: ${error.message}\nresult: ${resultPath}\n`);
+    process.exit(1);
+  }
+}
+
+run().catch((error) => fail(error.message, 1));

--- a/skills/bifrost-delegate/scripts/relay.mjs
+++ b/skills/bifrost-delegate/scripts/relay.mjs
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
@@ -214,9 +222,11 @@ async function listModels(config, apiKey, timeoutSeconds) {
     timeoutSeconds,
   );
 
-  const ids = Array.isArray(body?.data)
-    ? body.data.map((item) => item?.id).filter((id) => typeof id === "string")
-    : [];
+  if (!Array.isArray(body?.data)) {
+    throw new Error("Bifrost models response did not contain a data array");
+  }
+
+  const ids = body.data.map((item) => item?.id).filter((id) => typeof id === "string");
 
   return ids.sort((left, right) => left.localeCompare(right));
 }
@@ -246,18 +256,29 @@ function readBrief(path) {
 }
 
 function createRunDir(outDir) {
-  const resolved = outDir
-    ? resolve(outDir)
-    : join(tmpdir(), "delegate-relay", `bifrost-${new Date().toISOString().replace(/[:.]/g, "-")}`);
-  mkdirSync(resolved, { recursive: true });
-  return resolved;
+  if (outDir) {
+    const resolved = resolve(outDir);
+    mkdirSync(resolved, { recursive: true });
+    return resolved;
+  }
+
+  const runDir = mkdtempSync(join(tmpdir(), "bifrost-"));
+  chmodSync(runDir, 0o700);
+  return runDir;
 }
 
 function writeResult(runDir, result) {
   const resultPath = join(runDir, "result.json");
-  writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  const finalPath = join(runDir, "final.txt");
+  if (result.status === "failed" && existsSync(finalPath)) {
+    unlinkSync(finalPath);
+  }
+
+  writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  chmodSync(resultPath, 0o600);
   if (result.finalMessage) {
-    writeFileSync(join(runDir, "final.txt"), `${result.finalMessage}\n`, "utf8");
+    writeFileSync(finalPath, `${result.finalMessage}\n`, { encoding: "utf8", mode: 0o600 });
+    chmodSync(finalPath, 0o600);
   }
   return resultPath;
 }
@@ -339,6 +360,7 @@ async function run() {
       finalMessage,
       usage: body?.usage || null,
       requestId: headers.get("x-request-id") || headers.get("x-bifrost-trace-id") || null,
+      sessionId: null,
       touchedFiles: [],
     };
 
@@ -362,6 +384,7 @@ async function run() {
         statusCode: error.statusCode || null,
         message: error.message,
       },
+      sessionId: null,
       touchedFiles: [],
     };
     const resultPath = writeResult(runDir, result);

--- a/skills/bifrost-delegate/scripts/relay.mjs
+++ b/skills/bifrost-delegate/scripts/relay.mjs
@@ -104,6 +104,10 @@ function loadConfig(path) {
     fail("config must be a JSON object");
   }
 
+  if (config.apiKey !== undefined && typeof config.apiKey !== "string") {
+    fail("config.apiKey must be a string");
+  }
+
   if (typeof config.baseUrl !== "string" || !config.baseUrl.trim()) {
     fail("config.baseUrl must be a non-empty string");
   }
@@ -145,9 +149,11 @@ function validatePositiveInteger(value, name, optional = false) {
   if (!Number.isInteger(value) || value <= 0) fail(`${name} must be a positive integer`);
 }
 
-function requireApiKey() {
-  const key = process.env.BIFROST_API_KEY;
-  if (!key) fail("BIFROST_API_KEY is not set");
+function requireApiKey(config) {
+  const key = process.env.BIFROST_API_KEY || config.apiKey?.trim();
+  if (!key || key === "your-bifrost-key") {
+    fail("set BIFROST_API_KEY or config.apiKey");
+  }
   return key;
 }
 
@@ -262,7 +268,7 @@ async function run() {
 
   const configPath = resolveConfigPath(options);
   const config = loadConfig(configPath);
-  const apiKey = requireApiKey();
+  const apiKey = requireApiKey(config);
   const timeoutSeconds = options.timeoutSeconds ?? config.request?.timeoutSeconds ?? 180;
   validatePositiveInteger(timeoutSeconds, "timeout");
 


### PR DESCRIPTION
The idea is simple: instead of relying on one model for everything, Codex can delegate specific tasks to different models through Bifrost.

For example:

one model helps with planning;
another gives architecture advice;
another performs an independent code review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bifrost Delegate skill with Plan, Advise, and Review delegation modes.
  * Introduced a relay CLI to submit briefs, override models, list models, and validate configuration; saves run outputs (`result.json`, and `final.txt` when available) with advisory/untrusted results.
  * Added configurable connection/request controls (API key, base URL, timeouts, token limits, temperature, and optional request caching).
  * Added an agent configuration for “Bifrost Delegate” with implicit invocation enabled.

* **Documentation**
  * Added setup/configuration guide for the local delegate gateway.
  * Added references for writing briefs and reviewing delegated results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->