### PR TITLE
Field-notes docs: working-tree rule, event-log recovery, premise freeze, finalMessage pointer, read-only debates

### DIFF
--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -85,7 +85,7 @@ resume when it returns:
 
 Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
 process has exited. Read the working tree, not a status line. The implementer's full report is
-`result.json`'s `finalMessage` field; the stdout summary prints only its tail.
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
 
 ### 4. Review - do not trust the self-report
 

--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -84,7 +84,8 @@ resume when it returns:
   the result file.
 
 Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
-process has exited. Read the working tree, not a status line.
+process has exited. Read the working tree, not a status line. The implementer's full report is
+`result.json`'s `finalMessage` field; the stdout summary prints only its tail.
 
 ### 4. Review - do not trust the self-report
 

--- a/skills/agy-delegate/references/review-and-land.md
+++ b/skills/agy-delegate/references/review-and-land.md
@@ -68,7 +68,9 @@ it.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
+they are the implementer's new files, and `git diff` never shows their contents. The tree is
+evidence, not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/agy-delegate/references/review-and-land.md
+++ b/skills/agy-delegate/references/review-and-land.md
@@ -67,10 +67,11 @@ it.
 
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
-workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
-they are the implementer's new files, and `git diff` never shows their contents. The tree is
-evidence, not clutter. After that inspection the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/agy-delegate/references/review-and-land.md
+++ b/skills/agy-delegate/references/review-and-land.md
@@ -68,7 +68,10 @@ it.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter.
+`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
 
 ## Reworking: send the delta, not the whole task
 

--- a/skills/agy-delegate/references/review-and-land.md
+++ b/skills/agy-delegate/references/review-and-land.md
@@ -65,6 +65,11 @@ When the gates pass and the diff holds, **you commit** - the orchestrator, never
 a clear message describing what landed. If your project attributes co-authorship, that is the place for
 it.
 
+From dispatch until that commit, the uncommitted working tree is the only copy of the
+implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it with
+`git status` and `git diff` first. The tree is evidence, not clutter.
+
 ## Reworking: send the delta, not the whole task
 
 If the review turns up problems, don't restate the entire brief. Continue the same Antigravity

--- a/skills/agy-delegate/references/review-and-land.md
+++ b/skills/agy-delegate/references/review-and-land.md
@@ -65,8 +65,8 @@ When the gates pass and the diff holds, **you commit** - the orchestrator, never
 a clear message describing what landed. If your project attributes co-authorship, that is the place for
 it.
 
-From dispatch until that commit, the uncommitted working tree is the only copy of the
-implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
 `git status` and `git diff` first. The tree is evidence, not clutter.
 

--- a/skills/agy-delegate/references/writing-the-brief.md
+++ b/skills/agy-delegate/references/writing-the-brief.md
@@ -88,8 +88,9 @@ a roadmap" produces a muddled run; split it into separate dispatches. One brief 
 The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
 fact block before sending — ownership, target branch, constraints, anything a judgment call rests
 on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
-brief rather than discounting the output afterwards; for a write-capable run, inspect the working
-tree before the re-dispatch.
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
 
 ## A worked example
 

--- a/skills/agy-delegate/references/writing-the-brief.md
+++ b/skills/agy-delegate/references/writing-the-brief.md
@@ -83,6 +83,14 @@ Keep each brief to a single, bounded job. "Review this, fix what you find, updat
 a roadmap" produces a muddled run; split it into separate dispatches. One brief -> one Antigravity run
 -> one commit keeps review and rollback clean.
 
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterwards; for a write-capable run, inspect the working
+tree before the re-dispatch.
+
 ## A worked example
 
 ```xml

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -118,10 +118,10 @@ orchestrator commits.** Only after the gates pass and the diff holds:
 The relay doubles as a clean way to get an adversarial second opinion with no write risk: dispatch
 `--read-only` with a brief that lists the agreed points, then each contested point with both
 positions, and ask Codex to defend or concede each — deliverable in its final message, touching no
