### PR TITLE
Relay hardening: a result on every exit path, --timeout everywhere, distinct timeout/aborted statuses

### DIFF
--- a/.github/workflows/relays.yml
+++ b/.github/workflows/relays.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     strategy:
@@ -13,6 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 22

--- a/.github/workflows/relays.yml
+++ b/.github/workflows/relays.yml
@@ -1,0 +1,22 @@
+name: relays
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - run: node test/relay-smoke.mjs
+      - name: validate the skills package
+        if: runner.os == 'Linux'
+        run: npx -y skills add . --list

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -91,7 +91,10 @@ process has exited and `result.json` is written.
   brief, or a resume.
 - **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
   closed terminal) and forwarded the kill to agy. The result is written before the relay exits;
-  inspect the working tree before re-dispatching.
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
 - **`status: failed` with `signal: "SIGKILL"`:** the host ended the child - commonly the OOM killer
   or a supervisor timeout, not an implementer error. Free up host memory or split the task into
   smaller briefs, then re-dispatch.

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -49,7 +49,7 @@ touched-files report shows only Antigravity's edits and nothing of the helper's 
 
 - `schema` - the result-format version (currently `delegate-relay.result.v1`)
 - `tool` - `agy`
-- `status` - `completed` | `failed` | `agy_unavailable`
+- `status` - `completed` | `failed` | `timeout` | `aborted` | `agy_unavailable`
 - `exitCode` - mirrors Antigravity's exit code; `128` plus the signal number if the child was killed; `127` if `agy` is not on PATH
 - `signal` - the signal that killed the child, otherwise `null`
 - `agyVersion` - inferred from `agy changelog` when available
@@ -62,7 +62,7 @@ touched-files report shows only Antigravity's edits and nothing of the helper's 
 - `workdir`, `model`, `project` (the `--project` you passed, vs `projectId` parsed from the log),
   `sandbox`, `dangerouslySkipPermissions`, `resumed` (true for a `--resume-last` or `--conversation`
   run), `startedAt`, `finishedAt`
-- `stderrTail` - last ~20 stderr lines; present only on a failed run
+- `stderrTail` - last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`)
 - `error` - present only if Antigravity failed to launch
 
 The helper also prints a summary to stdout and exits with Antigravity's exit code, so a wrapping script
@@ -86,6 +86,12 @@ process has exited and `result.json` is written.
 
 - **`status: agy_unavailable` (exit 127):** `agy` is not on PATH. Install the Antigravity CLI and run
   its first-launch setup, then re-dispatch.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to agy. The result is written before the relay exits;
+  inspect the working tree before re-dispatching.
 - **`status: failed` with `signal: "SIGKILL"`:** the host ended the child - commonly the OOM killer
   or a supervisor timeout, not an implementer error. Free up host memory or split the task into
   smaller briefs, then re-dispatch.

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -50,7 +50,7 @@ touched-files report shows only Antigravity's edits and nothing of the helper's 
 - `schema` - the result-format version (currently `delegate-relay.result.v1`)
 - `tool` - `agy`
 - `status` - `completed` | `failed` | `timeout` | `aborted` | `agy_unavailable`
-- `exitCode` - mirrors Antigravity's exit code; `128` plus the signal number if the child was killed; `127` if `agy` is not on PATH
+- `exitCode` - mirrors Antigravity's exit code; `128` plus the signal number if the child was killed; `127` if `agy` is not on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
 - `signal` - the signal that killed the child, otherwise `null`
 - `agyVersion` - inferred from `agy changelog` when available
 - `projectId` / `conversationId` - parsed from the Antigravity log when present
@@ -62,8 +62,8 @@ touched-files report shows only Antigravity's edits and nothing of the helper's 
 - `workdir`, `model`, `project` (the `--project` you passed, vs `projectId` parsed from the log),
   `sandbox`, `dangerouslySkipPermissions`, `resumed` (true for a `--resume-last` or `--conversation`
   run), `startedAt`, `finishedAt`
-- `stderrTail` - last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`)
-- `error` - present only if Antigravity failed to launch
+- `stderrTail` - last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`
+- `error` - present on a launch failure, and on `timeout` and `aborted` runs
 
 The helper also prints a summary to stdout and exits with Antigravity's exit code, so a wrapping script
 can branch on success/failure directly.
@@ -86,9 +86,9 @@ process has exited and `result.json` is written.
 
 - **`status: agy_unavailable` (exit 127):** `agy` is not on PATH. Install the Antigravity CLI and run
   its first-launch setup, then re-dispatch.
-- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
-  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
-  or a resume.
+- **`status: timeout`:** the `--print-timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--print-timeout`, a smaller
+  brief, or a resume.
 - **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
   closed terminal) and forwarded the kill to agy. The result is written before the relay exits;
   inspect the working tree before re-dispatching.

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -358,7 +358,7 @@ function dispatchToAgy(opts, brief, run, writeResult) {
       if (sigkillTimer) clearTimeout(sigkillTimer);
       const finalMessage = stdout.trim();
       if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
-      const result = writeResult({
+      const abortedFields = {
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
         signal: sig,
@@ -366,11 +366,15 @@ function dispatchToAgy(opts, brief, run, writeResult) {
         touchedFiles: gitTouchedFiles(opts.cd),
         stderrTail: stderrTail.slice(-20),
         error: `the relay was killed by ${sig}; agy was terminated with it — inspect the working tree before re-dispatching`,
-      });
+      };
+      const result = writeResult(abortedFields);
       printSummary(result, run.resultPath);
       child.kill("SIGTERM");
       setTimeout(() => {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
         process.exit(result.exitCode);
       }, 2000);
     });

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -442,6 +442,9 @@ function dispatchToAgy(opts, brief, run, writeResult) {
     settled = true;
     clearTimeout(watchdogTimer);
     if (sigkillTimer) clearTimeout(sigkillTimer);
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
     const finalMessage = stdout.trim();
     if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
     // A timed-out run is failed even if agy handles SIGTERM by exiting 0 -

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -59,7 +59,9 @@
  * If the child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome -
- * completed, failed, or agy_unavailable. An orchestrator that polls for the
+ * completed, failed, timeout (the relay watchdog fired after --print-timeout
+ * plus 60s grace), aborted (the relay itself was killed and forwarded the kill
+ * to agy), or agy_unavailable. An orchestrator that polls for the
  * file must therefore also treat a non-zero exit with no file as a usage error.
  */
 
@@ -344,6 +346,36 @@ function dispatchToAgy(opts, brief, run, writeResult) {
     }, 10_000);
   }, timeoutMs + 60_000);
 
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the agy child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdogTimer);
+      if (sigkillTimer) clearTimeout(sigkillTimer);
+      const finalMessage = stdout.trim();
+      if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        finalMessage,
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; agy was terminated with it — inspect the working tree before re-dispatching`,
+      });
+      printSummary(result, run.resultPath);
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
   // Decode across chunk boundaries: a multibyte UTF-8 character split between
   // two data events would otherwise decode as U+FFFD and corrupt the report.
   const stdoutDecoder = new StringDecoder("utf8");
@@ -394,7 +426,7 @@ function dispatchToAgy(opts, brief, run, writeResult) {
     const succeeded = code === 0 && !watchdogFired;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const result = writeResult({
-      status: succeeded ? "completed" : "failed",
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
       exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
       signal: signal ?? null,
       finalMessage,
@@ -438,6 +470,7 @@ function printSummary(result, resultPath) {
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  agy ${result.agyVersion ?? "?"}`);
   if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an agy error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated agy (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumed) lines.push("mode: resumed an existing conversation");
   if (result.projectId) lines.push(`project id: ${result.projectId}`);
   if (result.conversationId) lines.push(`conversation id (resume with: --conversation ${result.conversationId}): ${result.conversationId}`);

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -469,7 +469,7 @@ function printSummary(result, resultPath) {
   const lines = [];
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  agy ${result.agyVersion ?? "?"}`);
-  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an agy error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an agy error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated agy (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumed) lines.push("mode: resumed an existing conversation");
   if (result.projectId) lines.push(`project id: ${result.projectId}`);

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -167,6 +167,24 @@ function readBrief(opts) {
   return stdin;
 }
 
+function killChild(child, signal = "SIGTERM") {
+  // The kill must reach the whole process family, not just the CLI — a tool subprocess left
+  // running would keep editing after the relay reports timeout/aborted. On Windows Node can't
+  // kill a process family without a Job Object, so kill the tree by pid with the OS tool
+  // (/t includes descendants, /f forces it — the tree-kill/npm idiom).
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
+    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
+    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
+    catch { /* already gone — nothing left to kill */ }
+  } else {
+    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
+    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
+    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+  }
+}
+
 function agyVersion() {
   try {
     const out = execFileSync("agy", ["changelog"], { encoding: "utf8" }).trim();
@@ -327,6 +345,7 @@ function dispatchToAgy(opts, brief, run, writeResult) {
     cwd: opts.cd,
     env: { ...process.env, PWD: opts.cd },
     stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
   });
 
   let stdout = "";
@@ -340,9 +359,9 @@ function dispatchToAgy(opts, brief, run, writeResult) {
       child.stdout.destroy();
       child.stderr.destroy();
     });
-    child.kill("SIGTERM");
+    killChild(child);
     sigkillTimer = setTimeout(() => {
-      if (!settled) child.kill("SIGKILL");
+      if (!settled) killChild(child, "SIGKILL");
     }, 10_000);
   }, timeoutMs + 60_000);
 
@@ -369,9 +388,9 @@ function dispatchToAgy(opts, brief, run, writeResult) {
       };
       const result = writeResult(abortedFields);
       printSummary(result, run.resultPath);
