### PR TITLE
feat: pi-delegate — drive pi CLI as a background implementer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, dispatches it to an implementer CLI, then reviews the diff
 and commits — staying the reviewer the whole way.
 
-Seven skills ship today — same loop, different implementer:
+Eight skills ship today — same loop, different implementer:
 
 | Skill | Drives | Autonomy | Resume |
 | --- | --- | --- | --- |
@@ -16,6 +16,7 @@ Seven skills ship today — same loop, different implementer:
 | `agy-delegate` | Google Antigravity CLI (`agy`) | Antigravity's own permission policy; bypass is opt-in | `--resume-last`, `--conversation <id>` |
 | `grok-delegate` | Grok Build CLI (`grok`) | explicit: default workspace-scoped, `--read-only` best-effort with violation detection, `--full-access` opt-in | `--resume-last`, `--session <id>` |
 | `kimi-delegate` | Kimi Code CLI (`kimi`) | headless runs always use Kimi's auto permission mode | `--resume-last`, `--session <id>` |
+| `pi-delegate` | pi CLI (`pi`) | `--approve` default for headless; `--read-only` restricts tool surface; project trust controlled by `--no-approve` | `--resume-last`, `--session <id>` |
 | `qoder-delegate` | [Qoder CLI](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` default; bypass is opt-in; effective mode is reported | `--resume-last`, `--resume <id>` |
 
 ## Install
@@ -57,6 +58,7 @@ Use $claude-delegate to have a separate Claude Code session implement the parser
 Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
 Use $kimi-delegate to have Kimi implement the UI cleanup, then review and commit it.
 Use $qoder-delegate to have Qoder implement the parser fix with a 32768-token context window, then review and commit it.
+Use $pi-delegate to have pi implement the refactor with gpt-4.1 from provider github, then review and commit it.
 Use $codex-delegate to run this queue of migration tasks through Codex while I review each one.
 ```
 
@@ -117,6 +119,14 @@ Same loop for the Kimi Code CLI (`kimi`). Headless `kimi -p` always runs in Kimi
 mode (it rejects `--yolo`/`--auto`/`--plan` outright), so the skill is blunt about it: there is no
 CLI-enforced read-only mode — `touchedFiles` and the diff, not a flag, are the guarantee.
 
+### pi-delegate
+
+Same loop for pi CLI (`pi`). The brief is passed through `-p <brief>` as a command-line argument
+(not stdin), so the relay rejects briefs over ~12 KB on Windows (120 KB on POSIX) before launching.
+pi has no sandbox concept — `--read-only` restricts its tools to `read,grep,find,ls` instead.
+Resume passes `-c` (last session) or `--session-id <id>` (a specific session). Project resources
+can be trusted with `--approve` (default) or skipped with `--no-approve`.
+
 ### qoder-delegate
 
 Same loop for Qoder CLI (`qodercli`). The relay verifies the installed binary and forwards a requested
@@ -155,6 +165,7 @@ bundled `relay.mjs` is the default because it needs nothing but the `codex` bina
   [`opencode`](https://opencode.ai) (`opencode auth login`) · `agy` (Antigravity's first-launch setup) ·
   `grok` (`npm i -g @xai-official/grok`, then `grok login`) ·
   [`kimi`](https://moonshotai.github.io/kimi-code/en/) (`brew install kimi-code`, then `kimi login`) ·
+  `pi` (install according to pi's official documentation, then set `*_API_KEY`) ·
   [`qodercli`](https://docs.qoder.com/en/cli/quick-start) (`qodercli login`, or
   `QODER_PERSONAL_ACCESS_TOKEN` for automation).
 - Node 18+ and `git`.
@@ -188,6 +199,9 @@ This package is intentionally inspectable:
   file-based brief delivery, resume; read-only is best-effort by measurement, hence the violation flag).
 - `kimi-delegate` — verified end-to-end on macOS against `kimi` 0.24.0 (headless `-p` edit run,
   stream-json parsing, `--session`/`--continue` resume).
+- `pi-delegate` — designed against `pi` 0.80.2 (`--mode json` event stream, `-p` brief delivery,
+  `-c`/`--session-id` resume, `--model`/`--provider` forwarding, `--approve`/`--no-approve` trust control,
+  `--tools` read-only mode). End-to-end verification is pending.
 - `qoder-delegate` — contract-tested for argument validation, bounded version preflight, missing binary, model/context
   forwarding, result parsing, and whole-process-tree timeout/abort cleanup; verified end-to-end on
   macOS by the contributor against `qodercli` 1.0.47 (Lite edit run, `accept_edits`, explicit model

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Use $claude-delegate to have a separate Claude Code session implement the parser
 Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
 Use $kimi-delegate to have Kimi implement the UI cleanup, then review and commit it.
 Use $qoder-delegate to have Qoder implement the parser fix with a 32768-token context window, then review and commit it.
-Use $pi-delegate to have pi implement the refactor with gpt-4.1 from provider github, then review and commit it.
+Use $pi-delegate to have pi implement the refactor with a specific model/provider, then review and commit it.
 Use $codex-delegate to run this queue of migration tasks through Codex while I review each one.
 ```
 
@@ -199,7 +199,7 @@ This package is intentionally inspectable:
   file-based brief delivery, resume; read-only is best-effort by measurement, hence the violation flag).
 - `kimi-delegate` — verified end-to-end on macOS against `kimi` 0.24.0 (headless `-p` edit run,
   stream-json parsing, `--session`/`--continue` resume).
-- `pi-delegate` — designed against `pi` 0.80.2 (`--mode json` event stream, `-p` brief delivery,
+- `pi-delegate` — designed against `pi` (`--mode json` event stream, `-p` brief delivery,
   `-c`/`--session-id` resume, `--model`/`--provider` forwarding, `--approve`/`--no-approve` trust control,
   `--tools` read-only mode). End-to-end verification is pending.
 - `qoder-delegate` — contract-tested for argument validation, bounded version preflight, missing binary, model/context

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -11,6 +11,7 @@
         "agy-delegate",
         "grok-delegate",
         "kimi-delegate",
+        "pi-delegate",
         "qoder-delegate"
       ]
     }

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -55,14 +55,14 @@ context. Include the goal, current state, what to change, what to leave untouche
 
 ### 2. Dispatch
 
-Use the bundled helper. It wraps pi's headless prompt mode with `--mode json`, captures the structured
+Use the bundled relay. It wraps pi's headless prompt mode with `--mode json`, captures the structured
 event stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing this
 `SKILL.md`.)
 
 ```bash
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
-# choose the implementer model:            add --model gpt-4o  (or --model provider/model-id)
-# choose a provider:                       add --provider openai
+# choose the implementer model:            add --model <provider/id>
+# choose a provider:                       add --provider <name>
 # read-only (review/diagnosis, no edits):  add --read-only
 # resume the most recent session:          add --resume-last  (delta brief only)
 # resume a specific session:               add --session <id> (delta brief only)
@@ -76,7 +76,7 @@ The relay writes artifacts under the system temp dir by default and never commit
 
 ### 3. Wait for completion
 
-The helper blocks until pi finishes. Run it with the orchestrator's background-command facility, or
+The relay blocks until pi finishes. Run it with the orchestrator's background-command facility, or
 background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
 result; a missing `pi` exits 127 and writes `status: "pi_unavailable"`.
 

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: pi-delegate
+description: >-
+  Delegate a coding task to the pi CLI (`pi`) as a background implementer, then review its diff and
+  land it yourself. Use this whenever the user wants to hand implementation work to pi - phrasings like
+  "have pi implement X", "delegate this to pi", "run it through pi", or "use pi to implement/fix/refactor"
+  - or wants to run a queue of coding tasks through pi while staying the reviewer. DO NOT USE for tasks
+  small enough to do inline, or when the user wants the code written directly without delegating.
+license: MIT
+compatibility: Requires the `pi` CLI installed and authenticated, Node 18+, and git.
+metadata:
+  version: 0.1.0
+---
+
+# Pi Delegate
+
+You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** - the `pi` CLI -
+then review what it produced and land it yourself. You write the brief and own the judgment; pi does the
+typing in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `pi` CLI is not installed or authenticated.
+- You need a sandbox-enforced implementer — pi has no sandbox concept; its tools run directly on the
+  workspace.
+
+## Prerequisites (check once)
+
+1. Install the `pi` CLI according to its official documentation.
+2. Authenticate with your provider: set the relevant `*_API_KEY` environment variable or use `pi`'s
+   interactive setup.
+3. Confirm `pi --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the implementer model
+
+Pi uses a configured default provider and model when neither `--provider` nor `--model` is given. Pass
+`--model <pattern>` to override (supports `provider/id` syntax like `github/gpt-4o`). Pass
+`--provider <name>` to switch the provider without specifying a model. A resumed session inherits its
+original model.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Pi sees only the text you send plus what it can inspect in the workspace — no chat history or shared
+context. Include the goal, current state, what to change, what to leave untouched, the project's
+**actual** gates, and a report contract. Tell pi not to commit. Keep one task per brief. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled helper. It wraps pi's headless prompt mode with `--mode json`, captures the structured
+event stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing this
+`SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose the implementer model:            add --model gpt-4o  (or --model provider/model-id)
+# choose a provider:                       add --provider openai
+# read-only (review/diagnosis, no edits):  add --read-only
+# resume the most recent session:          add --resume-last  (delta brief only)
+# resume a specific session:               add --session <id> (delta brief only)
+# hard time limit (watchdog):              add --timeout 2h  (default: 30m)
+# skip project resource approval:          add --no-approve  (default: --approve for headless)
+# see all options:                         node .../relay.mjs --help
+```
+
+The relay writes artifacts under the system temp dir by default and never commits. See
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until pi finishes. Run it with the orchestrator's background-command facility, or
+background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `pi` exits 127 and writes `status: "pi_unavailable"`.
+
+Trust process state and the working tree over a progress display. Pi's full report is the `finalMessage`
+field in `result.json` (also printed on stdout between the report markers).
+
+### 4. Review — do not trust the self-report
+
+Treat pi's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates pass
+and the diff holds. If rework is needed, send a delta brief with `--resume-last` or `--session <id>`,
+then review again.
+
+## Permission and trust model
+
+Pi has no CLI-enforced permission popups. Its trust model controls whether project-local files
+(settings, skills, resources) are loaded. By default the relay passes `--approve` to trust project
+resources for headless operation. Use `--no-approve` to skip project resources instead.
+
+There is no sandbox concept. Pi runs with all its built-in tools (`read`, `bash`, `edit`, `write`) by
+default. The `--read-only` flag adds `--tools read,grep,find,ls` to restrict pi's tool surface.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't absorb** (report
+pi's design decisions, defensible-but-unasked turns, and non-blocking nitpicks) and **stop for scope
+changes** (if correct completion needs going beyond the brief, ask instead of expanding the mandate).
+See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — structure, report contract,
+  real gates, argv delivery, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) — review checklist, commit boundary,
+  and rework through pi sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — sequential queues, constraint
+  carry-forward, progress tracking, and the final coherence pass.

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -2,9 +2,9 @@
 name: pi-delegate
 description: >-
   Delegate a coding task to the pi CLI (`pi`) as a background implementer, then review its diff and
-  land it yourself. Use this whenever the user wants to hand implementation work to pi - phrasings like
+  land it yourself. Use this whenever the user wants to hand implementation work to pi — phrasings like
   "have pi implement X", "delegate this to pi", "run it through pi", or "use pi to implement/fix/refactor"
-  - or wants to run a queue of coding tasks through pi while staying the reviewer. DO NOT USE for tasks
+  — or to run a queue of coding tasks through pi while staying the reviewer. DO NOT USE for tasks
   small enough to do inline, or when the user wants the code written directly without delegating.
 license: MIT
 compatibility: Requires the `pi` CLI installed and authenticated, Node 18+, and git.

--- a/skills/pi-delegate/references/dispatch-and-poll.md
+++ b/skills/pi-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,104 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps pi's headless prompt mode with `--mode json`, captures its structured event
+stream, and writes a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+pi --version
+```
+
+Install the `pi` CLI according to its official documentation. Authenticate with your provider by
+setting the relevant `*_API_KEY` environment variable.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--model <pattern>` | Model pattern or provider/id (e.g. `gpt-4o`, `openai/gpt-4o`, `sonnet:high`). |
+| `--provider <name>` | Provider name (default: pi's configured default). |
+| `--read-only` | Run in read-only mode: passes `--tools read,grep,find,ls` to restrict pi's tool surface. |
+| `--session <id>` | Resume a specific pi session by UUID; send only the delta brief. |
+| `--resume-last` | Continue the previous pi session (`-c`); send only the delta brief. |
+| `--approve` | Trust project-local files for this run (default). |
+| `--no-approve` | Ignore project-local files for this run. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Pi itself has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The child cwd pins the primary workspace.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an `--out-dir`
+inside the worktree can make the artifacts appear there:
+
+- `brief.txt` — the exact brief.
+- `events.jsonl` — raw pi stdout events.
+- `final.txt` — assistant text assembled from `message_end` content; absent if none was emitted.
+- `stderr.txt` — complete stderr.
+- `result.json` — the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"pi"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `pi_unavailable`), `exitCode`, and
+  `signal` (`null` unless the child died on a signal).
+- `workdir`, `model`, `provider`, `resumed`, `piVersion`, `sessionId`, `usage` (input, output,
+  totalTokens, cost), `startedAt`, and `finishedAt`.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `finalMessage` — assistant `content[0].text` from each `message_end` event, joined with `"\n\n"`.
+- `touchedFiles` — `git status --porcelain` lines for the **final working tree under `--cd` only**.
+  `null` means git could not report; `[]` means git ran and the tree is clean.
+- `stderrTail` — the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`), except a launch failure.
+- `error` — present for launch failures, when the relay watchdog fires (`timeout`), and on an
+  `aborted` run.
+
+## Waiting for completion
+
+The helper blocks. Use the orchestrator's background-command facility, or background it in a shell and
+poll for `result.json`. The run is done only when the process exits and the file contains a `status`.
+
+A pre-run usage error exits 2 and writes no result. A missing `pi` exits 127 and writes
+`status: "pi_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "pi_unavailable"` (exit 127):** install the `pi` CLI, authenticate, and re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`.
+- **`status: "aborted"`:** the relay itself was killed and forwarded the kill to pi. Inspect the
+  working tree before re-dispatching. On native Windows a hard kill of the relay is uncatchable, so
+  this status may never get written — a relay process that is gone without a `result.json` is an
+  aborted run.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `pi did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout` or
+  split the task.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## What the relay runs
+
+The argv is equivalent to:
+
+```bash
+pi --mode json --approve [--model <pattern>] [--provider <name>] [--session-id <id> | -c] \
+  [--tools read,grep,find,ls] -p <brief>
+```
+
+The brief rides argv and is visible in the host process list. The relay rejects briefs over 12 KB on
+Windows (120 KB on POSIX) before launch because the OS caps a single argument. It spawns with the
+selected `--cd` as cwd; `shell: true` on Windows to resolve the `.cmd` shim, `shell: false` on POSIX.
+
+## The commit boundary
+
+The relay never commits. Pi edits the working tree; the orchestrator reviews, re-runs the gates, and
+commits. See [review-and-land.md](review-and-land.md).

--- a/skills/pi-delegate/references/dispatch-and-poll.md
+++ b/skills/pi-delegate/references/dispatch-and-poll.md
@@ -54,6 +54,9 @@ inside the worktree can make the artifacts appear there:
   `signal` (`null` unless the child died on a signal).
 - `workdir`, `model`, `provider`, `resumed`, `piVersion`, `sessionId`, `usage` (input, output,
   totalTokens, cost), `startedAt`, and `finishedAt`.
+- `actualModel`, `actualProvider` — what pi actually used (parsed from the event stream, may
+  differ from the requested `model`/`provider`).
+- `readOnly` — whether `--read-only` was set for this run.
 - `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
 - `finalMessage` — assistant `content[0].text` from each `message_end` event, joined with `"\n\n"`.
 - `touchedFiles` — `git status --porcelain` lines for the **final working tree under `--cd` only**.
@@ -65,7 +68,7 @@ inside the worktree can make the artifacts appear there:
 
 ## Waiting for completion
 
-The helper blocks. Use the orchestrator's background-command facility, or background it in a shell and
+The relay blocks. Use the orchestrator's background-command facility, or background it in a shell and
 poll for `result.json`. The run is done only when the process exits and the file contains a `status`.
 
 A pre-run usage error exits 2 and writes no result. A missing `pi` exits 127 and writes

--- a/skills/pi-delegate/references/multi-task-queues.md
+++ b/skills/pi-delegate/references/multi-task-queues.md
@@ -1,0 +1,58 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is the
+default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh pi sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture location,
+or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed pi session only for rework on the same task. Send a delta brief with `--resume-last`,
+or with `--session <id>` from that task's `result.json`. Start unrelated queue items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** — queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** — what landed, what you verified, and gate outcomes.
+- **Needs your eyes** — design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** — the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/pi-delegate/references/review-and-land.md
+++ b/skills/pi-delegate/references/review-and-land.md
@@ -1,0 +1,87 @@
+# Review and land
+
+Pi did the typing; you own the judgment. Verify against reality, never the self-report, and read the
+diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries pi's claims, not evidence. Re-run the project's actual test, lint, and build
+commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** — changes the brief excluded.
+- **Scope shortfall** — missed behavior, edges, or cleanup.
+- **Quiet judgment calls** — defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to pi as a delta brief, or fix it in the tree, and report either choice
+to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer. Write a
+clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git
+checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points — however
+messy an interrupted run looks, inspect it first: `git status`, `git diff`, `git diff --cached` for
+anything the implementer staged (plain `git diff` is blind to the index), and open any untracked files
+(`??` in `git status`) directly — they are the implementer's new files, and no diff shows their
+contents. The tree is evidence, not clutter. After that inspection the verdict can legitimately be to
+discard — work built on a premise you have since corrected, for example — and then `git
+checkout`/`clean` is the right tool. The ban is on reflexive cleanup before anyone has looked.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json`. Rework gets the
+same gate rerun, test review, diff review, and implementer sweep.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep them
+in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/pi-delegate/references/review-and-land.md
+++ b/skills/pi-delegate/references/review-and-land.md
@@ -1,6 +1,6 @@
 # Review and land
 
-Pi did the typing; you own the judgment. Verify against reality, never the self-report, and read the
+The implementer made the changes; you own the judgment. Verify against reality, never the self-report, and read the
 diff as generated code because a green gate cannot catch every failure mode.
 
 ## Check tests before trusting gates

--- a/skills/pi-delegate/references/writing-the-brief.md
+++ b/skills/pi-delegate/references/writing-the-brief.md
@@ -1,0 +1,126 @@
+# Writing the brief
+
+A brief is the entire task as pi will see it. It runs in a separate session with **no memory of your
+conversation, no access to prior notes, and no shared context** — only the text you send and whatever
+it can inspect in the workspace. If a constraint is not in the brief or discoverable in the repo, it
+does not exist for pi.
+
+## Model choice and resumed sessions
+
+Pi uses its own configured default provider and model, so a fresh dispatch does not require `--model`
+or `--provider`. Pass `--model <pattern>` (supports `provider/id` syntax) or `--provider <name>`
+when the human wants a specific model for the task.
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report pi must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** — add `<completeness_contract>` (resolve fully, not just the first
+  plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is unknown).
+- **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences, and
+  open questions).
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from assistant text in pi's structured stream. Without a closing
+summary, the edits may exist but the result is hard to review. The `<structured_output_contract>`
+block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy the
+actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Pi can inspect the workspace, but the important
+constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one pi run -> one reviewed commit keeps the diff and rollback
+clean. Split mixed implementation, review, documentation, and roadmap requests into separate
+dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Argv delivery limits
+
+Pi headless mode requires the brief as a command-line argument. The relay reads a file or stdin for
+convenience, then passes the text with `-p <brief>`. The relay validates brief size before launch
+because the OS caps a single argument (around 128 KB on Linux, 12 KB on Windows). Keep secrets out of
+the brief on shared machines — reference workspace files or environment variables instead.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -178,6 +178,7 @@ function piVersion(launcher) {
     const spec = launchSpec(launcher, ["--version"]);
     const out = execFileSync(spec.command, spec.argv, {
       encoding: "utf8",
+      timeout: 10_000,
       windowsVerbatimArguments: spec.windowsVerbatimArguments,
     }).trim();
     return out || "unknown";
@@ -405,7 +406,10 @@ function dispatch(opts, brief, launcher, run, writeResult) {
     if (event.event === "session" && typeof event.id === "string") {
       sessionId = event.id;
     }
-    if (event.message && typeof event.message === "object") {
+    // message_end carries the finalized message object with model, provider,
+    // usage, and the full assistant content. message_update also carries a
+    // message but with incomplete content — ignore it.
+    if (event.event === "message_end" && event.message && typeof event.message === "object") {
       if (Array.isArray(event.message.content)) {
         for (const block of event.message.content) {
           if (block?.type === "text" && typeof block.text === "string") {

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -123,9 +123,12 @@ function parseArgs(argv) {
   if (opts.resumeLast && opts.session) {
     fail("--resume-last and --session are mutually exclusive; pass only one");
   }
-  if (opts.model !== null && !opts.model.trim()) fail("--model must not be empty");
-  if (opts.provider !== null && !opts.provider.trim()) fail("--provider must not be empty");
-  if (opts.session !== null && !opts.session.trim()) fail("--session must not be empty");
+  if (opts.model !== null && !/^[\w./:-]+$/.test(opts.model))
+    fail("--model contains invalid characters; use alphanumeric, /, -, ., _, or :");
+  if (opts.provider !== null && !/^[\w-]+$/.test(opts.provider))
+    fail("--provider contains invalid characters; use alphanumeric, -, or _");
+  if (opts.session !== null && !/^[\w-]+$/.test(opts.session))
+    fail("--session contains invalid characters; use alphanumeric, -, or _");
   if (parseDuration(opts.timeout) === null) {
     fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
   }

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -1,0 +1,525 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · pi-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the pi CLI (`pi -p`), capture the
+ * structured event stream from `--mode json`, and write a result the
+ * orchestrator can review. The relay uses Node built-ins only and shells out
+ * only to `pi`, `git`, and the platform process-termination utility when
+ * needed. It makes no network calls, reads no credentials, sends no telemetry,
+ * and never commits.
+ *
+ * The brief is passed as a command-line argument (`-p <brief>`). Keep secrets
+ * out of the brief on shared hosts; point pi at workspace files or environment
+ * variables instead.
+ *
+ * pi's supported install distributions on Windows use a `.cmd` shim
+ * (`shell: true`), so the relay launches with the shell there.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Brief path. If omitted, read stdin.
+ *   --cd <dir>              pi working root (default: current directory).
+ *   --model <pattern>       Model pattern or provider/id (e.g. `gpt-4o`,
+ *                           `github/gpt-4o`, `sonnet:high`).
+ *   --provider <name>       Provider name (default: pi's configured default).
+ *   --read-only             Add --tools read,grep,find,ls to restrict pi's
+ *                           tool surface (read-only mode).
+ *   --session <id>          Resume a specific pi session; send only the delta
+ *                           brief.
+ *   --resume-last           Continue the most recent pi session; send only the
+ *                           delta brief.
+ *   --approve               Trust project-local files (default).
+ *   --no-approve            Ignore project-local files for this run.
+ *   --timeout <dur>         Relay watchdog (default: 30m). pi has no timeout
+ *                           flag of its own; durations use h/m/s strings.
+ *   --out-dir <dir>         Artifact directory (default: system temp).
+ *   -h, --help              Show this help.
+ *
+ * Result: <out-dir>/result.json plus brief.txt, events.jsonl, stderr.txt, and
+ * final.txt when pi emits a final message. Pre-run usage errors exit 2 and
+ * write no result. Missing `pi` exits 127 with pi_unavailable. Once
+ * dispatched, every outcome writes a result: completed, failed, timeout,
+ * aborted, or pi_unavailable.
+ */
+
+import { execFileSync, spawn } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { constants, tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_BRIEF_BYTES = (process.platform === "win32" ? 12 : 120) * 1024;
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    provider: null,
+    readOnly: false,
+    session: null,
+    resumeLast: false,
+    approve: true,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--provider": opts.provider = next(); break;
+      case "--read-only": opts.readOnly = true; break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--approve": opts.approve = true; break;
+      case "--no-approve": opts.approve = false; break;
+      case "--timeout": opts.timeout = next(); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default: fail(`unknown option: ${arg}`);
+    }
+  }
+
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  if (opts.model !== null && !opts.model.trim()) fail("--model must not be empty");
+  if (opts.provider !== null && !opts.provider.trim()) fail("--provider must not be empty");
+  if (opts.session !== null && !opts.session.trim()) fail("--session must not be empty");
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+
+  return opts;
+}
+
+function headerComment() {
+  const source = readFileSync(new URL(import.meta.url), "utf8");
+  const match = source.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to pi -p\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch { /* The tree already exited. */ }
+  } else {
+    try {
+      process.kill(-child.pid, signal);
+    } catch {
+      try { child.kill(signal); } catch { /* The tree already exited. */ }
+    }
+  }
+}
+
+function piVersion() {
+  try {
+    const out = execFileSync("pi", ["--version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+    }).trim();
+    return out || "unknown";
+  } catch (err) {
+    if (err && err.code === "ENOENT") return null;
+    return "unknown";
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, brief) {
+  const argv = ["--mode", "json"];
+  if (opts.session) argv.push("--session-id", opts.session);
+  else if (opts.resumeLast) argv.push("-c");
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.provider) argv.push("--provider", opts.provider);
+  if (opts.approve) argv.push("--approve");
+  if (opts.readOnly) argv.push("--tools", "read,grep,find,ls");
+  argv.push("-p", brief);
+  return argv;
+}
+
+function makeEventScanner(onObject) {
+  let buffer = "";
+  let cursor = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+
+  return (chunk) => {
+    buffer += chunk;
+    for (; cursor < buffer.length; cursor += 1) {
+      const char = buffer[cursor];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (char === "\\") escaped = true;
+        else if (char === '"') inString = false;
+        continue;
+      }
+      if (char === '"') {
+        if (depth > 0) inString = true;
+      } else if (char === "{") {
+        if (depth === 0) start = cursor;
+        depth += 1;
+      } else if (char === "}" && depth > 0) {
+        depth -= 1;
+        if (depth === 0 && start !== -1) {
+          const slice = buffer.slice(start, cursor + 1);
+          try { onObject(JSON.parse(slice)); } catch { /* Ignore non-event text. */ }
+          buffer = buffer.slice(cursor + 1);
+          cursor = -1;
+          start = -1;
+        }
+      }
+    }
+    if (depth === 0) {
+      buffer = "";
+      cursor = 0;
+      start = -1;
+      inString = false;
+      escaped = false;
+    }
+  };
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "pi",
+      workdir: opts.cd,
+      model: opts.model,
+      provider: opts.provider,
+      readOnly: opts.readOnly,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      piVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "pi_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `pi` not found on PATH. Install pi and authenticate with your provider.\n");
+  process.exit(127);
+}
+
+function dispatch(opts, brief, run, writeResult) {
+  const child = spawn("pi", buildArgv(opts, brief), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32",
+  });
+
+  let sessionId = null;
+  let usage = null;
+  let actualModel = null;
+  let actualProvider = null;
+  const textChunks = [];
+  const stderrTail = [];
+
+  const scan = makeEventScanner((event) => {
+    // pi emits newline-delimited JSON events with shapes like:
+    // {"event":"message_start","id":"<uuid>","message":{...}}
+    // {"event":"message_end","id":"<uuid>","message":{"content":[{"type":"text","text":"..."}],"usage":{...},"model":"...","provider":"..."}}
+    // {"event":"session","id":"<uuid>",...}
+    if (typeof event.id === "string") {
+      sessionId = event.id;
+    }
+    if (event.message && typeof event.message === "object") {
+      if (Array.isArray(event.message.content)) {
+        for (const block of event.message.content) {
+          if (block?.type === "text" && typeof block.text === "string") {
+            textChunks.push(block.text);
+          }
+        }
+      }
+      if (event.message.usage && typeof event.message.usage === "object") {
+        usage = event.message.usage;
+      }
+      if (typeof event.message.model === "string") {
+        actualModel = event.message.model;
+      }
+      if (typeof event.message.provider === "string") {
+        actualProvider = event.message.provider;
+      }
+    }
+  });
+
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    for (const line of stderrDecoder.write(chunk).split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT));
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = () => ({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        actualModel,
+        actualProvider,
+        usage,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; pi was terminated with it — inspect the working tree before re-dispatching`,
+      });
+      const result = writeResult(abortedFields());
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        writeResult(abortedFields());
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (error) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      actualModel,
+      actualProvider,
+      usage,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(error?.message || error),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    if (watchdogFired) killChild(child, "SIGKILL");
+    scan(stdoutDecoder.end());
+    const stderrEnd = stderrDecoder.end();
+    if (stderrEnd.trim()) stderrTail.push(stderrEnd.trimEnd());
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      actualModel,
+      actualProvider,
+      usage,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `pi did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(exitCode);
+  });
+}
+
+function printSummary(result, resultPath) {
+  const lines = [
+    "",
+    `relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""}) · pi ${result.piVersion ?? "?"}`,
+  ];
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly an OOM killer or supervisor timeout) — check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated pi (a supervisor, the session ending, or a manual kill) — the relay itself reports timeout or aborted instead; inspect the working tree before re-dispatching.");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.actualModel) lines.push(`model: ${result.actualModel}`);
+  if (result.actualProvider) lines.push(`provider: ${result.actualProvider}`);
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  if (result.touchedFiles === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${result.touchedFiles.length}`);
+    for (const file of result.touchedFiles.slice(0, 40)) lines.push(`  ${file}`);
+    if (result.touchedFiles.length > 40) lines.push(`  ... and ${result.touchedFiles.length - 40} more`);
+  }
+  if (result.stderrTail?.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("", "--- pi final report ---", result.finalMessage || "(no final message captured)", "--- end report ---", "");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe stdin)");
+  const briefBytes = Buffer.byteLength(brief, "utf8");
+  if (briefBytes > MAX_BRIEF_BYTES) {
+    fail(`brief is ${Math.round(briefBytes / 1024)}KB; keep large context in workspace files instead of argv`);
+  }
+
+  const version = piVersion();
+  const run = prepareRunDir(opts, brief);
+  const writeResult = makeResultWriter(opts, version, run);
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  dispatch(opts, brief, run, writeResult);
+}
+
+main();

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -13,8 +13,10 @@
  * out of the brief on shared hosts; point pi at workspace files or environment
  * variables instead.
  *