-files. Any relay with a read-only mode supports the same use, but check how hard that mode's
-guarantee is first: Codex's sandbox enforces it, while Grok's is best-effort and only flagged
-after the fact (`readOnlyViolation`) — on those relays, verify `touchedFiles` came back empty
-instead of assuming no edits.
+files. Any delegation skill whose implementer offers a read-only mode supports the same use, but
+check how hard that mode's guarantee is first: Codex's sandbox enforces it, while Grok's is
+best-effort and only flagged after the fact (`readOnlyViolation`) — for those implementers,
+verify `touchedFiles` came back empty instead of assuming no edits.
 
 ## Authorization model
 

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -88,7 +88,7 @@ when it returns:
 
 Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
 process has exited. Read the working tree, not a status line. The implementer's full report is
-`result.json`'s `finalMessage` field; the stdout summary prints only its tail.
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
 
 ### 4. Review — do not trust the self-report
 
@@ -118,8 +118,8 @@ orchestrator commits.** Only after the gates pass and the diff holds:
 The relay doubles as a clean way to get an adversarial second opinion with no write risk: dispatch
 `--read-only` with a brief that lists the agreed points, then each contested point with both
 positions, and ask Codex to defend or concede each — deliverable in its final message, touching no
-files. This shape has settled design debates before any implementation was briefed; any relay with
-a read-only mode can run the same play.
+files. Any relay with a read-only mode supports the same use — a structured second opinion or
+design review with no risk of edits.
 
 ## Authorization model
 

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -118,8 +118,10 @@ orchestrator commits.** Only after the gates pass and the diff holds:
 The relay doubles as a clean way to get an adversarial second opinion with no write risk: dispatch
 `--read-only` with a brief that lists the agreed points, then each contested point with both
 positions, and ask Codex to defend or concede each — deliverable in its final message, touching no
-files. Any relay with a read-only mode supports the same use — a structured second opinion or
-design review with no risk of edits.
+files. Any relay with a read-only mode supports the same use, but check how hard that mode's
+guarantee is first: Codex's sandbox enforces it, while Grok's is best-effort and only flagged
+after the fact (`readOnlyViolation`) — on those relays, verify `touchedFiles` came back empty
+instead of assuming no edits.
 
 ## Authorization model
 

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -87,7 +87,8 @@ when it returns:
   a `result.json` with status `codex_unavailable`.)
 
 Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
-process has exited. Read the working tree, not a status line.
+process has exited. Read the working tree, not a status line. The implementer's full report is
+`result.json`'s `finalMessage` field; the stdout summary prints only its tail.
 
 ### 4. Review — do not trust the self-report
 
@@ -111,6 +112,14 @@ orchestrator commits.** Only after the gates pass and the diff holds:
 - Commit the verified work yourself, with a clear message.
 - If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
   review again.
+
+## Read-only second opinions
+
+The relay doubles as a clean way to get an adversarial second opinion with no write risk: dispatch
+`--read-only` with a brief that lists the agreed points, then each contested point with both
+positions, and ask Codex to defend or concede each — deliverable in its final message, touching no
+files. This shape has settled design debates before any implementation was briefed; any relay with
+a read-only mode can run the same play.
 
 ## Authorization model
 

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -107,9 +107,9 @@ process has exited and `result.json` is written — not when a status line says 
 ## Recovering lost work
 
 `events.jsonl` in the run directory records every event the implementer streamed, including its
