### PR TITLE
Add `vibe` delegate skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,10 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Five skills ship today: `codex-delegate` (OpenAI Codex), `opencode-delegate`
-(OpenCode), `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), and `kimi-delegate`
-(Kimi Code); siblings like `gemini-delegate` can be added later without renaming the repo.
+and land the result. Six skills ship today: `codex-delegate` (OpenAI Codex), `opencode-delegate`
+(OpenCode), `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate`
+(Kimi Code), and `vibe-delegate` (Mistral Vibe); siblings like `gemini-delegate` can be added later
+without renaming the repo.
 
 ## Vocabulary
 
@@ -26,6 +27,7 @@ jargon. Use these terms; don't invent synonyms.
 | `project`, `conversation`, `model`, `permissions`, `sandbox`, `TUI`, `tasks`, `subagents` | Antigravity's own terms — use verbatim when discussing `agy` | don't use `subagents` as a generic synonym for implementer |
 | `session`, `sandbox` (`workspace`/`read-only`/`off`), `permission-mode`, `effort`, `streaming-json` | Grok Build's own terms — use verbatim when discussing `grok` | don't paraphrase them |
 | `session`, `--continue`, `model alias`, `auto permission mode`, `plan mode`, `--yolo` | Kimi Code's own terms — use verbatim when discussing `kimi` | don't paraphrase them |
+| `--prompt`, `--output` (`streaming`/`json`/`text`), `--agent` (`plan`/`accept-edits`/`auto-approve`), `--max-turns`, `--trust`, `--resume`, `--continue`, `--enabled-tools`, `--disabled-tools` | Mistral Vibe's own terms — use verbatim when discussing `vibe` | don't invent a Vibe sandbox enum; don't use `--yolo` as a synonym for auto-approve agent |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -48,7 +50,8 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   when needed.
 - **Executables:** keep them minimal and inspectable. Today there is one per skill — a
   `scripts/relay.mjs` under each of `skills/codex-delegate/`, `skills/opencode-delegate/`,
-  `skills/agy-delegate/`, `skills/grok-delegate/`, and `skills/kimi-delegate/` — each Node built-ins
+  `skills/agy-delegate/`, `skills/grok-delegate/`, `skills/kimi-delegate/`, and
+  `skills/vibe-delegate/` — each Node built-ins
   only, no dependencies, no network calls of its own, no credentials, no telemetry. New scripts must
   hold the same line, and the README's trust section must stay accurate.
 
@@ -61,7 +64,8 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, and `grok` launches need
   `shell:true` on win32 to resolve the `.cmd` shim (which is why their spaceable args are quoted and
   value flags token-validated); `agy` and `kimi` use native binaries, but each still needs its own
-  Windows smoke before claiming support.
+  Windows smoke before claiming support. `vibe` officially targets UNIX environments; consult the
+  Mistral Vibe documentation before claiming Windows support.
 - Keep the README's "Verification status" honest — claim only what's been run.
 
 ## Local Claude Code config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,9 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   `shell:true` on win32 to resolve the `.cmd` shim (which is why their spaceable args are quoted and
   value flags token-validated); the `claude` launch resolves a native `.exe` or separately serializes
   a `.cmd` shim; `agy`, `kimi`, current `qodercli`, and `vibe` installs use native binaries. Each
-  changed launch still needs its own Windows smoke before claiming support; Vibe officially targets
-  UNIX environments, and its native Windows launch is unverified.
+  changed launch still needs its own Windows smoke before claiming support. Upstream Vibe works on
+  Windows but officially supports and targets UNIX; this repository's native Windows relay launch is
+  unverified.
 - Keep the README's "Verification status" honest — claim only what's been run.
 
 ## Local Claude Code config

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, hands it to an implementer CLI, then reviews the diff and
 commits — staying the reviewer the whole way.
 
-Five skills ship today — same loop, different implementer:
+Six skills ship today — same loop, different implementer:
 
 | Skill | Drives | Autonomy | Resume |
 | --- | --- | --- | --- |
@@ -15,6 +15,7 @@ Five skills ship today — same loop, different implementer:
 | `agy-delegate` | Google Antigravity CLI (`agy`) | Antigravity's own permission policy; bypass is opt-in | `--resume-last`, `--conversation <id>` |
 | `grok-delegate` | Grok Build CLI (`grok`) | explicit: default workspace-scoped, `--read-only` best-effort with violation detection, `--full-access` opt-in | `--resume-last`, `--session <id>` |
 | `kimi-delegate` | Kimi Code CLI (`kimi`) | headless runs always use Kimi's auto permission mode | `--resume-last`, `--session <id>` |
+| `vibe-delegate` | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) (`vibe`) | `auto-approve` agent by default; `--plan-only` uses `plan` agent (best-effort read-only) | `--resume-last`, `--session <id>` |
 
 ## Install
 
@@ -99,6 +100,14 @@ Same loop for the Kimi Code CLI (`kimi`). Headless `kimi -p` always runs in Kimi
 mode (it rejects `--yolo`/`--auto`/`--plan` outright), so the skill is blunt about it: there is no
 CLI-enforced read-only mode — `touchedFiles` and the diff, not a flag, are the guarantee.
 
+### vibe-delegate
+
+Same loop for the Mistral Vibe CLI (`vibe`). The `auto-approve` agent is the default for headless
+implementation work — it auto-approves all tool executions. `--plan-only` selects the `plan` agent
+(exploration and planning, auto-approves only safe read tools) as a best-effort read-only mode.
+`--trust` is always passed to prevent interactive directory-trust prompts in headless runs. `--max-turns`
+is available for cost control. Vibe works on Windows but officially targets UNIX environments.
+
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
@@ -126,7 +135,9 @@ bundled `relay.mjs` is the default because it needs nothing but the `codex` bina
   [`codex`](https://github.com/openai/codex) (`codex login`) · [`opencode`](https://opencode.ai)
   (`opencode auth login`) · `agy` (Antigravity's first-launch setup) ·
   `grok` (`npm i -g @xai-official/grok`, then `grok login`) ·
-  [`kimi`](https://moonshotai.github.io/kimi-code/en/) (`brew install kimi-code`, then `kimi login`).
+  [`kimi`](https://moonshotai.github.io/kimi-code/en/) (`brew install kimi-code`, then `kimi login`) ·
+  [`vibe`](https://github.com/mistralai/mistral-vibe) (`uv tool install mistral-vibe`, then configure
+  `MISTRAL_API_KEY`).
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -152,8 +163,12 @@ This package is intentionally inspectable:
 - `kimi-delegate` — verified end-to-end on macOS against `kimi` 0.24.0 (headless `-p` edit run,
   stream-json parsing, `--session`/`--continue` resume).
 - `opencode-delegate` — requires `--model`, since OpenCode has no safe default.
+- `vibe-delegate` — argument handling, exit codes, `result.json` shape, and the relay watchdog
+  validated locally (`node relay.mjs --help` confirmed; end-to-end run against a live `vibe` binary
+  not performed in this environment).
 - Windows: the codex/opencode launches handle the `.cmd` shim (`shell:true` + quoting); native Windows
-  launch smokes for `agy`/`grok`/`kimi` are still pending.
+  launch smokes for `agy`/`grok`/`kimi` are still pending. Vibe officially targets UNIX environments;
+  consult the Mistral Vibe documentation for Windows guidance.
 - The full delegate → review → commit loop is designed for and run on Claude Code; other orchestrators
   (Cursor, …) are designed-for but unproven.
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ Same loop for the Mistral Vibe CLI (`vibe`). Normal runs use `accept-edits`, whi
 built-in file edits but rejects tools that still require approval in headless mode. `--full-access`
 is the explicit opt-in to `auto-approve`; `--plan-only` selects Vibe's read-only `plan` agent.
 The relay always passes `--trust` to skip only the directory-trust prompt — it does not grant tool
-permissions or add a sandbox. Turn, price, and token limits can bound a run. Vibe's streaming output
-does not expose the new session id, so use `--resume-last` unless you already know a specific id.
+permissions or add a sandbox. Turn and token limits can bound a run; `--max-price` is indicative, not
+a hard budget. Vibe's streaming output does not expose the new session id, so use `--resume-last`
+unless you already know a specific id.
 
 ### gemini-delegate
 
@@ -167,8 +168,8 @@ bundled `relay.mjs` is the default because it needs nothing but the `codex` bina
   [`kimi`](https://moonshotai.github.io/kimi-code/en/) (`brew install kimi-code`, then `kimi login`) ·
   [`qodercli`](https://docs.qoder.com/en/cli/quick-start) (`qodercli login`, or
   `QODER_PERSONAL_ACCESS_TOKEN` for automation) ·
-  [`vibe`](https://github.com/mistralai/mistral-vibe) (`uv tool install mistral-vibe`, then configure
-  `MISTRAL_API_KEY`).
+  [`vibe`](https://github.com/mistralai/mistral-vibe) ([install `uv`](https://docs.astral.sh/uv/getting-started/installation/),
+  then run `uv tool install mistral-vibe` and configure `MISTRAL_API_KEY`).
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -205,14 +206,15 @@ This package is intentionally inspectable:
   macOS by the contributor against `qodercli` 1.0.47 (Lite edit run, `accept_edits`, explicit model
   and 32768-token context window, no commit).
 - `opencode-delegate` — requires `--model`, since OpenCode has no safe default.
-- `vibe-delegate` — contract-tested for launch-mode, resume, tool-filter, and budget forwarding;
-  bounded version preflight; result parsing; and whole-process-tree timeout/abort cleanup. A live
-  Vibe run and native Windows launch are unverified.
+- `vibe-delegate` — contract-tested for launch-mode, resume, tool-filter, and turn/price/token
+  forwarding; bounded version preflight; result parsing; and whole-process-tree timeout/abort
+  cleanup. A live Vibe run and native Windows launch are unverified.
 - Windows: the codex/opencode launches handle the `.cmd` shim (`shell:true` + quoting); the Qoder
   and Vibe relays target their currently documented native executables. Native Windows launch smokes
   for `claude`/`agy`/`grok`/`kimi`/`qoder`/`vibe` are still pending. Claude's own shell sandbox is
-  unsupported on native Windows regardless of launch mechanics; Vibe officially targets UNIX
-  environments, and its native Windows launch is unverified.
+  unsupported on native Windows regardless of launch mechanics. Upstream Vibe works on Windows but
+  officially supports and targets UNIX; this repository has not smoke-tested the relay's native
+  Windows launch.
 - The full delegate → review → commit loop is designed for and run on Claude Code; other orchestrators
   (Cursor, …) are designed-for but unproven.
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -9,7 +9,8 @@
         "opencode-delegate",
         "agy-delegate",
         "grok-delegate",
-        "kimi-delegate"
+        "kimi-delegate",
+        "vibe-delegate"
       ]
     }
   ]

--- a/skills/vibe-delegate/SKILL.md
+++ b/skills/vibe-delegate/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: vibe-delegate
+description: >-
+  Delegate a coding task to the Mistral Vibe CLI (`vibe`) as a background implementer, then review its
+  diff and land it yourself. Use this whenever the user wants to hand implementation work to Vibe —
+  phrasings like "have Vibe implement X", "delegate this to Vibe", "run it through Mistral Vibe", "use
+  vibe to implement/fix/refactor" — or wants to run a queue of coding tasks through Vibe while staying
+  the reviewer. DO NOT USE for tasks small enough to do inline, or when the user wants the code written
+  directly without delegating.
+license: MIT
+metadata:
+  version: 0.1.0
+---
+
+# Vibe Delegate
+
+You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** — the Mistral
+Vibe CLI (`vibe`) — then review what it produced and land it yourself. You write the brief and own
+the judgment; Vibe does the typing in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `vibe` CLI is not installed or authenticated.
+- You need a CLI-enforced read-only implementer. Vibe's `plan` agent is best-effort read-only only.
+
+## Prerequisites (check once)
+
+1. Install Mistral Vibe:
+   - **Linux/macOS (recommended):** `curl -LsSf https://mistral.ai/vibe/install.sh | bash`
+   - **With uv:** `uv tool install mistral-vibe`
+2. Configure your API key with `vibe --setup`, or set `MISTRAL_API_KEY` in the environment.
+3. Confirm `vibe --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Vibe sees only the text you send plus what it can inspect in the workspace — no chat history or shared
+context. Include the goal, current state, what to change, what to leave untouched, the project's
+**actual** gates, and a report contract. Tell Vibe not to commit. Keep one task per brief. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled helper. It wraps Vibe's headless `--prompt` mode, captures the structured event
+stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# limit turns for cost control:           add --max-turns <n>
+# planning/read-only (best-effort):       add --plan-only
+# resume the most recent session:         add --resume-last  (delta brief only)
+# resume a specific session:              add --session <id> (delta brief only)
+# see all options:                        node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. The relay writes artifacts under the system temp dir by
+default and never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Vibe finishes. Run it with the orchestrator's background-command facility, or
+background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `vibe` exits 127 and writes `status: "vibe_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process exited
+and `result.json` exists.
+
+### 4. Review — do not trust the self-report
+
+Treat Vibe's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates pass
+and the diff holds. If rework is needed, send a delta brief with `--resume-last` or `--session <id>`,
+then review again.
+
+## Autonomy and permissions
+
+In `--prompt` mode the relay always sets the agent profile explicitly:
+
+| Relay flag | What Vibe gets | Use when |
+| --- | --- | --- |
+| *(default)* | `--agent auto-approve` | Normal implementation — auto-approves all tool executions |
+| `--plan-only` | `--agent plan` | Review/diagnosis — **best-effort, not enforced** |
+
+The `plan` agent auto-approves only safe read tools (e.g. `grep`, `read`). Write tools require
+approval, which will not happen in headless mode — so the agent should not attempt them. Still,
+inspect `touchedFiles` and the diff after every run. The diff, not a flag, is the guarantee.
+
+`--trust` is always passed to prevent interactive trust prompts in headless runs.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't absorb**
+(report Vibe's design decisions, defensible-but-unasked turns, and non-blocking nitpicks) and **stop
+for scope changes** (if correct completion needs going beyond the brief, ask instead of expanding the
+mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — structure, report contract,
+  real gates, argv delivery, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) — review checklist, commit boundary,
+  and rework through Vibe sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — sequential queues, constraint
+  carry-forward, progress tracking, and the final coherence pass.

--- a/skills/vibe-delegate/SKILL.md
+++ b/skills/vibe-delegate/SKILL.md
@@ -27,7 +27,7 @@ The loop needs only a shell command and file access, so any comparable orchestra
 
 ## Prerequisites (check once)
 
-1. Install Mistral Vibe:
+1. Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/), then Mistral Vibe:
    - `uv tool install mistral-vibe`
 2. Configure your API key with `vibe --setup`, or set `MISTRAL_API_KEY` in the environment.
 3. Confirm `vibe --version` succeeds.