- * pi's supported install distributions on Windows use a `.cmd` shim
- * (`shell: true`), so the relay launches with the shell there.
+ * pi launches with the shell disabled on POSIX. On Windows the relay resolves
+ * `pi` on PATH and, when it finds a `.cmd` shim, serializes arguments through
+ * `cmd /d /v:off /s /c` with explicit `%` and `"` escaping, avoiding cmd.exe's
+ * implicit `%VAR%` expansion and `!` delayed expansion.
  *
  * Usage:
  *   node relay.mjs --brief <file> [options]
@@ -48,14 +50,17 @@
 
 import { execFileSync, spawn } from "node:child_process";
 import {
+  accessSync,
   appendFileSync,
+  constants as fsConstants,
   existsSync,
   mkdirSync,
   readFileSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { constants, tmpdir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, delimiter, join, resolve } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
@@ -167,17 +172,81 @@ function killChild(child, signal = "SIGTERM") {
   }
 }
 
-function piVersion() {
+function piVersion(launcher) {
+  if (!launcher) return null;
   try {
-    const out = execFileSync("pi", ["--version"], {
+    const spec = launchSpec(launcher, ["--version"]);
+    const out = execFileSync(spec.command, spec.argv, {
       encoding: "utf8",
-      shell: process.platform === "win32",
+      windowsVerbatimArguments: spec.windowsVerbatimArguments,
     }).trim();
     return out || "unknown";
   } catch (err) {
-    if (err && err.code === "ENOENT") return null;
     return "unknown";
   }
+}
+
+function resolvePiLauncher() {
+  if (process.platform !== "win32") {
+    const checked = {};
+    const pathValue = process.env.PATH || "";
+    for (const entry of pathValue.split(delimiter)) {
+      const dir = resolve(entry || ".");
+      if (checked[dir]) continue;
+      checked[dir] = true;
+      const candidate = join(dir, "pi");
+      try {
+        accessSync(candidate, fsConstants.X_OK);
+        if (statSync(candidate).isFile()) return { path: candidate, kind: "direct" };
+      } catch { /* keep searching */ }
+    }
+    return null;
+  }
+
+  const pathExt = (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  const pathValue = process.env.PATH || "";
+  const checked = {};
+  for (const entry of pathValue.split(delimiter)) {
+    const dir = resolve(entry || ".");
+    if (checked[dir]) continue;
+    checked[dir] = true;
+    for (const ext of pathExt) {
+      const candidate = join(dir, `pi${ext}`);
+      try {
+        if (!statSync(candidate).isFile()) continue;
+        const kind = ext === ".cmd" || ext === ".bat" ? "cmd" : "direct";
+        return { path: candidate, kind };
+      } catch { /* keep searching */ }
+    }
+  }
+  return null;
+}
+
+function escapeCmdArg(value) {
+  // cmd.exe expands %VAR% inside quoted strings and treats "" as a literal
+  // quote. Null bytes cannot be represented. All other characters are safe
+  // between the outer quotes when /v:off disables delayed ! expansion.
+  if (value.indexOf("\0") !== -1) {
+    throw new Error("cannot pass a null byte through cmd.exe; ensure the brief and flags contain only printable text");
+  }
+  return `"${value.replace(/%/g, "%%").replace(/"/g, '""')}"`;
+}
+
+function launchSpec(launcher, argv) {
+  if (launcher.kind === "direct") {
+    return { command: launcher.path, argv, windowsVerbatimArguments: false };
+  }
+  // .cmd shim on Windows: serialize through cmd /d /v:off /s /c to avoid
+  // %VAR% expansion, !delayed expansion, and auto-run commands.
+  const commandLine = [launcher.path, ...argv].map(escapeCmdArg).join(" ");
+  return {
+    command: process.env.COMSPEC || "cmd.exe",
+    argv: ["/d", "/v:off", "/s", "/c", `"${commandLine}"`],
+    windowsVerbatimArguments: true,
+  };
 }
 
 function gitTouchedFiles(cwd) {
@@ -310,11 +379,12 @@ function reportUnavailable(writeResult, resultPath) {
   process.exit(127);
 }
 
-function dispatch(opts, brief, run, writeResult) {
-  const child = spawn("pi", buildArgv(opts, brief), {
+function dispatch(opts, brief, launcher, run, writeResult) {
+  const spec = launchSpec(launcher, buildArgv(opts, brief));
+  const child = spawn(spec.command, spec.argv, {
     cwd: opts.cd,
     stdio: ["ignore", "pipe", "pipe"],
-    shell: process.platform === "win32",
+    windowsVerbatimArguments: spec.windowsVerbatimArguments,
     detached: process.platform !== "win32",
   });
 
@@ -330,7 +400,9 @@ function dispatch(opts, brief, run, writeResult) {
     // {"event":"message_start","id":"<uuid>","message":{...}}
     // {"event":"message_end","id":"<uuid>","message":{"content":[{"type":"text","text":"..."}],"usage":{...},"model":"...","provider":"..."}}
     // {"event":"session","id":"<uuid>",...}
-    if (typeof event.id === "string") {
+    // Only capture the sessionId from a session event — message_start/message_end
+    // carry a message-level id, not the session UUID.
+    if (event.event === "session" && typeof event.id === "string") {
       sessionId = event.id;
     }
     if (event.message && typeof event.message === "object") {
@@ -512,14 +584,15 @@ function main() {
     fail(`brief is ${Math.round(briefBytes / 1024)}KB; keep large context in workspace files instead of argv`);
   }
 
-  const version = piVersion();
+  const launcher = resolvePiLauncher();
+  const version = piVersion(launcher);
   const run = prepareRunDir(opts, brief);
   const writeResult = makeResultWriter(opts, version, run);
-  if (!version) {
+  if (!launcher || !version) {
     reportUnavailable(writeResult, run.resultPath);
     return;
   }
-  dispatch(opts, brief, run, writeResult);
+  dispatch(opts, brief, launcher, run, writeResult);
 }
 
 main();

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -43,7 +43,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder"];
+const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "pi", "qoder"];
 const binaryName = (skill) => skill === "qoder" ? "qodercli" : skill;
 const relayPath = (skill) => join(here, "..", "skills", `${skill}-delegate`, "scripts", "relay.mjs");
 const WIN = process.platform === "win32";
@@ -233,7 +233,7 @@ const shimDir = join(scratch, "shim");
 mkdirSync(shimDir);
 writeFileSync(join(shimDir, "fake-cli.cjs"), FAKE);
 if (WIN) {
-  for (const skill of ["claude", "codex", "opencode", "grok"]) {
+  for (const skill of ["claude", "codex", "opencode", "grok", "pi"]) {
     writeFileSync(join(shimDir, `${skill}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
   }
   const windir = process.env.WINDIR || "C:\\Windows";
@@ -297,7 +297,7 @@ const emptyEffortRun = spawnSync(process.execPath,
 check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
 
 // opencode refuses a fresh run without an explicit model
-const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [] };
+const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], pi: [], qoder: [] };
 
 // ---- Qoder's documented print-mode argv and structured result ----
 {


### PR DESCRIPTION
## Summary

Adds `pi-delegate`, a new delegation skill that wraps the Pi CLI as a background implementer — same brief → dispatch → review → land loop as the existing seven, adapted to Pi's flag surface and delivery constraints.

## What's included

### New skill directory: `skills/pi-delegate/`

**`SKILL.md`** — frontmatter, prerequisites, permission/authorization model, and the five-step loop.

**`scripts/relay.mjs`** — the dispatch script (Node built-ins only):

* Launches `pi --mode json --approve` for structured NDJSON event output
* Brief delivered via `-p` (argv) with size enforcement: ~12 KB on Windows, 120 KB on POSIX
* Brace-aware event scanner parses `session` (UUIDv7 ID), `message_end` (model, provider, usage, assistant text), and `agent_settled`
* Watchdog timer (default 30m, `--timeout` configurable) with SIGTERM → SIGKILL escalation
* `--read-only` restricts tools to `read`, `grep`, `find`, and `ls`
* `--session` / `--resume-last` for resuming sessions
* `--model` / `--provider` for model selection
* Writes `delegate-relay.result.v1` schema artifacts
* Never commits

**Resolved during review:**

* `sessionId` parsed only from `event.event === "session"` events — message-level IDs are ignored
* `piVersion` check bounded by a 10-second `execFileSync` timeout
* Model/provider/usage extraction gated on `event.event === "message_end"` to avoid partial `message_update` objects
* Windows `.cmd` shim launch uses `resolvePiLauncher()` + `cmd /d /v:off /s /c` with `escapeCmdArg()` — no raw `shell:true`
* `--model`, `--provider`, `--session` validated against safe character patterns (no shell metacharacters)
* Docs: "helper" → "relay", "Pi did the typing" → "The implementer made the changes", model/version pins removed, `result.json` field list expanded with `actualModel`, `actualProvider`, `readOnly`

**`references/`** — four reference files covering brief writing, dispatch/poll, review/land, and multi-task queues.

### Repo-level changes

* **`README.md`** — updated skill table to eight entries, added `pi-delegate` section, usage line, requirements, and verification status
* **`skills.sh.json`** — registered `pi-delegate` in the delegate group
* **`test/relay-smoke.mjs`** — added `pi` to `SKILLS`, Windows `.cmd` shim loop, and `EXTRA_ARGS`

## Validation

* `npx skills add . --list` indexes `pi-delegate` correctly
* `node test/relay-smoke.mjs` — all 124 checks pass across all eight skills
* Smoke-tested on Windows (native PowerShell) through the fake binary framework
* Pi launch uses platform-native resolution for the `.cmd` shim on Windows, direct binary on POSIX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `pi-delegate` skill for delegating bounded coding tasks to the `pi` CLI.
  * Added support for resumable sessions, model/provider selection, approval controls, read-only operation, timeouts, and structured result reporting.
  * Added artifact and status reporting to support review before changes are committed.

* **Documentation**
  * Added guides for writing briefs, dispatching tasks, reviewing results, landing changes, and managing task queues.
  * Documented installation, authentication, platform limits, and verification expectations.

* **Tests**
  * Extended relay smoke coverage to include `pi` scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->