-edits. If finished work is lost — the run killed late, or the working tree damaged afterwards —
-read the event log before re-dispatching: the recorded edits often reconstruct the completed
-change exactly, instead of paying for the run again.
+edits. If finished work is lost — the run killed late, or the working tree damaged afterward —
+read the event log before re-dispatching: its recorded tool calls and edits can often rebuild the
+lost work. Validate any reconstruction against the working-tree diff before relying on it.
 
 ## What the helper is doing (and the alternatives)
 

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -104,6 +104,13 @@ process has exited and `result.json` is written — not when a status line says 
 - **Empty `finalMessage`:** Codex exited before producing a final message. Treat as a failed run;
   the events log usually shows where it stopped.
 
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed, including its
+edits. If finished work is lost — the run killed late, or the working tree damaged afterwards —
+read the event log before re-dispatching: the recorded edits often reconstruct the completed
+change exactly, instead of paying for the run again.
+
 ## What the helper is doing (and the alternatives)
 
 Under the hood the helper runs roughly:

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -106,10 +106,13 @@ process has exited and `result.json` is written — not when a status line says 
 
 ## Recovering lost work
 
-`events.jsonl` in the run directory records every event the implementer streamed, including its
-edits. If finished work is lost — the run killed late, or the working tree damaged afterward —
-read the event log before re-dispatching: its recorded tool calls and edits can often rebuild the
-lost work. Validate any reconstruction against the working-tree diff before relying on it.
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. It cannot rebuild the changes themselves — Codex's JSON stream currently
+reports a file change as its path and kind only, without the diff contents — so when the tree
+still holds the work, preserve the tree, and otherwise re-dispatch with the log as the map of
+what was lost.
 
 ## What the helper is doing (and the alternatives)
 

--- a/skills/codex-delegate/references/review-and-land.md
+++ b/skills/codex-delegate/references/review-and-land.md
@@ -88,7 +88,9 @@ for it.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
+they are the implementer's new files, and `git diff` never shows their contents. The tree is
+evidence, not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/codex-delegate/references/review-and-land.md
+++ b/skills/codex-delegate/references/review-and-land.md
@@ -87,10 +87,11 @@ for it.
 
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
-workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
-they are the implementer's new files, and `git diff` never shows their contents. The tree is
-evidence, not clutter. After that inspection the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/codex-delegate/references/review-and-land.md
+++ b/skills/codex-delegate/references/review-and-land.md
@@ -85,8 +85,8 @@ workaround for a missing feature; it's the deliberate boundary. Codex's sandbox 
 a clear message describing what landed. If your project attributes co-authorship, that's the place
 for it.
 
-From dispatch until that commit, the uncommitted working tree is the only copy of the
-implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
 `git status` and `git diff` first. The tree is evidence, not clutter.
 

--- a/skills/codex-delegate/references/review-and-land.md
+++ b/skills/codex-delegate/references/review-and-land.md
@@ -85,6 +85,11 @@ workaround for a missing feature; it's the deliberate boundary. Codex's sandbox 
 a clear message describing what landed. If your project attributes co-authorship, that's the place
 for it.
 
+From dispatch until that commit, the uncommitted working tree is the only copy of the
+implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it with
+`git status` and `git diff` first. The tree is evidence, not clutter.
+
 ## Reworking: send the delta, not the whole task
 
 If the review turns up problems, don't restate the entire brief. Continue the same Codex session with