-      child.kill("SIGTERM");
+      killChild(child);
       setTimeout(() => {
-        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        killChild(child, "SIGKILL");
         // the child may flush files during the grace window; refresh the snapshot so the
         // artifact matches the tree the orchestrator will actually find
         writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -65,6 +65,7 @@ orchestrators use that same directory — if unsure where it landed, run
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # read-only (review/diagnosis, no edits):   add --read-only
 # continue the previous Codex session:      add --resume-last  (send only the delta brief)
+# hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
 # see all options:                          node .../relay.mjs --help
 ```
 

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -49,7 +49,7 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 `<out-dir>/result.json` is the contract. Fields:
 
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
-- `status` — `completed` | `failed` | `codex_unavailable`
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `codex_unavailable`
 - `exitCode` — mirrors Codex's exit code; `128` plus the signal number if the child was killed; `127` if `codex` isn't on PATH
 - `signal` — the signal that killed the child, otherwise `null`
 - `codexVersion` — the binary that actually ran
@@ -58,7 +58,7 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report — `git` missing, or a non-repo run under `--skip-git-repo-check`; `[]` means git ran and the tree is clean
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSONL event stream, and the final-message file
 - `workdir`, `sandbox`, `model`, `resumeLast`, `startedAt`, `finishedAt`
-- `stderrTail` — last ~20 stderr lines; present **only** on a failed run (a non-zero Codex exit), absent on `completed`, `codex_unavailable`, and launch failures
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `codex_unavailable`, and launch failures
 - `error` — present **only** if Codex failed to launch
 
 The helper also prints a summary to stdout and exits with Codex's exit code, so a wrapping script can
@@ -88,6 +88,12 @@ process has exited and `result.json` is written — not when a status line says 
   Common causes: an auth lapse, an invalid `--model`, or a sandbox that blocked something the task
   needed. Fix the cause and re-dispatch; don't paper over it by doing the work yourself unless that's
   what the user wants.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to codex. The result is written before the relay exits;
+  inspect the working tree before re-dispatching.
 - **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
   or a supervisor timeout, not an implementer error. Free up host memory or split the task into
   smaller briefs, then re-dispatch.

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -50,7 +50,7 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
 - `status` — `completed` | `failed` | `timeout` | `aborted` | `codex_unavailable`
-- `exitCode` — mirrors Codex's exit code; `128` plus the signal number if the child was killed; `127` if `codex` isn't on PATH
+- `exitCode` — mirrors Codex's exit code; `128` plus the signal number if the child was killed; `127` if `codex` isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
 - `signal` — the signal that killed the child, otherwise `null`
 - `codexVersion` — the binary that actually ran
 - `threadId` — feed this to a later `codex exec resume <id>` (or use `--resume-last`)
@@ -59,7 +59,7 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSONL event stream, and the final-message file
 - `workdir`, `sandbox`, `model`, `resumeLast`, `startedAt`, `finishedAt`
 - `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `codex_unavailable`, and launch failures
-- `error` — present **only** if Codex failed to launch
+- `error` — present on a launch failure, and on `timeout` and `aborted` runs
 
 The helper also prints a summary to stdout and exits with Codex's exit code, so a wrapping script can
 branch on success/failure directly.

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -94,7 +94,10 @@ process has exited and `result.json` is written — not when a status line says 
   or a resume.
 - **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
   closed terminal) and forwarded the kill to codex. The result is written before the relay exits;
-  inspect the working tree before re-dispatching.
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
 - **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
   or a supervisor timeout, not an implementer error. Free up host memory or split the task into
   smaller briefs, then re-dispatch.

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -39,6 +39,7 @@ Options:
 | `--read-only` | Shortcut for `--sandbox read-only` — review/diagnosis with no edits. |
 | `--resume-last` | Continue the most recent Codex session; send only the delta brief (see review-and-land). |
 | `--skip-git-repo-check` | Allow running outside a git repo. |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
 
 Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -400,6 +400,9 @@ function dispatchToCodex(opts, brief, run, writeResult) {
     if (settled) return;
     settled = true;
     clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
     if (stdoutBuf.trim()) {
       const tid = recordEventLine(run.eventsPath, stdoutBuf);
       if (tid) threadId = tid;

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -33,6 +33,10 @@
  *   --resume-last           Continue the most recent Codex session; send only the delta brief.
  *                           (Inherits the original session's sandbox and working root.)
  *   --skip-git-repo-check   Allow running outside a git repository.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the codex child is killed
+ *                           and result.json gets status "timeout". Codex has no timeout
+ *                           flag of its own, so the watchdog is relay-only.
  *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
  *                           the system temp dir, so the repo under review stays clean).
  *   -h, --help              Show this help.
@@ -48,8 +52,10 @@
  * If the child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome —
- * completed, failed, or codex_unavailable. An orchestrator that polls for the
- * file must therefore also treat a non-zero exit with no file as a usage error.
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to codex), or codex_unavailable. An
+ * orchestrator that polls for the file must therefore also treat a non-zero exit
+ * with no file as a usage error.
  */
 
 import { spawn, execFileSync } from "node:child_process";
@@ -73,6 +79,7 @@ function parseArgs(argv) {
     sandbox: "workspace-write",
     resumeLast: false,
     skipGitRepoCheck: false,
+    timeout: null,
     outDir: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -96,6 +103,7 @@ function parseArgs(argv) {
       case "--read-only": opts.sandbox = "read-only"; break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--skip-git-repo-check": opts.skipGitRepoCheck = true; break;
+      case "--timeout": opts.timeout = next(); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
         fail(`unknown option: ${arg}`);
@@ -104,7 +112,19 @@ function parseArgs(argv) {
   if (!SANDBOX_MODES.has(opts.sandbox)) {
     fail(`invalid --sandbox "${opts.sandbox}" (expected: ${[...SANDBOX_MODES].join(", ")})`);
   }
+  // The watchdog is relay-only (codex has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
   return opts;
+}
+
+function parseDuration(duration) {
+  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
 function headerComment() {
@@ -290,9 +310,62 @@ function dispatchToCodex(opts, brief, run, writeResult) {
   });
 
   let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      child.kill("SIGTERM");
+      sigkillTimer = setTimeout(() => {
+        if (!settled) child.kill("SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the codex child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const finalMessage = existsSync(run.finalPath) ? readFileSync(run.finalPath, "utf8").trim() : "";
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        threadId,
+        finalMessage,
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; codex was terminated with it — inspect the working tree before re-dispatching`,
+      });
+      printSummary(result, run.resultPath);
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
   child.on("error", (err) => {
     if (settled) return;
     settled = true;
+    clearWatchdog();
     const result = writeResult({ status: "failed", exitCode: 1, signal: null, threadId, finalMessage: "", touchedFiles: gitTouchedFiles(opts.cd), error: String(err && err.message ? err.message : err) });
     printSummary(result, run.resultPath);
     process.exit(1);
@@ -301,19 +374,25 @@ function dispatchToCodex(opts, brief, run, writeResult) {
   child.on("close", (code, signal) => {
     if (settled) return;
     settled = true;
+    clearWatchdog();
     if (stdoutBuf.trim()) {
       const tid = recordEventLine(run.eventsPath, stdoutBuf);
       if (tid) threadId = tid;
     }
     const finalMessage = existsSync(run.finalPath) ? readFileSync(run.finalPath, "utf8").trim() : "";
+    // A timed-out run is never a success even if codex handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const result = writeResult({
-      status: code === 0 ? "completed" : "failed",
-      exitCode: code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1),
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
       signal: signal ?? null,
       threadId,
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
-      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `codex did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
@@ -348,6 +427,7 @@ function printSummary(result, resultPath) {
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  codex ${result.codexVersion ?? "?"}`);
   if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a codex error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated codex (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumeLast) lines.push("mode: resumed most recent session");
   if (result.threadId) lines.push(`thread id (resume with: codex exec resume ${result.threadId}): ${result.threadId}`);
   const touched = result.touchedFiles;

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -426,7 +426,7 @@ function printSummary(result, resultPath) {
   const lines = [];
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  codex ${result.codexVersion ?? "?"}`);
-  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a codex error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a codex error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated codex (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumeLast) lines.push("mode: resumed most recent session");
   if (result.threadId) lines.push(`thread id (resume with: codex exec resume ${result.threadId}): ${result.threadId}`);

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -127,6 +127,21 @@ function parseDuration(duration) {
   return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
+function killChild(child) {
+  // On Windows the child is the .cmd shim (the shell:true launch above), so signalling it does
+  // not reach the Codex process it spawned — the run would keep editing after the relay reports
+  // timeout/aborted. Windows has no process-group signals and Node can't kill a process family
+  // without a Job Object, so kill the tree by pid with the OS tool: /t includes descendants,
+  // /f forces it. This is the same idiom tree-kill and npm/pnpm use. POSIX keeps real signals
+  // (the SIGKILL escalation at each call site still applies there).
+  if (process.platform === "win32") {
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" }); }
+    catch { /* already exited, or no such pid */ }
+  } else {
+    child.kill("SIGTERM");
+  }
+}
+
 function headerComment() {
   // The leading block comment doubles as --help text.
   const src = readFileSync(new URL(import.meta.url), "utf8");
@@ -321,7 +336,7 @@ function dispatchToCodex(opts, brief, run, writeResult) {
         child.stdout.destroy();
         child.stderr.destroy();
       });
-      child.kill("SIGTERM");
+      killChild(child);
       sigkillTimer = setTimeout(() => {
         if (!settled) child.kill("SIGKILL");
       }, 10_000);
@@ -354,7 +369,7 @@ function dispatchToCodex(opts, brief, run, writeResult) {
         error: `the relay was killed by ${sig}; codex was terminated with it — inspect the working tree before re-dispatching`,
       });
       printSummary(result, run.resultPath);
-      child.kill("SIGTERM");
+      killChild(child);
       setTimeout(() => {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }
         process.exit(result.exitCode);

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -135,8 +135,10 @@ function killChild(child) {
   // /f forces it. This is the same idiom tree-kill and npm/pnpm use. POSIX keeps real signals
   // (the SIGKILL escalation at each call site still applies there).
   if (process.platform === "win32") {
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" }); }
-    catch { /* already exited, or no such pid */ }
+    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
+    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
+    catch { /* already gone — nothing left to kill */ }
   } else {
     child.kill("SIGTERM");
   }

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -360,7 +360,7 @@ function dispatchToCodex(opts, brief, run, writeResult) {
       settled = true;
       clearWatchdog();
       const finalMessage = existsSync(run.finalPath) ? readFileSync(run.finalPath, "utf8").trim() : "";
-      const result = writeResult({
+      const abortedFields = {
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
         signal: sig,
@@ -369,11 +369,15 @@ function dispatchToCodex(opts, brief, run, writeResult) {
         touchedFiles: gitTouchedFiles(opts.cd),
         stderrTail: stderrTail.slice(-20),
         error: `the relay was killed by ${sig}; codex was terminated with it — inspect the working tree before re-dispatching`,
-      });
+      };
+      const result = writeResult(abortedFields);
       printSummary(result, run.resultPath);
       killChild(child);
       setTimeout(() => {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
         process.exit(result.exitCode);
       }, 2000);
     });

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -127,20 +127,23 @@ function parseDuration(duration) {
   return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
-function killChild(child) {
-  // On Windows the child is the .cmd shim (the shell:true launch above), so signalling it does
-  // not reach the Codex process it spawned — the run would keep editing after the relay reports
-  // timeout/aborted. Windows has no process-group signals and Node can't kill a process family
-  // without a Job Object, so kill the tree by pid with the OS tool: /t includes descendants,
-  // /f forces it. This is the same idiom tree-kill and npm/pnpm use. POSIX keeps real signals
-  // (the SIGKILL escalation at each call site still applies there).
+function killChild(child, signal = "SIGTERM") {
+  // The kill must reach the whole process family, not just the immediate child — a tool
+  // subprocess left running would keep editing after the relay reports timeout/aborted.
+  // On Windows the child is the .cmd shim (the shell:true launch above), Windows has no
+  // process-group signals, and Node can't kill a process family without a Job Object, so
+  // kill the tree by pid with the OS tool: /t includes descendants, /f forces it — the
+  // same idiom tree-kill and npm/pnpm use.
   if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
     // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
     // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
     try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
     catch { /* already gone — nothing left to kill */ }
   } else {
-    child.kill("SIGTERM");
+    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
+    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
+    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
   }
 }
 
@@ -294,7 +297,8 @@ function dispatchToCodex(opts, brief, run, writeResult) {
   // shell:true on Windows so the codex.cmd shim resolves (see codexVersion). Safe:
   // the brief is fed via child.stdin below — never argv — and argv holds only
   // sandbox enums, model names, and file paths, with no shell metacharacters.
-  const child = spawn("codex", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32" });
+  // detached on POSIX: the child leads a new process group so killChild can fell the whole tree
+  const child = spawn("codex", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32", detached: process.platform !== "win32" });
 
   let threadId = null;
   let stdoutBuf = "";
@@ -340,7 +344,7 @@ function dispatchToCodex(opts, brief, run, writeResult) {
       });
       killChild(child);
       sigkillTimer = setTimeout(() => {
-        if (!settled) child.kill("SIGKILL");
+        if (!settled) killChild(child, "SIGKILL");
       }, 10_000);
     }, timeoutMs);
   }
@@ -374,7 +378,7 @@ function dispatchToCodex(opts, brief, run, writeResult) {
       printSummary(result, run.resultPath);
       killChild(child);
       setTimeout(() => {
-        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        killChild(child, "SIGKILL");
         // the child may flush files during the grace window; refresh the snapshot so the
         // artifact matches the tree the orchestrator will actually find
         writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -68,6 +68,7 @@ orchestrators use that same directory — if unsure where it landed, run
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # read-only (review/diagnosis; best-effort — verify touchedFiles): add --read-only
 # continue the previous Grok session:       add --resume-last  (send only the delta brief)
+# hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
 # see all options:                          node .../relay.mjs --help
 ```
 

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -41,6 +41,7 @@ Options:
 | `--full-access` | Unrestricted auto-approve (`--always-approve --sandbox off`); opt-in. |
 | `--resume-last` | Continue the most recent Grok session for this cwd; send only the delta brief. |
 | `--session <id>` | Continue a specific session id; mutually exclusive with `--resume-last`. |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
 
 Default autonomy (neither `--read-only` nor `--full-access`) is **workspace-write**:

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -56,7 +56,7 @@ touched-files report shows only Grok's edits and nothing of the helper's own.
 
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
 - `tool` — `"grok"`
-- `status` — `completed` | `failed` | `grok_unavailable`
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `grok_unavailable`
 - `exitCode` — mirrors Grok's exit code; `128` plus the signal number if the child was killed; `127` if `grok` isn't on PATH
 - `signal` — the signal that killed the child, otherwise `null`
 - `grokVersion` — the binary that actually ran
@@ -70,7 +70,7 @@ touched-files report shows only Grok's edits and nothing of the helper's own.
   between dispatch and completion, i.e. the best-effort read-only was not honored. A porcelain-level
   tripwire: it catches new dirt, but an edit inside an already-dirty file can evade it — the diff
   review, not this flag, is the guarantee
-- `stderrTail` — last ~20 stderr lines; present **only** on a failed run (a non-zero Grok exit), absent on `completed`, `grok_unavailable`, and launch failures
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `grok_unavailable`, and launch failures
 - `error` — present **only** if Grok failed to launch
 
 The helper also prints a summary to stdout and exits with Grok's exit code, so a wrapping script can
@@ -96,6 +96,12 @@ process has exited and `result.json` is written — not when a status line says 
 
 - **`status: grok_unavailable` (exit 127):** `grok` isn't on PATH or isn't found. Install with
   `npm i -g @xai-official/grok` and `grok login`, then re-dispatch.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to grok. The result is written before the relay exits;
+  inspect the working tree before re-dispatching.
 - **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
   or a supervisor timeout, not an implementer error. Free up host memory or split the task into
   smaller briefs, then re-dispatch.

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -102,7 +102,10 @@ process has exited and `result.json` is written — not when a status line says 
   or a resume.
 - **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
   closed terminal) and forwarded the kill to grok. The result is written before the relay exits;
-  inspect the working tree before re-dispatching.
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
 - **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
   or a supervisor timeout, not an implementer error. Free up host memory or split the task into
   smaller briefs, then re-dispatch.

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -57,7 +57,7 @@ touched-files report shows only Grok's edits and nothing of the helper's own.
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
 - `tool` — `"grok"`
 - `status` — `completed` | `failed` | `timeout` | `aborted` | `grok_unavailable`
-- `exitCode` — mirrors Grok's exit code; `128` plus the signal number if the child was killed; `127` if `grok` isn't on PATH
+- `exitCode` — mirrors Grok's exit code; `128` plus the signal number if the child was killed; `127` if `grok` isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
 - `signal` — the signal that killed the child, otherwise `null`
 - `grokVersion` — the binary that actually ran
 - `sessionId` — feed this to a later `--session <id>` (or use `--resume-last`)
@@ -71,7 +71,7 @@ touched-files report shows only Grok's edits and nothing of the helper's own.
   tripwire: it catches new dirt, but an edit inside an already-dirty file can evade it — the diff
   review, not this flag, is the guarantee
 - `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `grok_unavailable`, and launch failures
-- `error` — present **only** if Grok failed to launch
+- `error` — present on a launch failure, and on `timeout` and `aborted` runs
 
 The helper also prints a summary to stdout and exits with Grok's exit code, so a wrapping script can
 branch on success/failure directly.

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -412,6 +412,12 @@ function dispatchToGrok(opts, run, writeResult) {
   // plan mode are advisory), so a --read-only run snapshots the tree up front
   // and flags a violation in the result instead of pretending to enforce.
   const beforeTree = opts.autonomy === "read-only" ? gitTouchedFiles(opts.cd) : null;
+  // every result that reports touchedFiles carries the verdict, aborted runs included -
+  // an aborted --read-only review can still have modified the tree
+  const readOnlyFlag = (touched) =>
+    opts.autonomy === "read-only"
+      ? { readOnlyViolation: beforeTree !== null && touched !== null && JSON.stringify(beforeTree) !== JSON.stringify(touched) }
+      : {};
   const argv = buildArgv(opts, run);
   // shell:true on Windows so the grok.cmd shim resolves (see grokVersion). Safe:
   // the brief is delivered via --prompt-file (never argv), --model/--effort/--session
@@ -495,6 +501,7 @@ function dispatchToGrok(opts, run, writeResult) {
       if (settled) return;
       settled = true;
       clearWatchdog();
+      const touchedAtAbort = gitTouchedFiles(opts.cd);
       const abortedFields = {
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
@@ -502,7 +509,8 @@ function dispatchToGrok(opts, run, writeResult) {
         sessionId,
         finalMessage: assembleFinal(),
         usage,
-        touchedFiles: gitTouchedFiles(opts.cd),
+        touchedFiles: touchedAtAbort,
+        ...readOnlyFlag(touchedAtAbort),
         stderrTail: stderrTail.slice(-20),
         error: `the relay was killed by ${sig}; grok was terminated with it — inspect the working tree before re-dispatching`,
       };
@@ -513,7 +521,8 @@ function dispatchToGrok(opts, run, writeResult) {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }
         // the child may flush files during the grace window; refresh the snapshot so the
         // artifact matches the tree the orchestrator will actually find
-        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        const touchedAfterGrace = gitTouchedFiles(opts.cd);
+        writeResult({ ...abortedFields, touchedFiles: touchedAfterGrace, ...readOnlyFlag(touchedAfterGrace) });
         process.exit(result.exitCode);
       }, 2000);
     });
@@ -555,9 +564,7 @@ function dispatchToGrok(opts, run, writeResult) {
       finalMessage,
       usage,
       touchedFiles,
-      ...(opts.autonomy === "read-only"
-        ? { readOnlyViolation: beforeTree !== null && touchedFiles !== null && JSON.stringify(beforeTree) !== JSON.stringify(touchedFiles) }
-        : {}),
+      ...readOnlyFlag(touchedFiles),
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `grok did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
     });

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -495,7 +495,7 @@ function dispatchToGrok(opts, run, writeResult) {
       if (settled) return;
       settled = true;
       clearWatchdog();
-      const result = writeResult({
+      const abortedFields = {
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
         signal: sig,
@@ -505,11 +505,15 @@ function dispatchToGrok(opts, run, writeResult) {
         touchedFiles: gitTouchedFiles(opts.cd),
         stderrTail: stderrTail.slice(-20),
         error: `the relay was killed by ${sig}; grok was terminated with it — inspect the working tree before re-dispatching`,
-      });
+      };
+      const result = writeResult(abortedFields);
       printSummary(result, run.resultPath);
       killChild(child);
       setTimeout(() => {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
         process.exit(result.exitCode);
       }, 2000);
     });

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -51,6 +51,9 @@
  *                           send only the delta brief.
  *   --session <id>          Continue a specific session id; send only the delta brief.
  *                           Mutually exclusive with --resume-last.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the grok child is killed
+ *                           and result.json gets status "timeout".
  *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
  *                           the system temp dir, so the repo under review stays clean).
  *   -h, --help              Show this help.
@@ -67,7 +70,9 @@
  * the child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome —
- * completed, failed, or grok_unavailable. An orchestrator that polls for the
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to grok), or grok_unavailable. An
+ * orchestrator that polls for the
  * file must therefore also treat a non-zero exit with no file as a usage error.
  */
 
@@ -94,6 +99,7 @@ function parseArgs(argv) {
     autonomy: "workspace-write",
     resumeLast: false,
     session: null,
+    timeout: null,
     outDir: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -119,10 +125,16 @@ function parseArgs(argv) {
       case "--full-access": opts.autonomy = "full-access"; break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--session": opts.session = next(); break;
+      case "--timeout": opts.timeout = next(); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
         fail(`unknown option: ${arg}`);
     }
+  }
+  // The watchdog is relay-only (the grok launch has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
   }
   if (!AUTONOMY_MODES.has(opts.autonomy)) {
     fail(`invalid autonomy "${opts.autonomy}"`);
@@ -142,6 +154,13 @@ function parseArgs(argv) {
     fail("--max-turns must be a positive integer");
   }
   return opts;
+}
+
+function parseDuration(duration) {
+  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
 function headerComment() {
@@ -427,9 +446,62 @@ function dispatchToGrok(opts, run, writeResult) {
   };
 
   let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      child.kill("SIGTERM");
+      sigkillTimer = setTimeout(() => {
+        if (!settled) child.kill("SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the grok child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        finalMessage: assembleFinal(),
+        usage,
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; grok was terminated with it — inspect the working tree before re-dispatching`,
+      });
+      printSummary(result, run.resultPath);
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
   child.on("error", (err) => {
     if (settled) return;
     settled = true;
+    clearWatchdog();
     const result = writeResult({
       status: "failed",
       exitCode: 1,
@@ -447,11 +519,16 @@ function dispatchToGrok(opts, run, writeResult) {
   child.on("close", (code, signal) => {
     if (settled) return;
     settled = true;
+    clearWatchdog();
     const finalMessage = assembleFinal();
     const touchedFiles = gitTouchedFiles(opts.cd);
+    // A timed-out run is never a success even if grok handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const result = writeResult({
-      status: code === 0 ? "completed" : "failed",
-      exitCode: code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1),
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
       signal: signal ?? null,
       sessionId,
       finalMessage,
@@ -460,7 +537,8 @@ function dispatchToGrok(opts, run, writeResult) {
       ...(opts.autonomy === "read-only"
         ? { readOnlyViolation: beforeTree !== null && touchedFiles !== null && JSON.stringify(beforeTree) !== JSON.stringify(touchedFiles) }
         : {}),
-      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `grok did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
@@ -489,6 +567,7 @@ function printSummary(result, resultPath) {
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  grok ${result.grokVersion ?? "?"}`);
   if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a grok error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated grok (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.readOnlyViolation) lines.push("warning: this --read-only run modified the working tree — grok's read-only is best-effort; review the diff before trusting the run.");
   lines.push(`autonomy: ${result.autonomy}`);
   if (result.resumeLast) lines.push("mode: resumed most recent session (--continue)");

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -163,6 +163,21 @@ function parseDuration(duration) {
   return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
+function killChild(child) {
+  // On Windows the child is the .cmd shim (the shell:true launch above), so signalling it does
+  // not reach the Grok process it spawned — the run would keep editing after the relay reports
+  // timeout/aborted. Windows has no process-group signals and Node can't kill a process family
+  // without a Job Object, so kill the tree by pid with the OS tool: /t includes descendants,
+  // /f forces it. This is the same idiom tree-kill and npm/pnpm use. POSIX keeps real signals
+  // (the SIGKILL escalation at each call site still applies there).
+  if (process.platform === "win32") {
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" }); }
+    catch { /* already exited, or no such pid */ }
+  } else {
+    child.kill("SIGTERM");
+  }
+}
+
 function headerComment() {
   // The leading block comment doubles as --help text.
   const src = readFileSync(new URL(import.meta.url), "utf8");
@@ -457,7 +472,7 @@ function dispatchToGrok(opts, run, writeResult) {
         child.stdout.destroy();
         child.stderr.destroy();
       });
-      child.kill("SIGTERM");
+      killChild(child);
       sigkillTimer = setTimeout(() => {
         if (!settled) child.kill("SIGKILL");
       }, 10_000);
@@ -490,7 +505,7 @@ function dispatchToGrok(opts, run, writeResult) {
         error: `the relay was killed by ${sig}; grok was terminated with it — inspect the working tree before re-dispatching`,
       });
       printSummary(result, run.resultPath);
-      child.kill("SIGTERM");
+      killChild(child);
       setTimeout(() => {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }
         process.exit(result.exitCode);

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -163,20 +163,23 @@ function parseDuration(duration) {
   return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
-function killChild(child) {
-  // On Windows the child is the .cmd shim (the shell:true launch above), so signalling it does
-  // not reach the Grok process it spawned — the run would keep editing after the relay reports
-  // timeout/aborted. Windows has no process-group signals and Node can't kill a process family
-  // without a Job Object, so kill the tree by pid with the OS tool: /t includes descendants,
-  // /f forces it. This is the same idiom tree-kill and npm/pnpm use. POSIX keeps real signals
-  // (the SIGKILL escalation at each call site still applies there).
+function killChild(child, signal = "SIGTERM") {
+  // The kill must reach the whole process family, not just the immediate child — a tool
+  // subprocess left running would keep editing after the relay reports timeout/aborted.
+  // On Windows the child is the .cmd shim (the shell:true launch above), Windows has no
+  // process-group signals, and Node can't kill a process family without a Job Object, so
+  // kill the tree by pid with the OS tool: /t includes descendants, /f forces it — the
+  // same idiom tree-kill and npm/pnpm use.
   if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
     // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
     // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
     try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
     catch { /* already gone — nothing left to kill */ }
   } else {
-    child.kill("SIGTERM");
+    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
+    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
+    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
   }
 }
 
@@ -428,6 +431,7 @@ function dispatchToGrok(opts, run, writeResult) {
     env: { ...process.env },
     stdio: ["ignore", "pipe", "pipe"],
     shell: process.platform === "win32",
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
   });
 
   let sessionId = opts.session || null;
@@ -482,7 +486,7 @@ function dispatchToGrok(opts, run, writeResult) {
       });
       killChild(child);
       sigkillTimer = setTimeout(() => {
-        if (!settled) child.kill("SIGKILL");
+        if (!settled) killChild(child, "SIGKILL");
       }, 10_000);
     }, timeoutMs);
   }
@@ -518,7 +522,7 @@ function dispatchToGrok(opts, run, writeResult) {
       printSummary(result, run.resultPath);
       killChild(child);
       setTimeout(() => {
-        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        killChild(child, "SIGKILL");
         // the child may flush files during the grace window; refresh the snapshot so the
         // artifact matches the tree the orchestrator will actually find
         const touchedAfterGrace = gitTouchedFiles(opts.cd);

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -554,6 +554,9 @@ function dispatchToGrok(opts, run, writeResult) {
     if (settled) return;
     settled = true;
     clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
     const finalMessage = assembleFinal();
     const touchedFiles = gitTouchedFiles(opts.cd);
     // A timed-out run is never a success even if grok handles SIGTERM by exiting 0 -

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -566,7 +566,7 @@ function printSummary(result, resultPath) {
   const lines = [];
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  grok ${result.grokVersion ?? "?"}`);
-  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a grok error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a grok error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated grok (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.readOnlyViolation) lines.push("warning: this --read-only run modified the working tree — grok's read-only is best-effort; review the diff before trusting the run.");
   lines.push(`autonomy: ${result.autonomy}`);

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -171,8 +171,10 @@ function killChild(child) {
   // /f forces it. This is the same idiom tree-kill and npm/pnpm use. POSIX keeps real signals
   // (the SIGKILL escalation at each call site still applies there).
   if (process.platform === "win32") {
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" }); }
-    catch { /* already exited, or no such pid */ }
+    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
+    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
+    catch { /* already gone — nothing left to kill */ }
   } else {
     child.kill("SIGTERM");
   }

--- a/skills/kimi-delegate/SKILL.md
+++ b/skills/kimi-delegate/SKILL.md
@@ -61,6 +61,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # choose a configured model alias:       add --model <alias from your kimi config>
 # resume the most recent session:        add --resume-last  (delta brief only)
 # resume a specific session:             add --session <id> (delta brief only)
+# hard time limit (watchdog):            add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
 # see all options:                       node .../relay.mjs --help
 ```
 

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -88,7 +88,10 @@ A pre-run usage error exits 2 and writes no result. A missing `kimi` exits 127 a
   cause is an unconfigured model alias: `error: failed to run prompt: config.invalid: Model "<x>" is not configured in config.toml…`
 - **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
   closed terminal) and forwarded the kill to kimi. The result is written before the relay exits;
-  inspect the working tree before re-dispatching.
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
 - **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through the
   OOM killer or a supervisor timeout. This is not a Kimi error; check host memory and re-dispatch, or
   split the task into smaller briefs.

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -55,7 +55,7 @@ inside the worktree can make the artifacts appear there:
 
 `result.json` fields:
 
-- `schema`, `tool` (`"kimi"`), `status` (`completed` | `failed` | `kimi_unavailable`), `exitCode`, and
+- `schema`, `tool` (`"kimi"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `kimi_unavailable`), `exitCode`, and
   `signal` (`null` unless the child died on a signal).
 - `workdir`, `model` (the model alias or `null`), `resumed`, `kimiVersion`, `sessionId`, `startedAt`,
   and `finishedAt`.
@@ -67,7 +67,7 @@ inside the worktree can make the artifacts appear there:
   Kimi makes inside `--add-dir` workspaces do not show up at all - inspect those trees yourself.
   Dispatch from a clean tree when you want the list to read as "what Kimi changed". `null` means git
   could not report; `[]` means git ran and the tree is clean.
-- `stderrTail` - the last 20 non-empty stderr lines on failure.
+- `stderrTail` - the last 20 non-empty stderr lines on any run that did not complete (`failed`, `timeout`, `aborted`).
 - `error` - present for launch failures or when the relay watchdog fires.
 
 Kimi's stream carries no token usage, so `result.json` has no `usage` field.
@@ -86,10 +86,13 @@ A pre-run usage error exits 2 and writes no result. A missing `kimi` exits 127 a
   `kimi login`, and re-dispatch.
 - **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. A common
   cause is an unconfigured model alias: `error: failed to run prompt: config.invalid: Model "<x>" is not configured in config.toml…`
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to kimi. The result is written before the relay exits;
+  inspect the working tree before re-dispatching.
 - **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through the
   OOM killer or a supervisor timeout. This is not a Kimi error; check host memory and re-dispatch, or
   split the task into smaller briefs.
-- **Watchdog failure:** `error` reads
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
   `kimi did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout` or
   split the task. The relay sends SIGTERM, waits 10 seconds, then sends SIGKILL if needed.
 - **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -67,8 +67,8 @@ inside the worktree can make the artifacts appear there:
   Kimi makes inside `--add-dir` workspaces do not show up at all - inspect those trees yourself.
   Dispatch from a clean tree when you want the list to read as "what Kimi changed". `null` means git
   could not report; `[]` means git ran and the tree is clean.
-- `stderrTail` - the last 20 non-empty stderr lines on any run that did not complete (`failed`, `timeout`, `aborted`).
-- `error` - present for launch failures or when the relay watchdog fires.
+- `stderrTail` - the last 20 non-empty stderr lines on any run that did not complete (`failed`, `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
+- `error` - present for launch failures, when the relay watchdog fires (`timeout`), and on an `aborted` run.
 
 Kimi's stream carries no token usage, so `result.json` has no `usage` field.
 

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -458,7 +458,7 @@ function printSummary(result, resultPath) {
   const lines = [];
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  kimi ${result.kimiVersion ?? "?"}`);
-  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a kimi error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a kimi error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated kimi (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumed) lines.push("mode: resumed an existing session");
   if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -367,7 +367,7 @@ function dispatchToKimi(opts, brief, run, writeResult) {
       settled = true;
       clearTimeout(watchdogTimer);
       if (sigkillTimer) clearTimeout(sigkillTimer);
-      const result = writeResult({
+      const abortedFields = {
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
         signal: sig,
@@ -376,11 +376,15 @@ function dispatchToKimi(opts, brief, run, writeResult) {
         touchedFiles: gitTouchedFiles(opts.cd),
         stderrTail: stderrTail.slice(-20),
         error: `the relay was killed by ${sig}; kimi was terminated with it — inspect the working tree before re-dispatching`,
-      });
+      };
+      const result = writeResult(abortedFields);
       printSummary(result, run.resultPath);
       child.kill("SIGTERM");
       setTimeout(() => {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
         process.exit(result.exitCode);
       }, 2000);
     });

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -59,7 +59,9 @@
  * otherwise the exit code mirrors Kimi's own (0 success, non-zero failure). If
  * the child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal. Once the brief validates, `result.json` is
- * written on every outcome - completed, failed, or kimi_unavailable.
+ * written on every outcome - completed, failed, timeout (the --timeout watchdog
+ * fired), aborted (the relay itself was killed and forwarded the kill to kimi),
+ * or kimi_unavailable.
  */
 
 import { spawn, execFileSync } from "node:child_process";
@@ -355,6 +357,35 @@ function dispatchToKimi(opts, brief, run, writeResult) {
     }, 10_000);
   }, timeoutMs);
 
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the kimi child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdogTimer);
+      if (sigkillTimer) clearTimeout(sigkillTimer);
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; kimi was terminated with it — inspect the working tree before re-dispatching`,
+      });
+      printSummary(result, run.resultPath);
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
   child.on("error", (err) => {
     if (settled) return;
     settled = true;
@@ -385,7 +416,7 @@ function dispatchToKimi(opts, brief, run, writeResult) {
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
     const result = writeResult({
-      status: succeeded ? "completed" : "failed",
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
       exitCode,
       signal: signal ?? null,
       sessionId,
@@ -428,6 +459,7 @@ function printSummary(result, resultPath) {
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  kimi ${result.kimiVersion ?? "?"}`);
   if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a kimi error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated kimi (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumed) lines.push("mode: resumed an existing session");
   if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
   const touched = result.touchedFiles;

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -154,6 +154,24 @@ function readBrief(opts) {
   return stdin;
 }
 
+function killChild(child, signal = "SIGTERM") {
+  // The kill must reach the whole process family, not just the CLI — a tool subprocess left
+  // running would keep editing after the relay reports timeout/aborted. On Windows Node can't
+  // kill a process family without a Job Object, so kill the tree by pid with the OS tool
+  // (/t includes descendants, /f forces it — the tree-kill/npm idiom).
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
+    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
+    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
+    catch { /* already gone — nothing left to kill */ }
+  } else {
+    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
+    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
+    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+  }
+}
+
 function kimiVersion() {
   try {
     const out = execFileSync("kimi", ["--version"], { encoding: "utf8" }).trim();
@@ -300,6 +318,7 @@ function dispatchToKimi(opts, brief, run, writeResult) {
   const child = spawn("kimi", buildArgv(opts, brief), {
     cwd: opts.cd,
     stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
   });
 
   let sessionId = null;
@@ -351,9 +370,9 @@ function dispatchToKimi(opts, brief, run, writeResult) {
       child.stdout.destroy();
       child.stderr.destroy();
     });
-    child.kill("SIGTERM");
+    killChild(child);
     sigkillTimer = setTimeout(() => {
-      if (!settled) child.kill("SIGKILL");
+      if (!settled) killChild(child, "SIGKILL");
     }, 10_000);
   }, timeoutMs);
 
@@ -379,9 +398,9 @@ function dispatchToKimi(opts, brief, run, writeResult) {
       };
       const result = writeResult(abortedFields);
       printSummary(result, run.resultPath);
-      child.kill("SIGTERM");
+      killChild(child);
       setTimeout(() => {
-        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        killChild(child, "SIGKILL");
         // the child may flush files during the grace window; refresh the snapshot so the
         // artifact matches the tree the orchestrator will actually find
         writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -433,6 +433,9 @@ function dispatchToKimi(opts, brief, run, writeResult) {
     settled = true;
     clearTimeout(watchdogTimer);
     if (sigkillTimer) clearTimeout(sigkillTimer);
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
     // A timed-out run is failed even if kimi handles SIGTERM by exiting 0 -
     // orchestrators key off status and the relay exit code.
     const succeeded = code === 0 && !watchdogFired;

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -86,6 +86,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --model <provider/model> 
 # --model is required on a fresh run (see "Choose the implementer model" above)
 # read-only (review/diagnosis, no edits):   add --read-only   (uses the plan agent)
 # continue the previous OpenCode session:   add --resume-last  (delta brief only; keeps the model)
+# hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
 # see all options:                          node .../relay.mjs --help
 ```
 

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -51,7 +51,7 @@ touched-files report shows only OpenCode's edits and nothing of the helper's own
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
 - `tool` — `opencode`
 - `status` — `completed` | `failed` | `timeout` | `aborted` | `opencode_unavailable`
-- `exitCode` — mirrors OpenCode's exit code; `128` plus the signal number if the child was killed; `127` if `opencode` isn't on PATH
+- `exitCode` — mirrors OpenCode's exit code; `128` plus the signal number if the child was killed; `127` if `opencode` isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
 - `signal` — the signal that killed the child, otherwise `null`
 - `opencodeVersion` — the binary that actually ran
 - `agent` — the agent used (`build`, `plan`, …), or a note that it was inherited from a resumed session
@@ -67,7 +67,7 @@ touched-files report shows only OpenCode's edits and nothing of the helper's own
 - `workdir`, `model`, `auto`, `resumeLast`, `startedAt`, `finishedAt`
 - `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`,
   `opencode_unavailable`, and launch failures
-- `error` — present **only** if OpenCode failed to launch
+- `error` — present on a launch failure, and on `timeout` and `aborted` runs
 
 The helper also prints a summary to stdout and exits with OpenCode's exit code, so a wrapping script can
 branch on success/failure directly.

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -102,7 +102,10 @@ process has exited and `result.json` is written — not when a status line says 
   or a resume.
 - **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
   closed terminal) and forwarded the kill to opencode. The result is written before the relay exits;
-  inspect the working tree before re-dispatching.
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
 - **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
   or a supervisor timeout, not an implementer error. Free up host memory or split the task into
   smaller briefs, then re-dispatch.

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -50,7 +50,7 @@ touched-files report shows only OpenCode's edits and nothing of the helper's own
 
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
 - `tool` — `opencode`
-- `status` — `completed` | `failed` | `opencode_unavailable`
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `opencode_unavailable`
 - `exitCode` — mirrors OpenCode's exit code; `128` plus the signal number if the child was killed; `127` if `opencode` isn't on PATH
 - `signal` — the signal that killed the child, otherwise `null`
 - `opencodeVersion` — the binary that actually ran
@@ -65,7 +65,7 @@ touched-files report shows only OpenCode's edits and nothing of the helper's own
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSON event stream, and
   the final-message file
 - `workdir`, `model`, `auto`, `resumeLast`, `startedAt`, `finishedAt`
-- `stderrTail` — last ~20 stderr lines; present **only** on a failed run, absent on `completed`,
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`,
   `opencode_unavailable`, and launch failures
 - `error` — present **only** if OpenCode failed to launch
 
@@ -96,6 +96,12 @@ process has exited and `result.json` is written — not when a status line says 
   Common causes: an auth lapse, an unknown `--model` or `--agent`, or a permission the run needed but
   the agent didn't grant. Fix the cause and re-dispatch; don't paper over it by doing the work yourself
   unless that's what the user wants.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to opencode. The result is written before the relay exits;
+  inspect the working tree before re-dispatching.
 - **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
   or a supervisor timeout, not an implementer error. Free up host memory or split the task into
   smaller briefs, then re-dispatch.

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -39,6 +39,7 @@ Options:
 | `--resume-last` | Continue the most recent OpenCode session; send only the delta brief (see review-and-land). |
 | `--session <id>` | Continue a specific session id (`ses_…`); send only the delta brief. |
 | `--pure` | Run OpenCode without external plugins (cleaner event stream). |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
 
 Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -522,7 +522,7 @@ function printSummary(result, resultPath) {
   const lines = [];
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  opencode ${result.opencodeVersion ?? "?"}`);
-  if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an opencode error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an opencode error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated opencode (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumeLast || result.agent === "(inherited from resumed session)") lines.push("mode: resumed existing session");
   if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -42,6 +42,9 @@
  *   --resume-last           Continue the most recent OpenCode session; send only the delta brief.
  *   --session <id>          Continue a specific session id (ses_...); send only the delta brief.
  *   --pure                  Run OpenCode without external plugins (cleaner event stream).
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the opencode child is
+ *                           killed and result.json gets status "timeout".
  *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
  *                           the system temp dir, so the repo under review stays clean).
  *   -h, --help              Show this help.
@@ -57,7 +60,9 @@
  * If the child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome —
- * completed, failed, or opencode_unavailable. An orchestrator that polls for the
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to opencode), or
+ * opencode_unavailable. An orchestrator that polls for the
  * file must therefore also treat a non-zero exit with no file as a usage error.
  */
 
@@ -83,6 +88,7 @@ function parseArgs(argv) {
     resumeLast: false,
     session: null,
     pure: false,
+    timeout: null,
     outDir: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -110,12 +116,25 @@ function parseArgs(argv) {
       case "--resume-last": opts.resumeLast = true; break;
       case "--session": opts.session = next(); break;
       case "--pure": opts.pure = true; break;
+      case "--timeout": opts.timeout = next(); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
         fail(`unknown option: ${arg}`);
     }
   }
+  // The watchdog is relay-only (the opencode launch has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
   return opts;
+}
+
+function parseDuration(duration) {
+  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
 function headerComment() {
@@ -380,9 +399,62 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
   };
 
   let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      child.kill("SIGTERM");
+      sigkillTimer = setTimeout(() => {
+        if (!settled) child.kill("SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the opencode child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        cost: sawCost ? Number(totalCost.toFixed(6)) : null,
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; opencode was terminated with it — inspect the working tree before re-dispatching`,
+      });
+      printSummary(result, run.resultPath);
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
   child.on("error", (err) => {
     if (settled) return;
     settled = true;
+    clearWatchdog();
     const result = writeResult({ status: "failed", exitCode: 1, signal: null, sessionId, finalMessage: assembleFinal(), touchedFiles: gitTouchedFiles(opts.cd), cost: sawCost ? totalCost : null, error: String(err && err.message ? err.message : err) });
     printSummary(result, run.resultPath);
     process.exit(1);
@@ -391,16 +463,22 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
   child.on("close", (code, signal) => {
     if (settled) return;
     settled = true;
+    clearWatchdog();
     const finalMessage = assembleFinal();
+    // A timed-out run is never a success even if opencode handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const result = writeResult({
-      status: code === 0 ? "completed" : "failed",
-      exitCode: code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1),
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
       signal: signal ?? null,
       sessionId,
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
       cost: sawCost ? Number(totalCost.toFixed(6)) : null,
-      ...(code === 0 ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `opencode did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
@@ -445,6 +523,7 @@ function printSummary(result, resultPath) {
   lines.push("");
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  opencode ${result.opencodeVersion ?? "?"}`);
   if (result.signal === "SIGKILL") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an opencode error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated opencode (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumeLast || result.agent === "(inherited from resumed session)") lines.push("mode: resumed existing session");
   if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
   if (typeof result.cost === "number") lines.push(`cost: $${result.cost}`);

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -448,7 +448,7 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
       if (settled) return;
       settled = true;
       clearWatchdog();
-      const result = writeResult({
+      const abortedFields = {
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
         signal: sig,
@@ -458,11 +458,15 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
         cost: sawCost ? Number(totalCost.toFixed(6)) : null,
         stderrTail: stderrTail.slice(-20),
         error: `the relay was killed by ${sig}; opencode was terminated with it — inspect the working tree before re-dispatching`,
-      });
+      };
+      const result = writeResult(abortedFields);
       printSummary(result, run.resultPath);
       killChild(child);
       setTimeout(() => {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
         process.exit(result.exitCode);
       }, 2000);
     });

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -137,6 +137,21 @@ function parseDuration(duration) {
   return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
+function killChild(child) {
+  // On Windows the child is the .cmd shim (the shell:true launch above), so signalling it does
+  // not reach the OpenCode process it spawned — the run would keep editing after the relay reports
+  // timeout/aborted. Windows has no process-group signals and Node can't kill a process family
+  // without a Job Object, so kill the tree by pid with the OS tool: /t includes descendants,
+  // /f forces it. This is the same idiom tree-kill and npm/pnpm use. POSIX keeps real signals
+  // (the SIGKILL escalation at each call site still applies there).
+  if (process.platform === "win32") {
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" }); }
+    catch { /* already exited, or no such pid */ }
+  } else {
+    child.kill("SIGTERM");
+  }
+}
+
 function headerComment() {
   // The leading block comment doubles as --help text.
   const src = readFileSync(new URL(import.meta.url), "utf8");
@@ -410,7 +425,7 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
         child.stdout.destroy();
         child.stderr.destroy();
       });
-      child.kill("SIGTERM");
+      killChild(child);
       sigkillTimer = setTimeout(() => {
         if (!settled) child.kill("SIGKILL");
       }, 10_000);
@@ -443,7 +458,7 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
         error: `the relay was killed by ${sig}; opencode was terminated with it — inspect the working tree before re-dispatching`,
       });
       printSummary(result, run.resultPath);
-      child.kill("SIGTERM");
+      killChild(child);
       setTimeout(() => {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }
         process.exit(result.exitCode);

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -145,8 +145,10 @@ function killChild(child) {
   // /f forces it. This is the same idiom tree-kill and npm/pnpm use. POSIX keeps real signals
   // (the SIGKILL escalation at each call site still applies there).
   if (process.platform === "win32") {
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" }); }
-    catch { /* already exited, or no such pid */ }
+    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
+    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
+    catch { /* already gone — nothing left to kill */ }
   } else {
     child.kill("SIGTERM");
   }

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -489,6 +489,9 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
     if (settled) return;
     settled = true;
     clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
     const finalMessage = assembleFinal();
     // A timed-out run is never a success even if opencode handles SIGTERM by exiting 0 -
     // orchestrators key off status and the relay exit code.

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -137,20 +137,23 @@ function parseDuration(duration) {
   return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
-function killChild(child) {
-  // On Windows the child is the .cmd shim (the shell:true launch above), so signalling it does
-  // not reach the OpenCode process it spawned — the run would keep editing after the relay reports
-  // timeout/aborted. Windows has no process-group signals and Node can't kill a process family
-  // without a Job Object, so kill the tree by pid with the OS tool: /t includes descendants,
-  // /f forces it. This is the same idiom tree-kill and npm/pnpm use. POSIX keeps real signals
-  // (the SIGKILL escalation at each call site still applies there).
+function killChild(child, signal = "SIGTERM") {
+  // The kill must reach the whole process family, not just the immediate child — a tool
+  // subprocess left running would keep editing after the relay reports timeout/aborted.
+  // On Windows the child is the .cmd shim (the shell:true launch above), Windows has no
+  // process-group signals, and Node can't kill a process family without a Job Object, so
+  // kill the tree by pid with the OS tool: /t includes descendants, /f forces it — the
+  // same idiom tree-kill and npm/pnpm use.
   if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
     // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
     // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
     try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
     catch { /* already gone — nothing left to kill */ }
   } else {
-    child.kill("SIGTERM");
+    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
+    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
+    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
   }
 }
 
@@ -362,6 +365,7 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
     env: { ...process.env, PWD: opts.cd },
     stdio: ["pipe", "pipe", "pipe"],
     shell: process.platform === "win32",
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
   });
 
   let sessionId = opts.session || null;
@@ -429,7 +433,7 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
       });
       killChild(child);
       sigkillTimer = setTimeout(() => {
-        if (!settled) child.kill("SIGKILL");
+        if (!settled) killChild(child, "SIGKILL");
       }, 10_000);
     }, timeoutMs);
   }
@@ -463,7 +467,7 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
       printSummary(result, run.resultPath);
       killChild(child);
       setTimeout(() => {
-        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        killChild(child, "SIGKILL");
         // the child may flush files during the grace window; refresh the snapshot so the
         // artifact matches the tree the orchestrator will actually find
         writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · relay smoke.
+ *
+ * Runs the codex relay against a fake implementer CLI and asserts the two
+ * guarantees the relay makes about runs that do not complete:
+ *
+ *   1. timeout  — the --timeout watchdog kills the implementer's WHOLE process
+ *                 tree (on Windows the relay launches a .cmd shim via shell:true,
+ *                 so this is exactly the case a plain child.kill would miss), and
+ *                 result.json reports status "timeout".
+ *   2. aborted  — killing the relay itself still produces result.json with
+ *                 status "aborted", and files the implementer flushes during the
+ *                 shutdown grace window appear in the refreshed touchedFiles.
+ *                 (POSIX only: Windows delivers no catchable SIGTERM, so the
+ *                 aborted path cannot be driven from a test there.)
+ *
+ * The fake implementer is a stand-in on PATH named `codex` (`codex.cmd` on
+ * Windows) — the relay is exercised unmodified, end to end. Node built-ins only.
+ */
+import { spawn } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, mkdirSync } from "node:fs";
+import { join, delimiter, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const RELAYS = ["codex", "opencode", "agy", "grok", "kimi"].map(
+  (s) => join(here, "..", "skills", `${s}-delegate`, "scripts", "relay.mjs"),
+);
+const CODEX_RELAY = RELAYS[0];
+const WIN = process.platform === "win32";
+let failed = 0;
+const check = (name, cond) => {
+  console.log(`${cond ? "  ok " : "  FAIL"}  ${name}`);
+  if (!cond) failed++;
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const until = async (fn, ms) => {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    if (fn()) return true;
+    await sleep(250);
+  }
+  return fn();
+};
+const alive = (pid) => {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+};
+
+// ---- every relay must at least parse ----
+for (const r of RELAYS) {
+  const c = spawnSync(process.execPath, ["--check", r], { encoding: "utf8" });
+  check(`syntax: ${r.split(/[\\/]/).slice(-3).join("/")}`, c.status === 0);
+}
+
+// ---- a fake `codex` on PATH: --version answers the preflight; anything else runs forever ----
+const FAKE = `const fs = require("node:fs");
+if (process.argv.includes("--version")) { console.log("codex-cli 0.0.0-smoke"); process.exit(0); }
+process.stdin.resume();
+fs.writeFileSync(process.env.SMOKE_PID_FILE, String(process.pid));
+if (process.env.SMOKE_MODE === "abort") {
+  process.on("SIGTERM", () => { fs.writeFileSync(process.env.SMOKE_LATE_FILE, "flushed during shutdown"); process.exit(0); });
+} else {
+  process.on("SIGTERM", () => {}); // ignore, so the relay's SIGKILL escalation is what ends it
+}
+setInterval(() => {}, 1000);
+`;
+
+const scratch = mkdtempSync(join(tmpdir(), "relay-smoke-"));
+const shimDir = join(scratch, "shim");
+mkdirSync(shimDir);
+writeFileSync(join(shimDir, "fake-codex.cjs"), FAKE);
+if (WIN) {
+  writeFileSync(join(shimDir, "codex.cmd"), `@node "%~dp0fake-codex.cjs" %*\r\n`);
+} else {
+  const shim = join(shimDir, "codex");
+  writeFileSync(shim, `#!/bin/sh\nexec node "$(dirname "$0")/fake-codex.cjs" "$@"\n`);
+  chmodSync(shim, 0o755);
+}
+const workDir = join(scratch, "repo");
+mkdirSync(workDir);
+spawnSync("git", ["-C", workDir, "init", "-q"], { encoding: "utf8" });
+const briefPath = join(scratch, "brief.txt");
+writeFileSync(briefPath, "smoke brief: run until killed.");
+const baseEnv = { ...process.env, PATH: shimDir + delimiter + process.env.PATH };
+
+const runRelay = (outDir, extraArgs, extraEnv) =>
+  spawn(process.execPath, [CODEX_RELAY, "--brief", briefPath, "--cd", workDir, "--out-dir", outDir, ...extraArgs], {
+    env: { ...baseEnv, ...extraEnv },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+
+const result = (outDir) => JSON.parse(readFileSync(join(outDir, "result.json"), "utf8"));
+
+// ---- 1. the --timeout watchdog fells the whole tree ----
+{
+  const outDir = join(scratch, "out-timeout");
+  const pidFile = join(scratch, "pid-timeout");
+  const child = runRelay(outDir, ["--timeout", "6s"], { SMOKE_PID_FILE: pidFile, SMOKE_MODE: "timeout" });
+  let stderr = "";
+  child.stderr.on("data", (d) => { stderr += d; });
+  check("timeout: the fake implementer came up", await until(() => existsSync(pidFile), 10_000));
+  const implementerPid = Number(readFileSync(pidFile, "utf8"));
+  const exited = await new Promise((res) => {
+    const t = setTimeout(() => res(false), 45_000);
+    child.on("close", () => { clearTimeout(t); res(true); });
+  });
+  check("timeout: the relay exited on its own", exited);
+  check("timeout: result.json exists", existsSync(join(outDir, "result.json")));
+  if (existsSync(join(outDir, "result.json"))) {
+    const r = result(outDir);
+    check(`timeout: status is "timeout" (got ${r.status})`, r.status === "timeout");
+    check("timeout: relay exit code is non-zero", r.exitCode !== 0);
+  }
+  check("timeout: the implementer process is dead (tree included)", await until(() => !alive(implementerPid), 20_000));
+  if (failed) console.error(`relay stderr tail:\n${stderr.split("\n").slice(-6).join("\n")}`);
+}
+
+// ---- 2. killing the relay still writes the artifact, with a refreshed snapshot ----
+if (WIN) {
+  console.log("  skip  aborted-path scenario: Windows delivers no catchable SIGTERM to drive it");
+} else {
+  const outDir = join(scratch, "out-abort");
+  const pidFile = join(scratch, "pid-abort");
+  const lateFile = join(workDir, "late-file.txt");
+  const child = runRelay(outDir, [], { SMOKE_PID_FILE: pidFile, SMOKE_MODE: "abort", SMOKE_LATE_FILE: lateFile });
+  check("aborted: the fake implementer came up", await until(() => existsSync(pidFile), 10_000));
+  child.kill("SIGTERM");
+  const exited = await new Promise((res) => {
+    const t = setTimeout(() => res(false), 20_000);
+    child.on("close", () => { clearTimeout(t); res(true); });
+  });
+  check("aborted: the relay exited after the grace window", exited);
+  check("aborted: result.json exists", existsSync(join(outDir, "result.json")));
+  if (existsSync(join(outDir, "result.json"))) {
+    const r = result(outDir);
+    check(`aborted: status is "aborted" (got ${r.status})`, r.status === "aborted");
+    check("aborted: the file flushed during shutdown is in touchedFiles",
+      Array.isArray(r.touchedFiles) && r.touchedFiles.some((f) => f.includes("late-file.txt")));
+  }
+}
+
+rmSync(scratch, { recursive: true, force: true });
+console.log(failed ? `\n${failed} FAILED` : "\nrelay smoke: all green");
+process.exit(failed ? 1 : 0);

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -2,34 +2,40 @@
 /**
  * delegate-skills · relay smoke.
  *
- * Runs the codex relay against a fake implementer CLI and asserts the two
- * guarantees the relay makes about runs that do not complete:
+ * Drives the relays, unmodified and end to end, against a fake implementer CLI
+ * planted on PATH, and asserts the two guarantees they make about runs that do
+ * not complete:
  *
- *   1. timeout  — the --timeout watchdog kills the implementer's WHOLE process
- *                 tree (on Windows the relay launches a .cmd shim via shell:true,
- *                 so this is exactly the case a plain child.kill would miss), and
- *                 result.json reports status "timeout".
+ *   1. timeout  — the watchdog kills the implementer's WHOLE process tree and
+ *                 result.json reports status "timeout". Driven for codex,
+ *                 opencode and grok on every platform (on Windows they launch a
+ *                 .cmd shim via shell:true — exactly the case a plain
+ *                 child.kill would miss) and for kimi on POSIX. kimi and agy
+ *                 spawn their binary directly, which never resolves a .cmd
+ *                 shim, so a PATH stand-in cannot exist for them on Windows —
+ *                 and neither has Windows-specific kill code to prove. agy's
+ *                 watchdog is --print-timeout plus a fixed 60s grace, too slow
+ *                 for a smoke; its changed code (signal handlers, snapshot
+ *                 refresh) is exactly the aborted path below.
  *   2. aborted  — killing the relay itself still produces result.json with
- *                 status "aborted", and files the implementer flushes during the
- *                 shutdown grace window appear in the refreshed touchedFiles.
- *                 (POSIX only: Windows delivers no catchable SIGTERM, so the
- *                 aborted path cannot be driven from a test there.)
+ *                 status "aborted", and files the implementer flushes during
+ *                 the shutdown grace window appear in the refreshed
+ *                 touchedFiles. Driven for all five relays on POSIX; Windows
+ *                 delivers no catchable SIGTERM, so the scenario cannot be
+ *                 driven there (the skill docs carry the same caveat).
  *
- * The fake implementer is a stand-in on PATH named `codex` (`codex.cmd` on
- * Windows) — the relay is exercised unmodified, end to end. Node built-ins only.
+ * The fake CLI answers each relay's version preflight (--version, `version`,
+ * `changelog`) and otherwise runs until killed. Node built-ins only.
  */
-import { spawn } from "node:child_process";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, mkdirSync } from "node:fs";
 import { join, delimiter, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["codex", "opencode", "agy", "grok", "kimi"].map(
-  (s) => join(here, "..", "skills", `${s}-delegate`, "scripts", "relay.mjs"),
-);
-const CODEX_RELAY = RELAYS[0];
+const SKILLS = ["codex", "opencode", "agy", "grok", "kimi"];
+const relayPath = (skill) => join(here, "..", "skills", `${skill}-delegate`, "scripts", "relay.mjs");
 const WIN = process.platform === "win32";
 let failed = 0;
 const check = (name, cond) => {
@@ -50,14 +56,19 @@ const alive = (pid) => {
 };
 
 // ---- every relay must at least parse ----
-for (const r of RELAYS) {
+for (const skill of SKILLS) {
+  const r = relayPath(skill);
   const c = spawnSync(process.execPath, ["--check", r], { encoding: "utf8" });
   check(`syntax: ${r.split(/[\\/]/).slice(-3).join("/")}`, c.status === 0);
 }
 
-// ---- a fake `codex` on PATH: --version answers the preflight; anything else runs forever ----
+// ---- one fake CLI, planted on PATH under every relay's binary name ----
 const FAKE = `const fs = require("node:fs");
-if (process.argv.includes("--version")) { console.log("codex-cli 0.0.0-smoke"); process.exit(0); }
+const args = process.argv.slice(2);
+if (args.includes("--version") || args[0] === "version" || args[0] === "changelog") {
+  console.log("fake-cli 0.0.0-smoke");
+  process.exit(0);
+}
 process.stdin.resume();
 fs.writeFileSync(process.env.SMOKE_PID_FILE, String(process.pid));
 if (process.env.SMOKE_MODE === "abort") {
@@ -71,74 +82,92 @@ setInterval(() => {}, 1000);
 const scratch = mkdtempSync(join(tmpdir(), "relay-smoke-"));
 const shimDir = join(scratch, "shim");
 mkdirSync(shimDir);
-writeFileSync(join(shimDir, "fake-codex.cjs"), FAKE);
-if (WIN) {
-  writeFileSync(join(shimDir, "codex.cmd"), `@node "%~dp0fake-codex.cjs" %*\r\n`);
-} else {
-  const shim = join(shimDir, "codex");
-  writeFileSync(shim, `#!/bin/sh\nexec node "$(dirname "$0")/fake-codex.cjs" "$@"\n`);
-  chmodSync(shim, 0o755);
+writeFileSync(join(shimDir, "fake-cli.cjs"), FAKE);
+for (const skill of SKILLS) {
+  if (WIN) {
+    writeFileSync(join(shimDir, `${skill}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
+  } else {
+    const shim = join(shimDir, skill);
+    writeFileSync(shim, `#!/bin/sh\nexec node "$(dirname "$0")/fake-cli.cjs" "$@"\n`);
+    chmodSync(shim, 0o755);
+  }
 }
-const workDir = join(scratch, "repo");
-mkdirSync(workDir);
-spawnSync("git", ["-C", workDir, "init", "-q"], { encoding: "utf8" });
 const briefPath = join(scratch, "brief.txt");
 writeFileSync(briefPath, "smoke brief: run until killed.");
 const baseEnv = { ...process.env, PATH: shimDir + delimiter + process.env.PATH };
 
-const runRelay = (outDir, extraArgs, extraEnv) =>
-  spawn(process.execPath, [CODEX_RELAY, "--brief", briefPath, "--cd", workDir, "--out-dir", outDir, ...extraArgs], {
+const freshRepo = (name) => {
+  const dir = join(scratch, name);
+  mkdirSync(dir);
+  spawnSync("git", ["-C", dir, "init", "-q"], { encoding: "utf8" });
+  return dir;
+};
+
+const runRelay = (skill, workDir, outDir, extraArgs, extraEnv) =>
+  spawn(process.execPath, [relayPath(skill), "--brief", briefPath, "--cd", workDir, "--out-dir", outDir, ...extraArgs], {
     env: { ...baseEnv, ...extraEnv },
     stdio: ["ignore", "ignore", "pipe"],
   });
 
 const result = (outDir) => JSON.parse(readFileSync(join(outDir, "result.json"), "utf8"));
 
+// opencode refuses a fresh run without an explicit model
+const EXTRA_ARGS = { codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [] };
+
 // ---- 1. the --timeout watchdog fells the whole tree ----
-{
-  const outDir = join(scratch, "out-timeout");
-  const pidFile = join(scratch, "pid-timeout");
-  const child = runRelay(outDir, ["--timeout", "6s"], { SMOKE_PID_FILE: pidFile, SMOKE_MODE: "timeout" });
+const TIMEOUT_SKILLS = WIN ? ["codex", "opencode", "grok"] : ["codex", "opencode", "grok", "kimi"];
+for (const skill of TIMEOUT_SKILLS) {
+  const outDir = join(scratch, `out-timeout-${skill}`);
+  const pidFile = join(scratch, `pid-timeout-${skill}`);
+  const workDir = freshRepo(`work-timeout-${skill}`);
+  const child = runRelay(skill, workDir, outDir, ["--timeout", "6s", ...EXTRA_ARGS[skill]], { SMOKE_PID_FILE: pidFile, SMOKE_MODE: "timeout" });
   let stderr = "";
   child.stderr.on("data", (d) => { stderr += d; });
-  check("timeout: the fake implementer came up", await until(() => existsSync(pidFile), 10_000));
-  const implementerPid = Number(readFileSync(pidFile, "utf8"));
+  check(`${skill} timeout: the fake implementer came up`, await until(() => existsSync(pidFile), 10_000));
+  const implementerPid = existsSync(pidFile) ? Number(readFileSync(pidFile, "utf8")) : null;
   const exited = await new Promise((res) => {
     const t = setTimeout(() => res(false), 45_000);
     child.on("close", () => { clearTimeout(t); res(true); });
   });
-  check("timeout: the relay exited on its own", exited);
-  check("timeout: result.json exists", existsSync(join(outDir, "result.json")));
+  check(`${skill} timeout: the relay exited on its own`, exited);
+  check(`${skill} timeout: result.json exists`, existsSync(join(outDir, "result.json")));
   if (existsSync(join(outDir, "result.json"))) {
     const r = result(outDir);
-    check(`timeout: status is "timeout" (got ${r.status})`, r.status === "timeout");
-    check("timeout: relay exit code is non-zero", r.exitCode !== 0);
+    check(`${skill} timeout: status is "timeout" (got ${r.status})`, r.status === "timeout");
+    check(`${skill} timeout: relay exit code is non-zero`, r.exitCode !== 0);
   }
-  check("timeout: the implementer process is dead (tree included)", await until(() => !alive(implementerPid), 20_000));
-  if (failed) console.error(`relay stderr tail:\n${stderr.split("\n").slice(-6).join("\n")}`);
+  check(`${skill} timeout: the implementer process is dead (tree included)`,
+    implementerPid !== null && await until(() => !alive(implementerPid), 20_000));
+  if (failed) console.error(`${skill} relay stderr tail:\n${stderr.split("\n").slice(-6).join("\n")}`);
 }
 
 // ---- 2. killing the relay still writes the artifact, with a refreshed snapshot ----
 if (WIN) {
-  console.log("  skip  aborted-path scenario: Windows delivers no catchable SIGTERM to drive it");
+  console.log("  skip  aborted-path scenarios: Windows delivers no catchable SIGTERM to drive them");
 } else {
-  const outDir = join(scratch, "out-abort");
-  const pidFile = join(scratch, "pid-abort");
-  const lateFile = join(workDir, "late-file.txt");
-  const child = runRelay(outDir, [], { SMOKE_PID_FILE: pidFile, SMOKE_MODE: "abort", SMOKE_LATE_FILE: lateFile });
-  check("aborted: the fake implementer came up", await until(() => existsSync(pidFile), 10_000));
-  child.kill("SIGTERM");
-  const exited = await new Promise((res) => {
-    const t = setTimeout(() => res(false), 20_000);
-    child.on("close", () => { clearTimeout(t); res(true); });
-  });
-  check("aborted: the relay exited after the grace window", exited);
-  check("aborted: result.json exists", existsSync(join(outDir, "result.json")));
-  if (existsSync(join(outDir, "result.json"))) {
-    const r = result(outDir);
-    check(`aborted: status is "aborted" (got ${r.status})`, r.status === "aborted");
-    check("aborted: the file flushed during shutdown is in touchedFiles",
-      Array.isArray(r.touchedFiles) && r.touchedFiles.some((f) => f.includes("late-file.txt")));
+  for (const skill of SKILLS) {
+    const outDir = join(scratch, `out-abort-${skill}`);
+    const pidFile = join(scratch, `pid-abort-${skill}`);
+    const workDir = freshRepo(`work-abort-${skill}`);
+    const lateFile = join(workDir, "late-file.txt");
+    const child = runRelay(skill, workDir, outDir, EXTRA_ARGS[skill], { SMOKE_PID_FILE: pidFile, SMOKE_MODE: "abort", SMOKE_LATE_FILE: lateFile });
+    let stderr = "";
+    child.stderr.on("data", (d) => { stderr += d; });
+    check(`${skill} aborted: the fake implementer came up`, await until(() => existsSync(pidFile), 10_000));
+    child.kill("SIGTERM");
+    const exited = await new Promise((res) => {
+      const t = setTimeout(() => res(false), 20_000);
+      child.on("close", () => { clearTimeout(t); res(true); });
+    });
+    check(`${skill} aborted: the relay exited after the grace window`, exited);
+    check(`${skill} aborted: result.json exists`, existsSync(join(outDir, "result.json")));
+    if (existsSync(join(outDir, "result.json"))) {
+      const r = result(outDir);
+      check(`${skill} aborted: status is "aborted" (got ${r.status})`, r.status === "aborted");
+      check(`${skill} aborted: the file flushed during shutdown is in touchedFiles`,
+        Array.isArray(r.touchedFiles) && r.touchedFiles.some((f) => f.includes("late-file.txt")));
+    }
+    if (failed) console.error(`${skill} relay stderr tail:\n${stderr.split("\n").slice(-6).join("\n")}`);
   }
 }
 

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -25,7 +25,11 @@
  *                 driven there (the skill docs carry the same caveat).
  *
  * The fake CLI answers each relay's version preflight (--version, `version`,
- * `changelog`) and otherwise runs until killed. Node built-ins only.
+ * `changelog`) and otherwise runs until killed. It also spawns a subprocess of
+ * its own, and both scenarios assert that this grandchild dies with it — the
+ * relays' kill must fell the whole process family (a process-group signal on
+ * POSIX, taskkill /t on Windows), not just the pid they launched.
+ * Node built-ins only.
  */
 import { spawn, spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, mkdirSync } from "node:fs";
@@ -70,7 +74,9 @@ if (args.includes("--version") || args[0] === "version" || args[0] === "changelo
   process.exit(0);
 }
 process.stdin.resume();
-fs.writeFileSync(process.env.SMOKE_PID_FILE, String(process.pid));
+const grand = require("node:child_process").spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+fs.writeFileSync(process.env.SMOKE_GRAND_PID_FILE, String(grand.pid));
+fs.writeFileSync(process.env.SMOKE_PID_FILE, String(process.pid)); // written last: its existence means both pid files are readable
 if (process.env.SMOKE_MODE === "abort") {
   process.on("SIGTERM", () => { fs.writeFileSync(process.env.SMOKE_LATE_FILE, "flushed during shutdown"); process.exit(0); });
 } else {
@@ -119,12 +125,14 @@ const TIMEOUT_SKILLS = WIN ? ["codex", "opencode", "grok"] : ["codex", "opencode
 for (const skill of TIMEOUT_SKILLS) {
   const outDir = join(scratch, `out-timeout-${skill}`);
   const pidFile = join(scratch, `pid-timeout-${skill}`);
+  const grandPidFile = join(scratch, `grandpid-timeout-${skill}`);
   const workDir = freshRepo(`work-timeout-${skill}`);
-  const child = runRelay(skill, workDir, outDir, ["--timeout", "6s", ...EXTRA_ARGS[skill]], { SMOKE_PID_FILE: pidFile, SMOKE_MODE: "timeout" });
+  const child = runRelay(skill, workDir, outDir, ["--timeout", "6s", ...EXTRA_ARGS[skill]], { SMOKE_PID_FILE: pidFile, SMOKE_GRAND_PID_FILE: grandPidFile, SMOKE_MODE: "timeout" });
   let stderr = "";
   child.stderr.on("data", (d) => { stderr += d; });
   check(`${skill} timeout: the fake implementer came up`, await until(() => existsSync(pidFile), 10_000));
   const implementerPid = existsSync(pidFile) ? Number(readFileSync(pidFile, "utf8")) : null;
+  const grandPid = existsSync(grandPidFile) ? Number(readFileSync(grandPidFile, "utf8")) : null;
   const exited = await new Promise((res) => {
     const t = setTimeout(() => res(false), 45_000);
     child.on("close", () => { clearTimeout(t); res(true); });
@@ -136,8 +144,10 @@ for (const skill of TIMEOUT_SKILLS) {
     check(`${skill} timeout: status is "timeout" (got ${r.status})`, r.status === "timeout");
     check(`${skill} timeout: relay exit code is non-zero`, r.exitCode !== 0);
   }
-  check(`${skill} timeout: the implementer process is dead (tree included)`,
+  check(`${skill} timeout: the implementer process is dead`,
     implementerPid !== null && await until(() => !alive(implementerPid), 20_000));
+  check(`${skill} timeout: the implementer's own subprocess is dead (whole tree felled)`,
+    grandPid !== null && await until(() => !alive(grandPid), 20_000));
   if (failed) console.error(`${skill} relay stderr tail:\n${stderr.split("\n").slice(-6).join("\n")}`);
 }
 
@@ -148,12 +158,14 @@ if (WIN) {
   for (const skill of SKILLS) {
     const outDir = join(scratch, `out-abort-${skill}`);
     const pidFile = join(scratch, `pid-abort-${skill}`);
+    const grandPidFile = join(scratch, `grandpid-abort-${skill}`);
     const workDir = freshRepo(`work-abort-${skill}`);
     const lateFile = join(workDir, "late-file.txt");
-    const child = runRelay(skill, workDir, outDir, EXTRA_ARGS[skill], { SMOKE_PID_FILE: pidFile, SMOKE_MODE: "abort", SMOKE_LATE_FILE: lateFile });
+    const child = runRelay(skill, workDir, outDir, EXTRA_ARGS[skill], { SMOKE_PID_FILE: pidFile, SMOKE_GRAND_PID_FILE: grandPidFile, SMOKE_MODE: "abort", SMOKE_LATE_FILE: lateFile });
     let stderr = "";
     child.stderr.on("data", (d) => { stderr += d; });
     check(`${skill} aborted: the fake implementer came up`, await until(() => existsSync(pidFile), 10_000));
+    const grandPid = existsSync(grandPidFile) ? Number(readFileSync(grandPidFile, "utf8")) : null;
     child.kill("SIGTERM");
     const exited = await new Promise((res) => {
       const t = setTimeout(() => res(false), 20_000);
@@ -167,6 +179,8 @@ if (WIN) {
       check(`${skill} aborted: the file flushed during shutdown is in touchedFiles`,
         Array.isArray(r.touchedFiles) && r.touchedFiles.some((f) => f.includes("late-file.txt")));
     }
+    check(`${skill} aborted: the implementer's own subprocess is dead (whole tree felled)`,
+      grandPid !== null && await until(() => !alive(grandPid), 20_000));
     if (failed) console.error(`${skill} relay stderr tail:\n${stderr.split("\n").slice(-6).join("\n")}`);
   }
 }

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -56,7 +56,17 @@ const until = async (fn, ms) => {
   return fn();
 };
 const alive = (pid) => {
-  try { process.kill(pid, 0); return true; } catch { return false; }
+  try { process.kill(pid, 0); } catch { return false; }
+  // a dead-but-unreaped zombie still accepts signal 0. That happens whenever nothing reaps the
+  // orphan — e.g. a container whose PID 1 is not an init — and would make a properly felled tree
+  // look alive forever. Where /proc exists, read the real state; a zombie is dead.
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const state = /\)\s+(\S)/.exec(stat.slice(stat.lastIndexOf(")")));
+    return state ? state[1] !== "Z" : true;
+  } catch {
+    return true; // no /proc (macOS, Windows): the signal-0 verdict stands
+  }
 };
 
 // ---- every relay must at least parse ----

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -7,16 +7,16 @@
  * not complete:
  *
  *   1. timeout  — the watchdog kills the implementer's WHOLE process tree and
- *                 result.json reports status "timeout". Driven for codex,
- *                 opencode and grok on every platform (on Windows they launch a
- *                 .cmd shim via shell:true — exactly the case a plain
- *                 child.kill would miss) and for kimi on POSIX. kimi and agy
- *                 spawn their binary directly, which never resolves a .cmd
- *                 shim, so a PATH stand-in cannot exist for them on Windows —
- *                 and neither has Windows-specific kill code to prove. agy's
- *                 watchdog is --print-timeout plus a fixed 60s grace, too slow
- *                 for a smoke; its changed code (signal handlers, snapshot
- *                 refresh) is exactly the aborted path below.
+ *                 result.json reports status "timeout". Driven for all five
+ *                 relays on both platforms. On Windows, codex/opencode/grok
+ *                 launch a .cmd shim via shell:true (exactly the case a plain
+ *                 child.kill would miss), while agy and kimi spawn a native
+ *                 binary directly — a .cmd stand-in can never represent them,
+ *                 so the smoke compiles a real fake .exe with the C# compiler
+ *                 that ships in-box with Windows (no install, no network) and
+ *                 puts it on PATH under their names. agy's watchdog is
+ *                 --print-timeout plus a fixed 60s grace, so its scenario is
+ *                 the slow one (about a minute) on every platform.
  *   2. aborted  — killing the relay itself still produces result.json with
  *                 status "aborted", and files the implementer flushes during
  *                 the shutdown grace window appear in the refreshed
@@ -24,7 +24,7 @@
  *                 delivers no catchable SIGTERM, so the scenario cannot be
  *                 driven there (the skill docs carry the same caveat).
  *
- * The fake CLI answers each relay's version preflight (--version, `version`,
+ * Every fake answers each relay's version preflight (--version, `version`,
  * `changelog`) and otherwise runs until killed. It also spawns a subprocess of
  * its own, and both scenarios assert that this grandchild dies with it — the
  * relays' kill must fell the whole process family (a process-group signal on
@@ -32,7 +32,7 @@
  * Node built-ins only.
  */
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, mkdirSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, mkdirSync, copyFileSync } from "node:fs";
 import { join, delimiter, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -85,14 +85,57 @@ if (process.env.SMOKE_MODE === "abort") {
 setInterval(() => {}, 1000);
 `;
 
+// agy and kimi spawn a native binary without a shell, so on Windows their stand-in must be a
+// real .exe. The C# compiler ships in-box with the .NET Framework on every supported Windows,
+// which lets the smoke build one locally — no install, no network, still dependency-free.
+const FAKE_EXE_SOURCE = `using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+class FakeCli {
+  static int Main(string[] args) {
+    if (Array.IndexOf(args, "--version") >= 0 || (args.Length > 0 && (args[0] == "version" || args[0] == "changelog"))) {
+      Console.WriteLine("fake-cli 0.0.0-smoke");
+      return 0;
+    }
+    var psi = new ProcessStartInfo {
+      FileName = Environment.GetEnvironmentVariable("SMOKE_NODE"),
+      Arguments = "-e setInterval(()=>{},1000)",
+      UseShellExecute = false,
+    };
+    var grand = Process.Start(psi);
+    File.WriteAllText(Environment.GetEnvironmentVariable("SMOKE_GRAND_PID_FILE"), grand.Id.ToString());
+    File.WriteAllText(Environment.GetEnvironmentVariable("SMOKE_PID_FILE"), Process.GetCurrentProcess().Id.ToString());
+    Thread.Sleep(Timeout.Infinite);
+    return 0;
+  }
+}
+`;
+
 const scratch = mkdtempSync(join(tmpdir(), "relay-smoke-"));
 const shimDir = join(scratch, "shim");
 mkdirSync(shimDir);
 writeFileSync(join(shimDir, "fake-cli.cjs"), FAKE);
-for (const skill of SKILLS) {
-  if (WIN) {
+if (WIN) {
+  for (const skill of ["codex", "opencode", "grok"]) {
     writeFileSync(join(shimDir, `${skill}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
-  } else {
+  }
+  const windir = process.env.WINDIR || "C:\\Windows";
+  const csc = [
+    join(windir, "Microsoft.NET", "Framework64", "v4.0.30319", "csc.exe"),
+    join(windir, "Microsoft.NET", "Framework", "v4.0.30319", "csc.exe"),
+  ].find((p) => existsSync(p));
+  check("windows: the in-box C# compiler exists (builds the native fake for agy/kimi)", Boolean(csc));
+  if (csc) {
+    const csFile = join(shimDir, "fake-cli.cs");
+    writeFileSync(csFile, FAKE_EXE_SOURCE);
+    const compiled = spawnSync(csc, ["/nologo", `/out:${join(shimDir, "kimi.exe")}`, csFile], { encoding: "utf8" });
+    check("windows: the native fake compiled", compiled.status === 0);
+    if (compiled.status === 0) copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "agy.exe"));
+    else console.error(`${compiled.stdout ?? ""}${compiled.stderr ?? ""}`);
+  }
+} else {
+  for (const skill of SKILLS) {
     const shim = join(shimDir, skill);
     writeFileSync(shim, `#!/bin/sh\nexec node "$(dirname "$0")/fake-cli.cjs" "$@"\n`);
     chmodSync(shim, 0o755);
@@ -100,7 +143,7 @@ for (const skill of SKILLS) {
 }
 const briefPath = join(scratch, "brief.txt");
 writeFileSync(briefPath, "smoke brief: run until killed.");
-const baseEnv = { ...process.env, PATH: shimDir + delimiter + process.env.PATH };
+const baseEnv = { ...process.env, PATH: shimDir + delimiter + process.env.PATH, SMOKE_NODE: process.execPath };
 
 const freshRepo = (name) => {
   const dir = join(scratch, name);
@@ -120,21 +163,29 @@ const result = (outDir) => JSON.parse(readFileSync(join(outDir, "result.json"), 
 // opencode refuses a fresh run without an explicit model
 const EXTRA_ARGS = { codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [] };
 
-// ---- 1. the --timeout watchdog fells the whole tree ----
-const TIMEOUT_SKILLS = WIN ? ["codex", "opencode", "grok"] : ["codex", "opencode", "grok", "kimi"];
-for (const skill of TIMEOUT_SKILLS) {
+// ---- 1. the watchdog fells the whole tree ----
+// agy's watchdog flag is --print-timeout, and it always adds a fixed 60s grace on top,
+// so its run needs about a minute wherever it executes.
+const TIMEOUT_CASES = [
+  { skill: "codex", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "opencode", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "grok", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "kimi", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "agy", flags: ["--print-timeout", "1s"], exitDeadline: 120_000 },
+];
+for (const { skill, flags, exitDeadline } of TIMEOUT_CASES) {
   const outDir = join(scratch, `out-timeout-${skill}`);
   const pidFile = join(scratch, `pid-timeout-${skill}`);
   const grandPidFile = join(scratch, `grandpid-timeout-${skill}`);
   const workDir = freshRepo(`work-timeout-${skill}`);
-  const child = runRelay(skill, workDir, outDir, ["--timeout", "6s", ...EXTRA_ARGS[skill]], { SMOKE_PID_FILE: pidFile, SMOKE_GRAND_PID_FILE: grandPidFile, SMOKE_MODE: "timeout" });
+  const child = runRelay(skill, workDir, outDir, [...flags, ...EXTRA_ARGS[skill]], { SMOKE_PID_FILE: pidFile, SMOKE_GRAND_PID_FILE: grandPidFile, SMOKE_MODE: "timeout" });
   let stderr = "";
   child.stderr.on("data", (d) => { stderr += d; });
   check(`${skill} timeout: the fake implementer came up`, await until(() => existsSync(pidFile), 10_000));
   const implementerPid = existsSync(pidFile) ? Number(readFileSync(pidFile, "utf8")) : null;
   const grandPid = existsSync(grandPidFile) ? Number(readFileSync(grandPidFile, "utf8")) : null;
   const exited = await new Promise((res) => {
-    const t = setTimeout(() => res(false), 45_000);
+    const t = setTimeout(() => res(false), exitDeadline);
     child.on("close", () => { clearTimeout(t); res(true); });
   });
   check(`${skill} timeout: the relay exited on its own`, exited);

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -16,7 +16,11 @@
  *                 that ships in-box with Windows (no install, no network) and
  *                 puts it on PATH under their names. agy's watchdog is
  *                 --print-timeout plus a fixed 60s grace, so its scenario is
- *                 the slow one (about a minute) on every platform.
+ *                 the slow one (about a minute) on every platform. A POSIX
+ *                 variant repeats each run with a parent that complies with
+ *                 SIGTERM while its grandchild ignores it — the sweep at close
+ *                 must fell the survivor even though the parent's exit
+ *                 cancelled the pending escalation timer.
  *   2. aborted  — killing the relay itself still produces result.json with
  *                 status "aborted", and files the implementer flushes during
  *                 the shutdown grace window appear in the refreshed
@@ -84,11 +88,16 @@ if (args.includes("--version") || args[0] === "version" || args[0] === "changelo
   process.exit(0);
 }
 process.stdin.resume();
-const grand = require("node:child_process").spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+const grandProgram = process.env.SMOKE_GRAND_IGNORES_SIGTERM
+  ? "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"
+  : "setInterval(() => {}, 1000)";
+const grand = require("node:child_process").spawn(process.execPath, ["-e", grandProgram], { stdio: "ignore" });
 fs.writeFileSync(process.env.SMOKE_GRAND_PID_FILE, String(grand.pid));
 fs.writeFileSync(process.env.SMOKE_PID_FILE, String(process.pid)); // written last: its existence means both pid files are readable
 if (process.env.SMOKE_MODE === "abort") {
   process.on("SIGTERM", () => { fs.writeFileSync(process.env.SMOKE_LATE_FILE, "flushed during shutdown"); process.exit(0); });
+} else if (process.env.SMOKE_MODE === "timeout-yield") {
+  process.on("SIGTERM", () => process.exit(0)); // the parent complies while the grandchild ignores
 } else {
   process.on("SIGTERM", () => {}); // ignore, so the relay's SIGKILL escalation is what ends it
 }
@@ -183,33 +192,47 @@ const TIMEOUT_CASES = [
   { skill: "kimi", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "agy", flags: ["--print-timeout", "1s"], exitDeadline: 120_000 },
 ];
-for (const { skill, flags, exitDeadline } of TIMEOUT_CASES) {
-  const outDir = join(scratch, `out-timeout-${skill}`);
-  const pidFile = join(scratch, `pid-timeout-${skill}`);
-  const grandPidFile = join(scratch, `grandpid-timeout-${skill}`);
-  const workDir = freshRepo(`work-timeout-${skill}`);
-  const child = runRelay(skill, workDir, outDir, [...flags, ...EXTRA_ARGS[skill]], { SMOKE_PID_FILE: pidFile, SMOKE_GRAND_PID_FILE: grandPidFile, SMOKE_MODE: "timeout" });
+async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag) {
+  const outDir = join(scratch, `out-${tag}-${skill}`);
+  const pidFile = join(scratch, `pid-${tag}-${skill}`);
+  const grandPidFile = join(scratch, `grandpid-${tag}-${skill}`);
+  const workDir = freshRepo(`work-${tag}-${skill}`);
+  const child = runRelay(skill, workDir, outDir, [...flags, ...EXTRA_ARGS[skill]], { SMOKE_PID_FILE: pidFile, SMOKE_GRAND_PID_FILE: grandPidFile, SMOKE_MODE: mode, ...extraEnv });
   let stderr = "";
   child.stderr.on("data", (d) => { stderr += d; });
-  check(`${skill} timeout: the fake implementer came up`, await until(() => existsSync(pidFile), 10_000));
+  check(`${skill} ${tag}: the fake implementer came up`, await until(() => existsSync(pidFile), 10_000));
   const implementerPid = existsSync(pidFile) ? Number(readFileSync(pidFile, "utf8")) : null;
   const grandPid = existsSync(grandPidFile) ? Number(readFileSync(grandPidFile, "utf8")) : null;
   const exited = await new Promise((res) => {
     const t = setTimeout(() => res(false), exitDeadline);
     child.on("close", () => { clearTimeout(t); res(true); });
   });
-  check(`${skill} timeout: the relay exited on its own`, exited);
-  check(`${skill} timeout: result.json exists`, existsSync(join(outDir, "result.json")));
+  check(`${skill} ${tag}: the relay exited on its own`, exited);
+  check(`${skill} ${tag}: result.json exists`, existsSync(join(outDir, "result.json")));
   if (existsSync(join(outDir, "result.json"))) {
     const r = result(outDir);
-    check(`${skill} timeout: status is "timeout" (got ${r.status})`, r.status === "timeout");
-    check(`${skill} timeout: relay exit code is non-zero`, r.exitCode !== 0);
+    check(`${skill} ${tag}: status is "timeout" (got ${r.status})`, r.status === "timeout");
+    check(`${skill} ${tag}: relay exit code is non-zero`, r.exitCode !== 0);
   }
-  check(`${skill} timeout: the implementer process is dead`,
+  check(`${skill} ${tag}: the implementer process is dead`,
     implementerPid !== null && await until(() => !alive(implementerPid), 20_000));
-  check(`${skill} timeout: the implementer's own subprocess is dead (whole tree felled)`,
+  check(`${skill} ${tag}: the implementer's own subprocess is dead (whole tree felled)`,
     grandPid !== null && await until(() => !alive(grandPid), 20_000));
   if (failed) console.error(`${skill} relay stderr tail:\n${stderr.split("\n").slice(-6).join("\n")}`);
+}
+
+for (const tc of TIMEOUT_CASES) {
+  await driveTimeout(tc, "timeout", {}, "timeout");
+}
+
+// A compliant parent must not shield a defiant descendant: the parent exits on the group
+// SIGTERM, its grandchild ignores it, and the sweep at close must still fell the grandchild
+// before the relay reports. POSIX only — the Windows kill is a single unconditional
+// taskkill /t /f with no SIGTERM/escalation phase to defeat.
+if (!WIN) {
+  for (const tc of TIMEOUT_CASES) {
+    await driveTimeout(tc, "timeout-yield", { SMOKE_GRAND_IGNORES_SIGTERM: "1" }, "timeout-yield");
+  }
 }
 
 // ---- 2. killing the relay still writes the artifact, with a refreshed snapshot ----


### PR DESCRIPTION
Field-driven fixes from real orchestrator use (~10 dispatches through kimi-delegate and codex-delegate on a 2,500-line Node repo, including two runs killed mid-flight and one recovered from events.jsonl).

## The problem

1. **A kill of the relay itself left nothing behind.** No relay registered signal handlers, so an orchestrator-side kill (its command timeout, a stopped task, a closed terminal) wrote no `result.json` and left the implementer child dying mid-edit — a bare exit 143 with no artifact explaining it. The artifact that would explain the death is exactly what the death prevented.
2. **A hung run had no bounded exit on three relays.** codex, opencode, and grok had no watchdog at all; the only remedy was killing the relay — which is problem 1.
3. **Watchdog kills were indistinguishable from ordinary failures.** kimi and agy reported the watchdog firing as generic `failed`, with the cause only in a prose `error` string.

## The change (all five relays, same shape)

- **Signal handlers** (`SIGTERM`/`SIGINT`/`SIGHUP`): write `result.json` with distinct `status: "aborted"` (exit 128+signal), print the summary, forward SIGTERM to the child, SIGKILL after 2s, exit. A result now exists on every exit path. Registration of SIGTERM/SIGHUP is a no-op on Windows; SIGINT works there; the launch code is untouched.
- **`--timeout <dur>` on codex, opencode, and grok** (kimi already had it; agy's watchdog stays tied to `--print-timeout` + 60s by design). Default **off** on the three new ones so existing behavior is unchanged — say the word if you'd rather align defaults across the family.
- **Distinct `status: "timeout"`** when any watchdog fires (was `failed`), with the relay exit staying non-zero even if the implementer handles SIGTERM by exiting 0.
- **SIGTERM hint** in the summary next to the existing SIGKILL hint, for the case where something *outside* the relay killed the implementer.
- Docs updated to match: status vocabulary and `stderrTail` presence in each `references/dispatch-and-poll.md`, new failure-mode bullets, and a watchdog line in each dispatch example (the kimi line notes the 30m default is sized for short runs — implementation briefs routinely need 1–2h, which is how this batch of fixes got discovered).

## Verification (macOS, all five CLIs installed)

| Relay | `node --check` + `--help` | live `--timeout` kill | live relay-SIGTERM (`aborted`) |
|---|---|---|---|
| codex | ✓ | ✓ status `timeout`, no orphan | ✓ status `aborted`, exit 143, no orphan |
| kimi | ✓ | ✓ | ✓ |
| opencode | ✓ | ✓ | ✓ |
| grok | ✓ | ✓ | ✓ |
| agy | ✓ | not exercised — two live attempts completed before the 65s minimum watchdog; the status mapping is the same one-line ternary live-verified on the other four | ✓ |

Also: malformed `--timeout` rejected loudly pre-run (exit 2, no result file, matching the existing usage-error contract); `npx skills add . --list` still finds all 5 skills. The codex timeout test hit the subtle case the kimi comment warns about — codex caught SIGTERM and exited 0, and the relay still reported `timeout` with a non-zero exit. Windows not smoke-tested this round: launch paths are untouched, but per AGENTS.md claiming Windows support for the new flag needs its own smoke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional relay-side hard watchdog timeouts for delegation runs (`--timeout <dur>`), with validated `h/m/s` durations (default off).
  * Relay interruptions now produce `aborted`; watchdog expiry produces `timeout`, across supported delegations.
* **Bug Fixes**
  * Improved non-completion reporting: expanded `result.json` status mapping, forced non-zero `exitCode` on `timeout`, and more consistent inclusion of `finalMessage`, `touchedFiles`, `stderrTail`, and `error` where applicable.
* **Documentation**
  * Updated dispatch-and-poll and troubleshooting guidance for the expanded `result.json` contract and operator expectations.
* **Tests**
  * Added end-to-end relay smoke tests.
* **Chores**
  * Added a new CI workflow to run relay smoke tests and validate the skills package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->