@@ -55,7 +55,7 @@ stream, and writes `result.json`. (`<skill-dir>` is the installed folder contain
 ```bash
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # limit turns for cost control:           add --max-turns <n>
-# cap price or total tokens:              add --max-price <usd> --max-tokens <n>
+# indicative price threshold/token cap:  add --max-price <usd> --max-tokens <n>
 # planning/read-only:                     add --plan-only
 # unrestricted shell and tools:           add --full-access (explicit authorization required)
 # resume the most recent session:         add --resume-last  (delta brief only)

--- a/skills/vibe-delegate/references/dispatch-and-poll.md
+++ b/skills/vibe-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,132 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps Vibe's headless `--prompt` mode, captures its structured stream, and writes
+a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v vibe
+vibe --version
+```
+
+Install on Linux/macOS with the one-line installer:
+
+```bash
+curl -LsSf https://mistral.ai/vibe/install.sh | bash
+```
+
+Or with uv: `uv tool install mistral-vibe`. Then configure your API key:
+
+```bash
+vibe --setup                    # interactive setup
+export MISTRAL_API_KEY="..."    # or set it in the environment
+```
+
+Mistral Vibe works on Windows, but the upstream project officially targets UNIX environments. Consult
+the [official Mistral Vibe documentation](https://github.com/mistralai/mistral-vibe) for Windows
+guidance.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--max-turns <n>` | Maximum number of Vibe agent turns (`--max-turns`). Useful for cost control. |
+| `--session <id>` | Resume a specific Vibe session (`--resume SESSION_ID`); send only the delta brief. |
+| `--resume-last` | Resume the most recent Vibe session (`--continue`); send only the delta brief. |
+| `--plan-only` | Use Vibe's `plan` agent (exploration/planning, best-effort read-only — verify `touchedFiles`). |
+| `--enabled-tools <tool>` | Enable only this tool (`--enabled-tools`). Repeatable. |
+| `--disabled-tools <tool>` | Disable this tool (`--disabled-tools`). Repeatable. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Vibe has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The relay always passes `--trust` to Vibe so
+headless runs do not prompt for directory trust.
+
+Default mode uses Vibe's `auto-approve` agent, which auto-approves all tool executions. `--plan-only`
+uses the `plan` agent (auto-approves safe read tools only). Inspect `touchedFiles` and the diff after
+every run.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an `--out-dir`
+inside the worktree can make the artifacts appear there:
+
+- `brief.txt` — the exact brief.
+- `events.jsonl` — raw Vibe stdout in streaming JSON format.
+- `final.txt` — assistant text joined with a blank line between chunks; absent if none was emitted.
+- `stderr.txt` — complete stderr.
+- `result.json` — the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"vibe"`), `status` (`completed` | `failed` | `vibe_unavailable`), `exitCode`,
+  and `signal` (`null` unless the child died on a signal).
+- `workdir`, `agent` (`"auto-approve"` or `"plan"`), `maxTurns`, `resumed`, `vibeVersion`,
+  `sessionId`, `startedAt`, and `finishedAt`.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `finalMessage` — assistant content strings joined with `"\n\n"`; tool calls and tool results are
+  excluded.
+- `touchedFiles` — `git status --porcelain` lines for the **final working tree under `--cd`**. Not
+  an attribution of Vibe's edits: anything already dirty before dispatch shows up too. Dispatch from
+  a clean tree when you want the list to read as "what Vibe changed". `null` means git could not
+  report; `[]` means git ran and the tree is clean.
+- `stderrTail` — the last 20 non-empty stderr lines on failure.
+- `error` — present for launch failures or when the relay watchdog fires.
+
+Note: `sessionId` is extracted from Vibe's streaming output on a best-effort basis. If `sessionId`
+is `null`, use `--resume-last` to continue the most recent session without a specific ID.
+
+## Waiting for completion
+
+The helper blocks. Use the orchestrator's background-command facility, or background it in a shell and
+poll for `result.json`. The run is done only when the process exits and the file contains a `status`.
+
+A pre-run usage error exits 2 and writes no result. A missing `vibe` exits 127 and writes
+`status: "vibe_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "vibe_unavailable"` (exit 127):** `vibe` isn't on PATH. Install with
+  `uv tool install mistral-vibe` and configure `MISTRAL_API_KEY`, then re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
+  causes: an unconfigured or expired API key, an invalid model, or a trust-folder prompt that was
+  not suppressed (the relay passes `--trust`, but check that the binary supports it).
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through the
+  OOM killer or a supervisor timeout. This is not a Vibe error; check host memory and re-dispatch, or
+  split the task into smaller briefs.
+- **Watchdog failure:** `error` reads
+  `vibe did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout` or
+  split the task. The relay sends SIGTERM, waits 10 seconds, then sends SIGKILL if needed.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report. The streaming events
+  in `events.jsonl` are the source of truth for diagnosing missing messages.
+
+## What the relay runs
+
+The argv is equivalent to:
+
+```bash
+vibe --output streaming --agent auto-approve --trust \
+  [--max-turns <n>] [--resume SESSION_ID | --continue] \
+  [--enabled-tools TOOL ...] [--disabled-tools TOOL ...] \
+  --prompt=<brief>
+```
+
+The prompt rides argv and is visible in the host process list. The relay rejects briefs over 120 KB
+before launch because the OS caps a single argument. It spawns `vibe` directly with `--cd` as cwd;
+no shell or Vibe timeout flag is involved.
+
+## The commit boundary
+
+The relay never commits. Vibe edits the working tree; the orchestrator reviews, re-runs the gates, and
+commits. See [review-and-land.md](review-and-land.md).

--- a/skills/vibe-delegate/references/dispatch-and-poll.md
+++ b/skills/vibe-delegate/references/dispatch-and-poll.md
@@ -10,14 +10,16 @@ command -v vibe
 vibe --version
 ```
 
-Install with `uv tool install mistral-vibe`. Then configure your API key:
+Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/), then install Vibe with
+`uv tool install mistral-vibe`. Configure your API key:
 
 ```bash
 vibe --setup                    # interactive setup
 export MISTRAL_API_KEY="..."    # or set it in the environment
 ```
 
-Mistral Vibe officially targets UNIX environments. Native Windows launch is unverified; consult the
+Upstream Vibe works on Windows but officially supports and targets UNIX. This repository has not
+smoke-tested the relay's native Windows launch; consult the
 [official Mistral Vibe documentation](https://github.com/mistralai/mistral-vibe) for Windows guidance.
 
 ## Dispatching
@@ -33,7 +35,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
 | `--cd <dir>` | Working root and child process cwd (default: current directory). |
 | `--max-turns <n>` | Maximum number of Vibe agent turns (`--max-turns`). Useful for cost control. |
-| `--max-price <usd>` | Positive maximum session cost in USD (`--max-price`). |
+| `--max-price <usd>` | Positive, indicative cost threshold in USD; not a hard budget (`--max-price`). |
 | `--max-tokens <n>` | Positive maximum cumulative session tokens (`--max-tokens`). |
 | `--session <id>` | Resume a specific Vibe session (`--resume SESSION_ID`); send only the delta brief. |
 | `--resume-last` | Resume the most recent Vibe session (`--continue`); send only the delta brief. |
@@ -93,8 +95,9 @@ A pre-run usage error exits 2 and writes no result. A missing `vibe` exits 127 a
 
 ## When a run misbehaves
 
-- **`status: "vibe_unavailable"` (exit 127):** `vibe` isn't on PATH. Install with
-  `uv tool install mistral-vibe` and configure `MISTRAL_API_KEY`, then re-dispatch.
+- **`status: "vibe_unavailable"` (exit 127):** `vibe` isn't on PATH. Install
+  [`uv`](https://docs.astral.sh/uv/getting-started/installation/), run
+  `uv tool install mistral-vibe`, and configure `MISTRAL_API_KEY`, then re-dispatch.
 - **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
   causes: an unconfigured or expired API key, an invalid model, or a trust-folder prompt that was
   not suppressed (the relay passes `--trust`, but check that the binary supports it).

--- a/skills/vibe-delegate/references/multi-task-queues.md
+++ b/skills/vibe-delegate/references/multi-task-queues.md
@@ -1,0 +1,58 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is the
+default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh Vibe sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture location,
+or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed Vibe session only for rework on the same task. Send a delta brief with `--resume-last`,
+or with `--session <id>` from that task's `result.json`. Start unrelated queue items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** — queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** — what landed, what you verified, and gate outcomes.
+- **Needs your eyes** — design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** — the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/vibe-delegate/references/review-and-land.md
+++ b/skills/vibe-delegate/references/review-and-land.md
@@ -1,0 +1,78 @@
+# Review and land
+
+Vibe did the typing; you own the judgment. Verify against reality, never the self-report, and read the
+diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries Vibe's claims, not evidence. Re-run the project's actual test, lint, and build
+commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** — changes the brief excluded.
+- **Scope shortfall** — missed behavior, edges, or cleanup.
+- **Quiet judgment calls** — defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to Vibe as a delta brief, or fix it in the tree, and report either choice
+to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer. Write a
+clear message describing what landed.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove
+the unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json`. If `sessionId`
+is `null` in `result.json`, use `--resume-last` to continue the most recent session. Rework gets the
+same gate rerun, test review, diff review, and implementer sweep.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep them
+in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/vibe-delegate/references/writing-the-brief.md
+++ b/skills/vibe-delegate/references/writing-the-brief.md
@@ -1,0 +1,120 @@
+# Writing the brief
+
+A brief is the entire task as Vibe will see it. It runs in a separate session with **no memory of your
+conversation, no access to prior notes, and no shared context** — only the text you send and whatever
+it can inspect in the workspace. If a constraint is not in the brief or discoverable in the repo, it
+does not exist for Vibe.
+
+## Resumed sessions
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report Vibe must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** — add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences, and
+  open questions).
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from Vibe's assistant messages in its structured stream. Without a
+closing summary, the edits may exist but the result is hard to review. The
+`<structured_output_contract>` block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy the
+actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Vibe can inspect the workspace, but the important
+constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief → one Vibe run → one reviewed commit keeps the diff and rollback
+clean. Split mixed implementation, review, documentation, and roadmap requests into separate
+dispatches.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Argv delivery limits
+
+Vibe's headless mode requires the brief as a command-line argument via `--prompt`. The relay reads a
+file or stdin for convenience, then passes the text with `--prompt=<brief>`. The equals form binds a
+brief that starts with `-` instead of treating it as another flag.
+
+This has two consequences:
+
+- The brief is visible in the host process list (`ps`, `/proc`). Keep secrets out of it on shared
+  machines; reference workspace files or environment variables instead.
+- A brief over 120 KB is rejected before launch because operating systems cap a single argv value.
+  Put large context in the workspace and tell Vibe which file to read.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/vibe-delegate/scripts/relay.mjs
+++ b/skills/vibe-delegate/scripts/relay.mjs
@@ -1,0 +1,497 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · vibe-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Mistral Vibe CLI (`vibe --prompt`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Vibe-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `vibe` and `git`. The `vibe` process it launches
+ * does authenticate — exactly as you do at the terminal. Read this file before
+ * you run it.
+ *
+ * Note: `vibe --prompt` takes the prompt as a command-line argument, so the
+ * brief is visible in the host process list (`ps`, /proc). On a shared machine
+ * keep secrets out of the brief — reference them by a path or environment
+ * variable the workspace can read.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Default mode uses Vibe's `auto-approve` agent profile, which auto-approves
+ * all tool executions. `--plan-only` uses the `plan` agent (exploration and
+ * planning, auto-approves only safe read tools); this is best-effort — check
+ * `touchedFiles` and the diff after every run regardless of mode.
+ *
+ * Mistral Vibe works on Windows, but the upstream project officially targets
+ * UNIX environments. The relay does not set `shell:true` on win32, so Windows
+ * is untested; consult the Mistral Vibe documentation for Windows guidance.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>           Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>               Working root for Vibe (default: current directory).
+ *   --max-turns <n>          Maximum number of Vibe agent turns (--max-turns).
+ *   --session <id>           Resume a specific Vibe session (--resume SESSION_ID);
+ *                            send only the delta brief.
+ *   --resume-last            Resume the most recent Vibe session (--continue);
+ *                            send only the delta brief.
+ *   --plan-only              Use Vibe's plan agent (exploration/planning, best-
+ *                            effort read-only — verify touchedFiles after run).
+ *   --enabled-tools <tool>   Enable only this tool (--enabled-tools). Repeatable.
+ *   --disabled-tools <tool>  Disable this tool (--disabled-tools). Repeatable.
+ *   --timeout <dur>          Relay-side watchdog (default: 30m). Vibe has no
+ *                            timeout flag; durations use h/m/s strings.
+ *   --out-dir <dir>          Where to write run artifacts (default: a fresh dir
+ *                            under the system temp dir).
+ *   -h, --help               Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, vibeVersion, sessionId, finalMessage (Vibe's own
+ *   report), touchedFiles (git porcelain, null if git cannot report), and paths
+ *   to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `vibe` binary exits 127;
+ * otherwise the exit code mirrors Vibe's own (0 success, non-zero failure). If
+ * the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome — completed, failed, or vibe_unavailable.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_TIMEOUT = "30m";
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    maxTurns: null,
+    session: null,
+    resumeLast: false,
+    planOnly: false,
+    enabledTools: [],
+    disabledTools: [],
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--max-turns": {
+        const v = next();
+        const n = Number(v);
+        if (!Number.isInteger(n) || n < 1) fail(`--max-turns must be a positive integer; got: ${v}`);
+        opts.maxTurns = n;
+        break;
+      }
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--plan-only": opts.planOnly = true; break;
+      case "--enabled-tools": opts.enabledTools.push(next()); break;
+      case "--disabled-tools": opts.disabledTools.push(next()); break;
+      case "--timeout": opts.timeout = next(); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  // The watchdog is relay-only (vibe has no timeout flag), so a malformed
+  // --timeout must fail loudly here — a silent 30m fallback would be wrong.
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to vibe --prompt\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function vibeVersion() {
+  try {
+    const out = execFileSync("vibe", ["--version"], { encoding: "utf8" }).trim();
+    return out || "unknown";
+  } catch (err) {
+    // Only a missing binary means "unavailable"; any other version-probe
+    // failure must not masquerade as exit 127.
+    if (err && err.code === "ENOENT") return null;
+    return "unknown";
+  }
+}
+
+function parseDuration(duration) {
+  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git cannot report — git missing, or a non-repo run — so
+  // the caller can tell "git unavailable" apart from "Vibe changed nothing."
+  // [] means git ran and the working tree is clean.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, brief) {
+  const argv = [
+    "--output", "streaming",
+    "--agent", opts.planOnly ? "plan" : "auto-approve",
+    "--trust",
+  ];
+  if (opts.maxTurns != null) argv.push("--max-turns", String(opts.maxTurns));
+  if (opts.session) argv.push("--resume", opts.session);
+  else if (opts.resumeLast) argv.push("--continue");
+  for (const tool of opts.enabledTools) argv.push("--enabled-tools", tool);
+  for (const tool of opts.disabledTools) argv.push("--disabled-tools", tool);
+  // Use --prompt=<brief>, not a separate ["--prompt", brief] pair: the equals
+  // form binds a brief that starts with "-" instead of letting it parse as a flag.
+  argv.push(`--prompt=${brief}`);
+  return argv;
+}
+
+function makeLineScanner(onObject) {
+  // Vibe's --output streaming emits newline-delimited JSON: one JSON object per
+  // line. Parse line by line; skip blank lines and non-JSON gracefully.
+  let buf = "";
+  return (chunk) => {
+    buf += chunk;
+    const lines = buf.split("\n");
+    buf = lines.pop() ?? "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try { onObject(JSON.parse(trimmed)); } catch { /* skip non-JSON lines */ }
+    }
+  };
+}
+
+function extractFromEvent(obj, textChunks, sessionIdRef) {
+  if (!obj || typeof obj !== "object") return;
+
+  // Session ID extraction (best-effort; checked on every event type since the
+  // session metadata can appear in any message).
+  if (typeof obj.session_id === "string" && obj.session_id) {
+    sessionIdRef.value = obj.session_id;
+  } else if (obj.metadata && typeof obj.metadata.session_id === "string") {
+    sessionIdRef.value = obj.metadata.session_id;
+  }
+
+  // Primary format: { role: "assistant", content: "..." }
+  if (obj.role === "assistant") {
+    const content =
+      typeof obj.content === "string"
+        ? obj.content
+        : Array.isArray(obj.content)
+          ? obj.content
+              .filter((c) => c && c.type === "text")
+              .map((c) => (typeof c.text === "string" ? c.text : ""))
+              .join("")
+          : "";
+    if (content) textChunks.push(content);
+    return;
+  }
+
+  // OpenAI-style streaming delta: { choices: [{ delta: { role: "assistant", content: "..." } }] }
+  if (Array.isArray(obj.choices)) {
+    for (const choice of obj.choices) {
+      const delta = choice && choice.delta;
+      if (delta && typeof delta.content === "string" && delta.content) {
+        textChunks.push(delta.content);
+      }
+    }
+  }
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir =
+    opts.outDir ||
+    join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "vibe",
+      workdir: opts.cd,
+      agent: opts.planOnly ? "plan" : "auto-approve",
+      maxTurns: opts.maxTurns,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      vibeVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "vibe_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write(
+    "relay: `vibe` not found on PATH. Install with `uv tool install mistral-vibe` and configure MISTRAL_API_KEY.\n",
+  );
+  process.exit(127);
+}
+
+function dispatchToVibe(opts, brief, run, writeResult) {
+  const child = spawn("vibe", buildArgv(opts, brief), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const sessionIdRef = { value: null };
+  const textChunks = [];
+  const stderrTail = [];
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  const scan = makeLineScanner((obj) => extractFromEvent(obj, textChunks, sessionIdRef));
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    child.kill("SIGTERM");
+    sigkillTimer = setTimeout(() => {
+      if (!settled) child.kill("SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId: sessionIdRef.value,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    // A timed-out run is failed even if vibe handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId: sessionIdRef.value,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired
+        ? {
+            error: `vibe did not finish within --timeout ${opts.timeout}; killed by the relay watchdog`,
+          }
+        : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // vibe --prompt takes the prompt as a CLI argument, so the brief rides argv.
+  // The OS caps one argument (~128KB on Linux via MAX_ARG_STRLEN); reject a
+  // huge brief early instead of allowing an opaque E2BIG spawn failure.
+  const briefBytes = Buffer.byteLength(brief, "utf8");
+  const MAX_BRIEF_BYTES = 120 * 1024;
+  if (briefBytes > MAX_BRIEF_BYTES) {
+    fail(
+      `brief is ${Math.round(briefBytes / 1024)}KB; vibe passes the prompt as a CLI argument, which the OS caps (~128KB on Linux). Trim it, or have vibe read large context from the workspace instead of inlining it.`,
+    );
+  }
+
+  const version = vibeVersion();
+  const run = prepareRunDir(opts, brief);
+  const writeResult = makeResultWriter(opts, version, run);
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  dispatchToVibe(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(
+    `relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  vibe ${result.vibeVersion ?? "?"}`,
+  );
+  if (result.signal === "SIGKILL") {
+    lines.push(
+      "hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a vibe error; check host memory and re-dispatch, or split the task into smaller briefs.",
+    );
+  }
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.sessionId) {
+    lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  }
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- vibe final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push(
+    "relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.",
+  );
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/vibe-delegate/scripts/relay.mjs
+++ b/skills/vibe-delegate/scripts/relay.mjs
@@ -27,8 +27,8 @@
  * `--full-access` explicitly opts into `auto-approve`; `--plan-only` selects
  * Vibe's read-only `plan` agent.
  *
- * Mistral Vibe officially targets UNIX environments. Native Windows launch is
- * unverified; consult the Mistral Vibe documentation for Windows guidance.
+ * Upstream Vibe works on Windows but officially supports and targets UNIX. This
+ * repository has not smoke-tested the relay's native Windows launch.
  *
  * Usage:
  *   node relay.mjs --brief <file> [options]
@@ -38,7 +38,8 @@
  *   --brief <file>           Path to the brief. If omitted, read it from stdin.
  *   --cd <dir>               Working root for Vibe (default: current directory).
  *   --max-turns <n>          Maximum number of Vibe agent turns (--max-turns).
- *   --max-price <usd>        Maximum session cost in USD (--max-price).
+ *   --max-price <usd>        Indicative cost threshold in USD (--max-price);
+ *                            not a hard budget.
  *   --max-tokens <n>         Maximum cumulative session tokens (--max-tokens).
  *   --session <id>           Resume a specific Vibe session (--resume SESSION_ID);
  *                            send only the delta brief.
@@ -412,7 +413,7 @@ function reportUnavailable(opts, writeResult, resultPath) {
   });
   printSummary(result, resultPath);
   process.stderr.write(
-    "relay: `vibe` not found on PATH. Install with `uv tool install mistral-vibe` and configure MISTRAL_API_KEY.\n",
+    "relay: `vibe` not found on PATH. Install `uv`, run `uv tool install mistral-vibe`, and configure MISTRAL_API_KEY.\n",
   );
   process.exit(127);
 }


### PR DESCRIPTION
Implemented using Copilot.

This PR adds support for Mistral Vibe CLI delegation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `vibe-delegate` skill, dispatching work via the Mistral Vibe CLI with planning/full-access modes, session resumption guidance, headless operation, watchdog timeouts, and a structured `result.json` contract.
  * Added `vibe-delegate` to the shipped delegate-skill catalog.
* **Documentation**
  * Added comprehensive `vibe-delegate` guides (brief writing, dispatch/polling artifacts + stable result schema, review-and-land, and multi-task queue workflow) and expanded setup/verification and Windows support notes.
* **Tests**
  * Extended relay smoke tests for `vibe`, covering argv forwarding, version preflight behavior, result parsing, resume semantics, timeout/aborted outcomes, and NUL/oversized brief handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->