--- a/skills/codex-delegate/references/review-and-land.md
+++ b/skills/codex-delegate/references/review-and-land.md
@@ -88,7 +88,10 @@ for it.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter.
+`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
 
 ## Reworking: send the delta, not the whole task
 

--- a/skills/codex-delegate/references/writing-the-brief.md
+++ b/skills/codex-delegate/references/writing-the-brief.md
@@ -75,6 +75,14 @@ Keep each brief to a single, bounded job. "Review this, fix what you find, updat
 suggest a roadmap" produces a muddled run; split it into separate dispatches. One brief → one Codex
 run → one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
 
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterwards; for a write-capable run, inspect the working
+tree before the re-dispatch.
+
 ## Expect environment preamble in the reply
 
 Codex's final message may carry environment noise on top of your requested report — a banner injected

--- a/skills/codex-delegate/references/writing-the-brief.md
+++ b/skills/codex-delegate/references/writing-the-brief.md
@@ -80,8 +80,9 @@ run → one commit keeps review and rollback clean, and lets a later task assume
 The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
 fact block before sending — ownership, target branch, constraints, anything a judgment call rests
 on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
-brief rather than discounting the output afterwards; for a write-capable run, inspect the working
-tree before the re-dispatch.
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
 
 ## Expect environment preamble in the reply
 

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -91,7 +91,8 @@ when it returns:
   a `result.json` with status `grok_unavailable`.)
 
 Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
-process has exited. Read the working tree, not a status line.
+process has exited. Read the working tree, not a status line. The implementer's full report is
+`result.json`'s `finalMessage` field; the stdout summary prints only its tail.
 
 ### 4. Review — do not trust the self-report
 

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -92,7 +92,7 @@ when it returns:
 
 Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
 process has exited. Read the working tree, not a status line. The implementer's full report is
-`result.json`'s `finalMessage` field; the stdout summary prints only its tail.
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
 
 ### 4. Review — do not trust the self-report
 

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -117,6 +117,13 @@ process has exited and `result.json` is written — not when a status line says 
   shape didn't match the extractor. Treat as a failed run; the events log usually shows where it
   stopped — and is the source of truth for tightening the parser.
 
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed, including its
+edits. If finished work is lost — the run killed late, or the working tree damaged afterwards —
+read the event log before re-dispatching: the recorded edits often reconstruct the completed
+change exactly, instead of paying for the run again.
+
 ## What the helper is doing (and the alternatives)
 
 Under the hood the helper runs roughly:

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -119,10 +119,12 @@ process has exited and `result.json` is written — not when a status line says 
 
 ## Recovering lost work
 
-`events.jsonl` in the run directory records every event the implementer streamed, including its
-edits. If finished work is lost — the run killed late, or the working tree damaged afterward —
-read the event log before re-dispatching: its recorded tool calls and edits can often rebuild the
-lost work. Validate any reconstruction against the working-tree diff before relying on it.
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Whether it also carries the edit contents depends on what the CLI streams,
+so treat any reconstruction as unverified until it matches a working-tree diff — when the tree
+still holds the work, preserve the tree rather than replaying the log.
 
 ## What the helper is doing (and the alternatives)
 

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -120,9 +120,9 @@ process has exited and `result.json` is written — not when a status line says 
 ## Recovering lost work
 
 `events.jsonl` in the run directory records every event the implementer streamed, including its
-edits. If finished work is lost — the run killed late, or the working tree damaged afterwards —
-read the event log before re-dispatching: the recorded edits often reconstruct the completed
-change exactly, instead of paying for the run again.
+edits. If finished work is lost — the run killed late, or the working tree damaged afterward —
+read the event log before re-dispatching: its recorded tool calls and edits can often rebuild the
+lost work. Validate any reconstruction against the working-tree diff before relying on it.
 
 ## What the helper is doing (and the alternatives)
 

--- a/skills/grok-delegate/references/review-and-land.md
+++ b/skills/grok-delegate/references/review-and-land.md
@@ -87,7 +87,9 @@ co-authorship, that's the place for it.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
+they are the implementer's new files, and `git diff` never shows their contents. The tree is
+evidence, not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/grok-delegate/references/review-and-land.md
+++ b/skills/grok-delegate/references/review-and-land.md
@@ -86,10 +86,11 @@ co-authorship, that's the place for it.
 
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
-workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
-they are the implementer's new files, and `git diff` never shows their contents. The tree is
-evidence, not clutter. After that inspection the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/grok-delegate/references/review-and-land.md
+++ b/skills/grok-delegate/references/review-and-land.md
@@ -87,7 +87,10 @@ co-authorship, that's the place for it.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter.
+`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
 
 ## Reworking: send the delta, not the whole task
 

--- a/skills/grok-delegate/references/review-and-land.md
+++ b/skills/grok-delegate/references/review-and-land.md
@@ -84,6 +84,11 @@ workaround for a missing feature; it's the deliberate boundary. Committing shoul
 party that verified the work. Write a clear message describing what landed. If your project attributes
 co-authorship, that's the place for it.
 
+From dispatch until that commit, the uncommitted working tree is the only copy of the
+implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it with
+`git status` and `git diff` first. The tree is evidence, not clutter.
+
 ## Reworking: send the delta, not the whole task
 
 If the review turns up problems, don't restate the entire brief. Continue the same Grok session with

--- a/skills/grok-delegate/references/review-and-land.md
+++ b/skills/grok-delegate/references/review-and-land.md
@@ -84,8 +84,8 @@ workaround for a missing feature; it's the deliberate boundary. Committing shoul
 party that verified the work. Write a clear message describing what landed. If your project attributes
 co-authorship, that's the place for it.
 
-From dispatch until that commit, the uncommitted working tree is the only copy of the
-implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
 `git status` and `git diff` first. The tree is evidence, not clutter.
 

--- a/skills/grok-delegate/references/writing-the-brief.md
+++ b/skills/grok-delegate/references/writing-the-brief.md
@@ -77,6 +77,14 @@ Keep each brief to a single, bounded job. "Review this, fix what you find, updat
 suggest a roadmap" produces a muddled run; split it into separate dispatches. One brief → one Grok
 run → one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
 
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterwards; for a write-capable run, inspect the working
+tree before the re-dispatch.
+
 ## A worked example
 
 ```xml

--- a/skills/grok-delegate/references/writing-the-brief.md
+++ b/skills/grok-delegate/references/writing-the-brief.md
@@ -82,8 +82,9 @@ run → one commit keeps review and rollback clean, and lets a later task assume
 The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
 fact block before sending — ownership, target branch, constraints, anything a judgment call rests
 on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
-brief rather than discounting the output afterwards; for a write-capable run, inspect the working
-tree before the re-dispatch.
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
 
 ## A worked example
 

--- a/skills/kimi-delegate/SKILL.md
+++ b/skills/kimi-delegate/SKILL.md
@@ -76,8 +76,8 @@ background it in the shell and poll for `result.json`. A pre-run usage error exi
 result; a missing `kimi` exits 127 and writes `status: "kimi_unavailable"`.
 
 Trust process state and the working tree over a progress display. Completion means the process exited
-and `result.json` exists. Kimi's full report is `result.json`'s `finalMessage` field; the stdout
-summary prints only its tail.
+and `result.json` exists. Kimi's full report is the `finalMessage` field in `result.json` (also printed
+in full on stdout between the report markers).
 
 ### 4. Review - do not trust the self-report
 

--- a/skills/kimi-delegate/SKILL.md
+++ b/skills/kimi-delegate/SKILL.md
@@ -76,7 +76,8 @@ background it in the shell and poll for `result.json`. A pre-run usage error exi
 result; a missing `kimi` exits 127 and writes `status: "kimi_unavailable"`.
 
 Trust process state and the working tree over a progress display. Completion means the process exited
-and `result.json` exists.
+and `result.json` exists. Kimi's full report is `result.json`'s `finalMessage` field; the stdout
+summary prints only its tail.
 
 ### 4. Review - do not trust the self-report
 

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -101,6 +101,13 @@ A pre-run usage error exits 2 and writes no result. A missing `kimi` exits 127 a
 - **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
   `<structured_output_contract>` to the next brief to require a closing report.
 
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed, including its
+edits. If finished work is lost — the run killed late, or the working tree damaged afterwards —
+read the event log before re-dispatching: the recorded edits often reconstruct the completed
+change exactly, instead of paying for the run again. A kimi run's edits have been replayed from the event log byte-exact this way.
+
 ## What the relay runs
 
 The argv is equivalent to:

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -104,9 +104,9 @@ A pre-run usage error exits 2 and writes no result. A missing `kimi` exits 127 a
 ## Recovering lost work
 
 `events.jsonl` in the run directory records every event the implementer streamed, including its
-edits. If finished work is lost — the run killed late, or the working tree damaged afterwards —
-read the event log before re-dispatching: the recorded edits often reconstruct the completed
-change exactly, instead of paying for the run again. A kimi run's edits have been replayed from the event log byte-exact this way.
+edits. If finished work is lost — the run killed late, or the working tree damaged afterward —
+read the event log before re-dispatching: its recorded tool calls and edits can often rebuild the
+lost work. Validate any reconstruction against the working-tree diff before relying on it.
 
 ## What the relay runs
 

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -103,10 +103,12 @@ A pre-run usage error exits 2 and writes no result. A missing `kimi` exits 127 a
 
 ## Recovering lost work
 
-`events.jsonl` in the run directory records every event the implementer streamed, including its
-edits. If finished work is lost — the run killed late, or the working tree damaged afterward —
-read the event log before re-dispatching: its recorded tool calls and edits can often rebuild the
-lost work. Validate any reconstruction against the working-tree diff before relying on it.
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Whether it also carries the edit contents depends on what the CLI streams,
+so treat any reconstruction as unverified until it matches a working-tree diff — when the tree
+still holds the work, preserve the tree rather than replaying the log.
 
 ## What the relay runs
 

--- a/skills/kimi-delegate/references/review-and-land.md
+++ b/skills/kimi-delegate/references/review-and-land.md
@@ -54,10 +54,11 @@ clear message describing what landed.
 
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
-workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
-they are the implementer's new files, and `git diff` never shows their contents. The tree is
-evidence, not clutter. After that inspection the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/kimi-delegate/references/review-and-land.md
+++ b/skills/kimi-delegate/references/review-and-land.md
@@ -55,7 +55,10 @@ clear message describing what landed.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter.
+`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
 
 ## Rework: send the delta
 

--- a/skills/kimi-delegate/references/review-and-land.md
+++ b/skills/kimi-delegate/references/review-and-land.md
@@ -55,7 +55,9 @@ clear message describing what landed.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
+they are the implementer's new files, and `git diff` never shows their contents. The tree is
+evidence, not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/kimi-delegate/references/review-and-land.md
+++ b/skills/kimi-delegate/references/review-and-land.md
@@ -52,8 +52,8 @@ to the human. Run relevant guard skills if installed.
 When the gates pass and the diff holds, **the orchestrator commits**, never the implementer. Write a
 clear message describing what landed.
 
-From dispatch until that commit, the uncommitted working tree is the only copy of the
-implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
 `git status` and `git diff` first. The tree is evidence, not clutter.
 

--- a/skills/kimi-delegate/references/review-and-land.md
+++ b/skills/kimi-delegate/references/review-and-land.md
@@ -52,6 +52,11 @@ to the human. Run relevant guard skills if installed.
 When the gates pass and the diff holds, **the orchestrator commits**, never the implementer. Write a
 clear message describing what landed.
 
+From dispatch until that commit, the uncommitted working tree is the only copy of the
+implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it with
+`git status` and `git diff` first. The tree is evidence, not clutter.
+
 ## Rework: send the delta
 
 Continue the same session with only the correction:

--- a/skills/kimi-delegate/references/writing-the-brief.md
+++ b/skills/kimi-delegate/references/writing-the-brief.md
@@ -83,8 +83,9 @@ dispatches.
 The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
 fact block before sending — ownership, target branch, constraints, anything a judgment call rests
 on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
-brief rather than discounting the output afterwards; for a write-capable run, inspect the working
-tree before the re-dispatch.
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
 
 ## A worked example
 

--- a/skills/kimi-delegate/references/writing-the-brief.md
+++ b/skills/kimi-delegate/references/writing-the-brief.md
@@ -78,6 +78,14 @@ Keep each brief bounded. One brief -> one Kimi run -> one reviewed commit keeps 
 clean. Split mixed implementation, review, documentation, and roadmap requests into separate
 dispatches.
 
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterwards; for a write-capable run, inspect the working
+tree before the re-dispatch.
+
 ## A worked example
 
 ```xml

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -109,7 +109,7 @@ when it returns:
 
 Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
 process has exited. Read the working tree, not a status line. The implementer's full report is
-`result.json`'s `finalMessage` field; the stdout summary prints only its tail.
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
 
 ### 4. Review — do not trust the self-report
 

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -108,7 +108,8 @@ when it returns:
   `result.json` with status `opencode_unavailable`.)
 
 Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
-process has exited. Read the working tree, not a status line.
+process has exited. Read the working tree, not a status line. The implementer's full report is
+`result.json`'s `finalMessage` field; the stdout summary prints only its tail.
 
 ### 4. Review — do not trust the self-report
 

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -118,6 +118,13 @@ process has exited and `result.json` is written — not when a status line says 
   you passed `--no-auto`. Either drop it, or set the agent's permissions to *allow* (not ask) the
   actions the task needs.
 
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed, including its
+edits. If finished work is lost — the run killed late, or the working tree damaged afterwards —
+read the event log before re-dispatching: the recorded edits often reconstruct the completed
+change exactly, instead of paying for the run again.
+
 ## What the helper is doing (and the alternatives)
 
 Under the hood the helper runs roughly:

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -120,10 +120,12 @@ process has exited and `result.json` is written — not when a status line says 
 
 ## Recovering lost work
 
-`events.jsonl` in the run directory records every event the implementer streamed, including its
-edits. If finished work is lost — the run killed late, or the working tree damaged afterward —
-read the event log before re-dispatching: its recorded tool calls and edits can often rebuild the
-lost work. Validate any reconstruction against the working-tree diff before relying on it.
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Whether it also carries the edit contents depends on what the CLI streams,
+so treat any reconstruction as unverified until it matches a working-tree diff — when the tree
+still holds the work, preserve the tree rather than replaying the log.
 
 ## What the helper is doing (and the alternatives)
 

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -121,9 +121,9 @@ process has exited and `result.json` is written — not when a status line says 
 ## Recovering lost work
 
 `events.jsonl` in the run directory records every event the implementer streamed, including its
-edits. If finished work is lost — the run killed late, or the working tree damaged afterwards —
-read the event log before re-dispatching: the recorded edits often reconstruct the completed
-change exactly, instead of paying for the run again.
+edits. If finished work is lost — the run killed late, or the working tree damaged afterward —
+read the event log before re-dispatching: its recorded tool calls and edits can often rebuild the
+lost work. Validate any reconstruction against the working-tree diff before relying on it.
 
 ## What the helper is doing (and the alternatives)
 

--- a/skills/opencode-delegate/references/review-and-land.md
+++ b/skills/opencode-delegate/references/review-and-land.md
@@ -87,7 +87,10 @@ attributes co-authorship, that's the place for it.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter.
+`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
 
 ## Reworking: send the delta, not the whole task
 

--- a/skills/opencode-delegate/references/review-and-land.md
+++ b/skills/opencode-delegate/references/review-and-land.md
@@ -87,7 +87,9 @@ attributes co-authorship, that's the place for it.
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first. The tree is evidence, not clutter. After that inspection the
+`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
+they are the implementer's new files, and `git diff` never shows their contents. The tree is
+evidence, not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/opencode-delegate/references/review-and-land.md
+++ b/skills/opencode-delegate/references/review-and-land.md
@@ -86,10 +86,11 @@ attributes co-authorship, that's the place for it.
 
 From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
 implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
-workspace between those two points — however messy an interrupted run looks, inspect it with
-`git status` and `git diff` first — and open any untracked files (`??` in `git status`) directly:
-they are the implementer's new files, and `git diff` never shows their contents. The tree is
-evidence, not clutter. After that inspection the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
 verdict can legitimately be to discard — work built on a premise you have since corrected, for
 example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
 before anyone has looked.

--- a/skills/opencode-delegate/references/review-and-land.md
+++ b/skills/opencode-delegate/references/review-and-land.md
@@ -84,6 +84,11 @@ When the gates pass and the diff holds, **you commit** — the orchestrator, nev
 the work, not the one that produced it. Write a clear message describing what landed. If your project
 attributes co-authorship, that's the place for it.
 
+From dispatch until that commit, the uncommitted working tree is the only copy of the
+implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it with
+`git status` and `git diff` first. The tree is evidence, not clutter.
+
 ## Reworking: send the delta, not the whole task
 
 If the review turns up problems, don't restate the entire brief. Continue the same OpenCode session with

--- a/skills/opencode-delegate/references/review-and-land.md
+++ b/skills/opencode-delegate/references/review-and-land.md
@@ -84,8 +84,8 @@ When the gates pass and the diff holds, **you commit** — the orchestrator, nev
 the work, not the one that produced it. Write a clear message describing what landed. If your project
 attributes co-authorship, that's the place for it.
 
-From dispatch until that commit, the uncommitted working tree is the only copy of the
-implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
 workspace between those two points — however messy an interrupted run looks, inspect it with
 `git status` and `git diff` first. The tree is evidence, not clutter.
 

--- a/skills/opencode-delegate/references/writing-the-brief.md
+++ b/skills/opencode-delegate/references/writing-the-brief.md
@@ -100,6 +100,14 @@ Keep each brief to a single, bounded job. "Review this, fix what you find, updat
 a roadmap" produces a muddled run; split it into separate dispatches. One brief → one OpenCode run →
 one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
 
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterwards; for a write-capable run, inspect the working
+tree before the re-dispatch.
+
 ## A worked example
 
 ```xml

--- a/skills/opencode-delegate/references/writing-the-brief.md
+++ b/skills/opencode-delegate/references/writing-the-brief.md
@@ -105,8 +105,9 @@ one commit keeps review and rollback clean, and lets a later task assume the ear
 The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
 fact block before sending — ownership, target branch, constraints, anything a judgment call rests
 on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
-brief rather than discounting the output afterwards; for a write-capable run, inspect the working
-tree before the re-dispatch.
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
 
 ## A worked example
 


### PR DESCRIPTION
Documentation companions to #23, from the same field use. Stacked on `relay-hardening` — merge that first, then this retargets clean.

Five additions, applied consistently across the skills:

1. **The working-tree rule** (`review-and-land.md`, all five): from dispatch until the orchestrator's commit, the uncommitted tree is the only copy of the implementer's work — never `git checkout`/`reset`/`clean` in the workspace between those points. Learned the hard way: a reflexive checkout after a crashed run erased a finished change.
2. **Recovering lost work** (`dispatch-and-poll.md`, the four relays that write `events.jsonl` — agy's writes none, so it makes no such claim): the event log records the implementer's edits; finished work can often be reconstructed from it instead of re-paying for the run. A kimi run's edits have been replayed byte-exact this way.
3. **Premises freeze at dispatch** (`writing-the-brief.md`, all five): there is no mid-run steering channel; audit the fact block before sending, and stop + re-dispatch corrected rather than discounting output when a premise was wrong.
4. **The `finalMessage` pointer** (`SKILL.md`, all five): the full report lives in `result.json`'s `finalMessage`; the stdout summary prints only its tail. Small, but it cost a round-trip of fumbling for `summary`/`lastMessage` in real use.
5. **Read-only second opinions** (codex `SKILL.md`): the `--read-only` design-debate pattern — agreed points, contested points with both positions, defend-or-concede each, deliverable in the final message, touching no files. Used twice in real work; both times it changed the plan for the better.

Docs-only; no script changes. Wording follows the AGENTS.md vocabulary (implementer/orchestrator/brief/dispatch), and every claim of "this happened" did happen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how to confirm delegated runs are complete and where to find the full report.
  - Added guidance for obtaining read-only second opinions without modifying files.
  - Documented recovery of lost work from recorded run activity.
  - Emphasized protecting uncommitted changes before finalizing work.
  - Added instructions to validate and freeze task assumptions before dispatch, with re-dispatch guidance when premises change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->