### PR TITLE
feat: add pi-delegate (Pi coding agent CLI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Seven skills ship today: `claude-delegate` (Claude Code), `codex-delegate` (OpenAI
+and land the result. Eight skills ship today: `claude-delegate` (Claude Code), `codex-delegate` (OpenAI
 Codex), `opencode-delegate` (OpenCode), `agy-delegate` (Google Antigravity), `grok-delegate` (Grok
-Build), `kimi-delegate` (Kimi Code), and `qoder-delegate` (Qoder CLI); siblings like
+Build), `kimi-delegate` (Kimi Code), `qoder-delegate` (Qoder CLI), and `pi-delegate` (Pi CLI); siblings like
 `gemini-delegate` can be added later without renaming the repo.
 
 ## Vocabulary
@@ -29,6 +29,7 @@ jargon. Use these terms; don't invent synonyms.
 | `session`, `--continue`, `model alias`, `auto permission mode`, `plan mode`, `--yolo` | Kimi Code's own terms — use verbatim when discussing `kimi` | don't paraphrase them |
 | `session`, `--continue`, `--resume`, `permission mode` (`acceptEdits`/`plan`/`bypassPermissions`), `sandbox`, `subagents`, `agent teams`, `background sessions` | Claude Code's own terms — use verbatim when discussing Claude | never use `subagents` as a generic synonym for implementer |
 | `session`, `-c`, `--resume`, `permission mode` (`default`/`accept_edits`/`auto`/`bypass_permissions`/`dont_ask`/`plan`), `print mode`, `stream-json`, `model`, `context window` | Qoder CLI's own terms — use verbatim when discussing Qoder | don't paraphrase them |
+| `session`, `--continue`, `--session`, `print mode`, `--mode json`, `tools`, `context files`, `project trust` | Pi's own terms — use verbatim when discussing `pi` | don't paraphrase them |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -52,7 +53,7 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - **Executables:** keep them minimal and inspectable. Today there is one per skill — a
   `scripts/relay.mjs` under each of `skills/claude-delegate/`, `skills/codex-delegate/`,
   `skills/opencode-delegate/`, `skills/agy-delegate/`, `skills/grok-delegate/`, and
-  `skills/kimi-delegate/`, and `skills/qoder-delegate/` — each Node built-ins only, no dependencies,
+  `skills/kimi-delegate/`, `skills/qoder-delegate/`, and `skills/pi-delegate/` — each Node built-ins only, no dependencies,
   no network calls of its own, no credentials, no telemetry. New scripts must hold the same line,
   and the README's trust section must stay accurate.
 
@@ -62,7 +63,7 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - Smoke-test any changed script directly (e.g. `node skills/<skill>/scripts/relay.mjs --help`, and a
   no-write or read-only run against a throwaway repo) before relying on it.
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
-  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, and `grok` launches need
+  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, `grok`, and `pi` launches need
   `shell:true` on win32 to resolve the `.cmd` shim (which is why their spaceable args are quoted and
   value flags token-validated); the `claude` launch resolves a native `.exe` or separately serializes
   a `.cmd` shim; `agy`, `kimi`, and current `qodercli` installs use native binaries. Each changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the separate agent (Claude, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor) | "worker", "sub-agent", "executor" |
+| **implementer** | the separate agent (Claude, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -38,8 +38,8 @@ Banned on sight: coined umbrella terms in user-facing surfaces (README headings,
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
 version-neutral); and claims that can't be verified ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
-`codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent`) and the skill's
-`relay.mjs`.
+`codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi`) and
+the skill's `relay.mjs`.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ten skills ship today — same loop, different implementer:
 | `qoder-delegate` | [Qoder CLI](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` default; bypass is opt-in; effective mode is reported | `--resume-last`, `--resume <id>` |
 | `cursor-delegate` | [Cursor Agent CLI](https://cursor.com/cli) (`cursor-agent`) | `--force` write default; `--no-force` withholds command approval; `--read-only` selects plan mode; `--trust` always | `--resume-last`, `--session <id>` |
 | `vibe-delegate` | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits` default; `--full-access` selects `auto-approve`; `--plan-only` selects `plan` | `--resume-last`, `--session <id>` |
-| `pi-delegate` | [Pi CLI](https://github.com/earendil-works/pi-mono) (`pi`) | full local tools by default (no sandbox, no permission modes); `--read-only` enforces a `read,grep,find,ls` tool surface | `--resume-last`, `--session <id>` |
+| `pi-delegate` | [Pi CLI](https://github.com/earendil-works/pi-mono) (`pi`) | full local tools by default (no sandbox, no permission modes); `--read-only` restricts callable tools to `read,grep,find,ls`; project trust is opt-in | `--resume-last`, `--session <id>` |
 
 ## Install
 
@@ -88,7 +88,7 @@ orchestrators, with the commit on the reviewer.
 ### codex-delegate
 
 Drive the OpenAI Codex CLI as a background implementer. Ships four references (writing the brief,
-dispatch/poll, review/land, multi-task queues) loaded only when needed, and one small helper script.
+dispatch/poll, review/land, multi-task queues) loaded only when needed, and one small relay script.
 
 **You'll feel it when:** a bounded task — a migration, a mechanical refactor, a removal sweep — gets
 handed to Codex, comes back as a clean diff with a structured report, and you commit it after re-running
@@ -154,9 +154,11 @@ unless you already know a specific id.
 Same loop for the Pi coding agent CLI (`pi`). The brief rides stdin to `pi --mode json` — no argv
 size cap, nothing in the host process list — and the relay lifts the session id from the JSON
 event stream for later resume. Pi has no sandbox and no permission modes: a default headless run
-writes and executes without prompts, so the guarantees are `--read-only` (an enforced
-`read,grep,find,ls` tool surface, covering extension tools too) and the diff. Project `.pi`
-resources stay untrusted unless the orchestrator explicitly opts in.
+writes and executes without prompts, so its controls are `--read-only` (an enforced
+`read,grep,find,ls` callable-tool allowlist, covering extension/custom tools too) and the diff.
+Installed extension code still has the user's host permissions. The relay passes `--no-approve`
+by default; `--approve` is the explicit opt-in for trusted project `.pi` resources. Requested and
+actual provider/model, usage, and stop reason are recorded in `result.json`.
 
 ### gemini-delegate
 
@@ -229,12 +231,12 @@ This package is intentionally inspectable:
   forwarding, result parsing, and whole-process-tree timeout/abort cleanup; verified end-to-end on
   macOS by the contributor against `qodercli` 1.0.47 (Lite edit run, `accept_edits`, explicit model
   and 32768-token context window, no commit).
-- `pi-delegate` — contributor-reported end-to-end on macOS (stdin brief delivery, a write
-  run, `--read-only` leaving a clean tree, `--session`/`--resume-last` resume, session-id capture
-  from the JSON stream, a bad-model failure, watchdog timeout felling the process tree,
-  `pi_unavailable`/127, and usage errors exiting 2 without artifacts). The shared relay suite is
-  configured to drive its timeout, abort, success, and preflight paths against a stand-in binary
-  on Linux and Windows; a native Windows launch is unverified.
+- `pi-delegate` — verified end-to-end on macOS against `pi` 0.82.1 (stdin brief delivery,
+  explicit provider/model selection, JSON session/provider/model/usage capture, and a
+  `--read-only` run leaving a clean tree). Contributor-reported write, `--session`, and
+  `--resume-last` runs complement the shared relay suite's success, assistant-error, timeout,
+  abort, and bounded-preflight coverage on Linux and Windows; a native Windows launch is
+  unverified.
 - `opencode-delegate` — requires `--model`, since OpenCode has no safe default.
 - `cursor-delegate` — verified end-to-end on Windows against `cursor-agent` 2026.07.23-e383d2b (write run
   under `--force` editing real files; plan-mode `--read-only` run touching nothing;

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ This package is intentionally inspectable:
   forwarding, result parsing, and whole-process-tree timeout/abort cleanup; verified end-to-end on
   macOS by the contributor against `qodercli` 1.0.47 (Lite edit run, `accept_edits`, explicit model
   and 32768-token context window, no commit).
-- `pi-delegate` — verified end-to-end on macOS against `pi` 0.82.1 (stdin brief delivery,
-  explicit provider/model selection, JSON session/provider/model/usage capture, and a
+- `pi-delegate` — verified end-to-end on macOS (stdin brief delivery, explicit provider/model
+  selection, JSON session/provider/model/usage capture, and a
   `--read-only` run leaving a clean tree). Contributor-reported write, `--session`, and
   `--resume-last` runs complement the shared relay suite's success, assistant-error, timeout,
   abort, and bounded-preflight coverage on Linux and Windows; a native Windows launch is

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, dispatches it to an implementer CLI, then reviews the diff
 and commits — staying the reviewer the whole way.
 
-Seven skills ship today — same loop, different implementer:
+Eight skills ship today — same loop, different implementer:
 
 | Skill | Drives | Autonomy | Resume |
 | --- | --- | --- | --- |
@@ -17,6 +17,7 @@ Seven skills ship today — same loop, different implementer:
 | `grok-delegate` | Grok Build CLI (`grok`) | explicit: default workspace-scoped, `--read-only` best-effort with violation detection, `--full-access` opt-in | `--resume-last`, `--session <id>` |
 | `kimi-delegate` | Kimi Code CLI (`kimi`) | headless runs always use Kimi's auto permission mode | `--resume-last`, `--session <id>` |
 | `qoder-delegate` | [Qoder CLI](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` default; bypass is opt-in; effective mode is reported | `--resume-last`, `--resume <id>` |
+| `pi-delegate` | [Pi CLI](https://github.com/earendil-works/pi-mono) (`pi`) | full local tools by default (no sandbox, no permission modes); `--read-only` enforces a `read,grep,find,ls` tool surface | `--resume-last`, `--session <id>` |
 
 ## Install
 
@@ -57,6 +58,7 @@ Use $claude-delegate to have a separate Claude Code session implement the parser
 Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
 Use $kimi-delegate to have Kimi implement the UI cleanup, then review and commit it.
 Use $qoder-delegate to have Qoder implement the parser fix with a 32768-token context window, then review and commit it.
+Use $pi-delegate to have Pi implement the parser fix, then review and commit it.
 Use $codex-delegate to run this queue of migration tasks through Codex while I review each one.
 ```
 
@@ -126,6 +128,15 @@ models that support explicit sizing. Non-interactive runs use Qoder's `auto` per
 default; bypass remains opt-in. Qoder falls back to `default` outside a trusted directory, so the
 relay records both the requested and effective modes.
 
+### pi-delegate
+
+Same loop for the Pi coding agent CLI (`pi`). The brief rides stdin to `pi --mode json` — no argv
+size cap, nothing in the host process list — and the relay lifts the session id from the JSON
+event stream for later resume. Pi has no sandbox and no permission modes: a default headless run
+writes and executes without prompts, so the guarantees are `--read-only` (an enforced
+`read,grep,find,ls` tool surface, covering extension tools too) and the diff. The relay never
+passes `--approve`, leaving project `.pi` resources untrusted.
+
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
@@ -156,7 +167,9 @@ bundled `relay.mjs` is the default because it needs nothing but the `codex` bina
   `grok` (`npm i -g @xai-official/grok`, then `grok login`) ·
   [`kimi`](https://moonshotai.github.io/kimi-code/en/) (`brew install kimi-code`, then `kimi login`) ·
   [`qodercli`](https://docs.qoder.com/en/cli/quick-start) (`qodercli login`, or
-  `QODER_PERSONAL_ACCESS_TOKEN` for automation).
+  `QODER_PERSONAL_ACCESS_TOKEN` for automation) ·
+  [`pi`](https://github.com/earendil-works/pi-mono) (`npm install -g @earendil-works/pi-coding-agent`,
+  then `/login` or an API-key environment variable).
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -192,11 +205,18 @@ This package is intentionally inspectable:
   forwarding, result parsing, and whole-process-tree timeout/abort cleanup; verified end-to-end on
   macOS by the contributor against `qodercli` 1.0.47 (Lite edit run, `accept_edits`, explicit model
   and 32768-token context window, no commit).
+- `pi-delegate` — verified end-to-end on macOS against `pi` 0.82.1 (stdin brief delivery, a write
+  run, `--read-only` leaving a clean tree, `--session`/`--resume-last` resume, session-id capture
+  from the JSON stream, a bad-model failure, watchdog timeout felling the process tree,
+  `pi_unavailable`/127, and usage errors exiting 2 without artifacts). CI drives its timeout,
+  abort, success, and preflight paths against a stand-in binary on Linux and Windows; a native
+  Windows launch is unverified.
 - `opencode-delegate` — requires `--model`, since OpenCode has no safe default.
-- Windows: the codex/opencode launches handle the `.cmd` shim (`shell:true` + quoting); the Qoder
-  relay targets its currently documented native `qodercli.exe`. Native Windows launch smokes for
-  `claude`/`agy`/`grok`/`kimi`/`qoder` are still pending. Claude's own shell sandbox is unsupported on
-  native Windows regardless of launch mechanics.
+- Windows: the codex/opencode/grok/pi launches handle the `.cmd` shim (`shell:true`; pi's value
+  flags are token-validated and its brief rides stdin); the Qoder relay targets its currently
+  documented native `qodercli.exe`. Native Windows launch smokes for
+  `claude`/`agy`/`grok`/`kimi`/`qoder`/`pi` are still pending. Claude's own shell sandbox is
+  unsupported on native Windows regardless of launch mechanics.
 - The full delegate → review → commit loop is designed for and run on Claude Code; other orchestrators
   (Cursor, …) are designed-for but unproven.
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -11,7 +11,8 @@
         "agy-delegate",
         "grok-delegate",
         "kimi-delegate",
-        "qoder-delegate"
+        "qoder-delegate",
+        "pi-delegate"
       ]
     }
   ]

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: pi-delegate
 description: >-
   Delegate a coding task to the Pi coding agent CLI (`pi`) as a background implementer, then review
-  its diff and land it yourself. Use this whenever the user wants to hand implementation work to Pi -
+  its diff and land it yourself. Use this whenever the user wants to delegate implementation work to Pi -
   phrasings like "have Pi implement X", "delegate this to pi", "run it through Pi", or "use pi to
   implement/fix/refactor" - or wants to run a queue of coding tasks through Pi while staying the
   reviewer. DO NOT USE for tasks small enough to do inline, or when the user wants the code written
@@ -14,9 +14,9 @@ metadata:
 
 # Pi Delegate
 
-You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** - the Pi
+You are the **orchestrator**. Delegate a bounded coding task to a separate **implementer** - the Pi
 coding agent CLI - then review what it produced and land it yourself. You write the brief and own
-the judgment; pi does the typing in its own session; you verify and commit.
+the judgment; the implementer makes changes in its own session; you verify and commit.
 
 The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
 
@@ -38,7 +38,7 @@ The loop needs only a shell command and file access, so any comparable orchestra
 ## Choose the model (optional)
 
 Omit `--model` to use pi's configured default. To pick another, choose from `pi --list-models`
-and pass an explicit id or pattern like `google/gemini-2.5-pro` or `sonnet:high`. The relay
+and pass an explicit id or pattern like `<provider>/<model-id>` or `sonnet:high`. The relay
 accepts letters, digits, and `. _ : / -` only (the value reaches a shell on Windows), so glob
 patterns with `*` are not forwarded.
 
@@ -57,14 +57,16 @@ instructions reach it without inlining. See
 
 ### 2. Dispatch
 
-Use the bundled helper. It pipes the brief to `pi --mode json` on stdin, captures the JSON event
+Use the bundled relay. It pipes the brief to `pi --mode json` on stdin, captures the JSON event
 stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing this
 `SKILL.md`.)
 
 ```bash
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # choose a model:                          add --model <id from pi --list-models>
+# choose a provider:                       add --provider <name>
 # read-only run (review/diagnosis):        add --read-only
+# trust project .pi resources:             add --approve
 # resume the most recent session:          add --resume-last  (delta brief only)
 # resume a specific session:               add --session <id> (delta brief only)
 # hard time limit (watchdog):              add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
@@ -76,7 +78,7 @@ by default and never commits. See [references/dispatch-and-poll.md](references/d
 
 ### 3. Wait for completion
 
-The helper blocks until pi finishes. Run it with the orchestrator's background-command facility,
+The relay blocks until pi finishes. Run it with the orchestrator's background-command facility,
 or background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes
 no result; a missing `pi` exits 127 and writes `status: "pi_unavailable"`.
 
@@ -104,12 +106,12 @@ pass and the diff holds. If rework is needed, send a delta brief with `--resume-
 ## Autonomy and permissions
 
 Pi has **no sandbox and no permission modes**. A default headless run reads, writes, edits, and
-executes shell commands with no prompts - the guarantees are:
+executes shell commands with no prompts - the controls are:
 
-1. `--read-only` restricts pi to `--tools read,grep,find,ls`, an allowlist pi enforces across
-   built-in, extension, and custom tools. A write-capable tool simply does not exist in that run.
-2. The relay never passes `--approve`, so project `.pi` settings, extensions, and skills stay
-   untrusted (pi's non-interactive default).
+1. `--read-only` restricts pi's callable tools to `--tools read,grep,find,ls` across built-in,
+   extension, and custom tools. Installed extension code still runs with the user's host permissions.
+2. The relay passes `--no-approve` by default, so project `.pi` settings, extensions, and skills
+   stay untrusted. `--approve` is the explicit opt-in for a repository the user trusts.
 3. `touchedFiles` and the diff are the record of what changed. Inspect them after every run.
 
 ## Authorization model

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: pi-delegate
+description: >-
+  Delegate a coding task to the Pi coding agent CLI (`pi`) as a background implementer, then review
+  its diff and land it yourself. Use this whenever the user wants to hand implementation work to Pi -
+  phrasings like "have Pi implement X", "delegate this to pi", "run it through Pi", or "use pi to
+  implement/fix/refactor" - or wants to run a queue of coding tasks through Pi while staying the
+  reviewer. DO NOT USE for tasks small enough to do inline, or when the user wants the code written
+  directly without delegating.
+license: MIT
+metadata:
+  version: 0.1.0
+---
+
+# Pi Delegate
+
+You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** - the Pi
+coding agent CLI - then review what it produced and land it yourself. You write the brief and own
+the judgment; pi does the typing in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `pi` CLI is not installed or authenticated.
+- You need a sandboxed implementer. Pi has no sandbox and no permission modes; `--read-only`
+  restricts the tool surface, but a write-capable run executes without prompts.
+
+## Prerequisites (check once)
+
+1. Install pi with `npm install -g @earendil-works/pi-coding-agent`.
+2. Authenticate: `/login` inside pi for a subscription provider, or an API-key environment
+   variable / `pi`'s auth file for an API-key provider.
+3. Confirm `pi --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model (optional)
+
+Omit `--model` to use pi's configured default. To pick another, choose from `pi --list-models`
+and pass an explicit id or pattern like `google/gemini-2.5-pro` or `sonnet:high`. The relay
+accepts letters, digits, and `. _ : / -` only (the value reaches a shell on Windows), so glob
+patterns with `*` are not forwarded.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Pi sees only the text you send plus what it can inspect in the workspace - no chat history or
+shared context. Include the goal, current state, what to change, what to leave untouched, the
+project's **actual** gates, and a report contract. Tell pi not to commit. Keep one task per brief.
+Pi auto-loads `AGENTS.md`/`CLAUDE.md` context files from the workspace and its parents, so repo
+instructions reach it without inlining. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled helper. It pipes the brief to `pi --mode json` on stdin, captures the JSON event
+stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing this
+`SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model:                          add --model <id from pi --list-models>
+# read-only run (review/diagnosis):        add --read-only
+# resume the most recent session:          add --resume-last  (delta brief only)
+# resume a specific session:               add --session <id> (delta brief only)
+# hard time limit (watchdog):              add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                         node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. The relay writes artifacts under the system temp dir
+by default and never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until pi finishes. Run it with the orchestrator's background-command facility,
+or background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes
+no result; a missing `pi` exits 127 and writes `status: "pi_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process
+exited and `result.json` exists. Pi's full report is the `finalMessage` field in `result.json`
+(also printed in full on stdout between the report markers).
+
+### 4. Review - do not trust the self-report
+
+Treat pi's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates
+pass and the diff holds. If rework is needed, send a delta brief with `--resume-last` or
+`--session <id>`, then review again.
+
+## Autonomy and permissions
+
+Pi has **no sandbox and no permission modes**. A default headless run reads, writes, edits, and
+executes shell commands with no prompts - the guarantees are:
+
+1. `--read-only` restricts pi to `--tools read,grep,find,ls`, an allowlist pi enforces across
+   built-in, extension, and custom tools. A write-capable tool simply does not exist in that run.
+2. The relay never passes `--approve`, so project `.pi` settings, extensions, and skills stay
+   untrusted (pi's non-interactive default).
+3. `touchedFiles` and the diff are the record of what changed. Inspect them after every run.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"),
+committing verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't
+absorb** (report pi's design decisions, defensible-but-unasked turns, and non-blocking nitpicks)
+and **stop for scope changes** (if correct completion needs going beyond the brief, ask instead of
+expanding the mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, report contract,
+  real gates, stdin delivery, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist, commit
+  boundary, and rework through pi sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues,
+  constraint carry-forward, progress tracking, and the final coherence pass.

--- a/skills/pi-delegate/references/dispatch-and-poll.md
+++ b/skills/pi-delegate/references/dispatch-and-poll.md
@@ -104,7 +104,9 @@ A pre-run usage error exits 2 and writes no result. A missing `pi` exits 127 and
   re-dispatch, or split the task into smaller briefs.
 - **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
   `pi did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout`
-  or split the task. The relay sends SIGTERM, waits 10 seconds, then sends SIGKILL if needed.
+  or split the task. On POSIX the relay sends SIGTERM to the process group, waits 10 seconds,
+  then sends SIGKILL if needed; on Windows there is no escalation phase — the whole process tree
+  is felled immediately with `taskkill /pid <pid> /t /f`.
 - **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
   `<structured_output_contract>` to the next brief to require a closing report.
 

--- a/skills/pi-delegate/references/dispatch-and-poll.md
+++ b/skills/pi-delegate/references/dispatch-and-poll.md
@@ -27,10 +27,12 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | --- | --- |
 | `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
 | `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--provider <name>` | pi provider name (default: pi's own default). Token-validated. |
 | `--model <pattern>` | pi model id or pattern (default: pi's own default). Token-validated: letters, digits, `. _ : / -`. |
 | `--session <id>` | Resume a specific pi session; send only the delta brief. |
 | `--resume-last` | Continue the most recent pi session for this cwd (`pi --continue`); send only the delta brief. |
-| `--read-only` | Restrict pi to `--tools read,grep,find,ls` - no write/edit/bash in the run. |
+| `--read-only` | Restrict pi's callable tools to `--tools read,grep,find,ls`. |
+| `--approve` | Trust project-local `.pi` resources for this run. The default passes `--no-approve`. |
 | `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Pi has no timeout flag. |
 | `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
 | `-h`, `--help` | Print the relay's header help. |
@@ -39,7 +41,8 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 no add-dir flag and no sandbox, so reachability is simply the filesystem.
 
 Remember: pi has no permission modes. A run without `--read-only` can write and execute anything
-the user account can. Use `--read-only` for review and diagnosis briefs.
+the user account can. `--read-only` removes write/edit/bash from Pi's callable tool surface, but
+installed extension code still runs with the user's host permissions.
 
 ## Artifacts and result fields
 
@@ -56,8 +59,9 @@ Artifacts live outside the repo by default, so they do not appear in `touchedFil
 
 - `schema`, `tool` (`"pi"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `pi_unavailable`), `exitCode`, and
   `signal` (`null` unless the child died on a signal).
-- `workdir`, `model` (the model pattern or `null`), `readOnly`, `resumed`, `piVersion`,
+- `workdir`, requested `provider`/`model`, `projectTrusted`, `readOnly`, `resumed`, `piVersion`,
   `sessionId`, `startedAt`, and `finishedAt`.
+- `actualProvider`, `actualModel`, `usage`, and `stopReason` from Pi's final assistant event.
 - `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
 - `sessionId` - parsed from the JSON stream's `session` header. Resume with `--session <id>`.
   Note: `--continue` may mint a new session id for the continued run; the result always reports
@@ -73,12 +77,11 @@ Artifacts live outside the repo by default, so they do not appear in `touchedFil
 - `error` - present for launch failures, preflight failures, when the relay watchdog fires
   (`timeout`), and on an `aborted` run.
 
-Pi's stream carries thinking and message-update events the relay archives but does not parse;
-`result.json` has no `usage` field.
+Pi's stream carries thinking and message-update events the relay archives but does not parse.
 
 ## Waiting for completion
 
-The helper blocks. Use the orchestrator's background-command facility, or background it in a
+The relay blocks. Use the orchestrator's background-command facility, or background it in a
 shell and poll for `result.json`. The run is done only when the process exits and the file
 contains a `status`. The result file is written atomically, so a partial read is impossible.
 
@@ -91,6 +94,7 @@ A pre-run usage error exits 2 and writes no result. A missing `pi` exits 127 and
   authenticate, and re-dispatch.
 - **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
   causes: an unknown `--model` (`Model "<x>" not found`), an expired login, or a provider error.
+  A final assistant event with `stopReason: "error"` or `"aborted"` is failed even if Pi exits zero.
 - **`status: "failed"` with an `error` mentioning `version preflight`:** the bounded `pi --version`
   probe failed or hung, so pi was never dispatched. Check the install (`pi --version` yourself).
 - **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
@@ -124,16 +128,16 @@ work, preserve the tree rather than replaying the log.
 The launch is equivalent to:
 
 ```bash
-cat brief.txt | pi --mode json [--model <pattern>] [--session <id> | --continue] \
-  [--tools read,grep,find,ls]
+cat brief.txt | pi --mode json [--provider <name>] [--model <pattern>] \
+  [--session <id> | --continue] [--approve | --no-approve] [--tools read,grep,find,ls]
 ```
 
 The brief rides stdin, so it is not visible in the host process list and no argv size cap
 applies. On native Windows `pi` is a `.cmd` shim, so the relay launches it with `shell:true`;
-only the token-validated `--model`/`--session` values ever ride argv. Before dispatch the relay
+only the token-validated `--provider`/`--model`/`--session` values ever ride argv. Before dispatch the relay
 runs a bounded `pi --version` preflight (10s cap) so a hung or crashing CLI fails fast and
-explicitly instead of hanging the run. The relay never passes `--approve`, so project `.pi`
-settings, extensions, and skills stay untrusted.
+explicitly instead of hanging the run. The relay passes `--no-approve` by default, so project
+`.pi` settings, extensions, and skills stay untrusted; `--approve` opts in for a trusted repository.
 
 ## The commit boundary
 

--- a/skills/pi-delegate/references/dispatch-and-poll.md
+++ b/skills/pi-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,139 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps pi's non-interactive JSON mode, captures its event stream, and writes a
+`result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v pi
+pi --version
+pi --list-models   # optional: pick a model id for --model
+```
+
+Install with `npm install -g @earendil-works/pi-coding-agent`. Authenticate with `/login` inside
+pi (subscription providers) or an API-key environment variable; pi stores credentials in
+`~/.pi/agent/`.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--model <pattern>` | pi model id or pattern (default: pi's own default). Token-validated: letters, digits, `. _ : / -`. |
+| `--session <id>` | Resume a specific pi session; send only the delta brief. |
+| `--resume-last` | Continue the most recent pi session for this cwd (`pi --continue`); send only the delta brief. |
+| `--read-only` | Restrict pi to `--tools read,grep,find,ls` - no write/edit/bash in the run. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Pi has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The child cwd pins the workspace; pi has
+no add-dir flag and no sandbox, so reachability is simply the filesystem.
+
+Remember: pi has no permission modes. A run without `--read-only` can write and execute anything
+the user account can. Use `--read-only` for review and diagnosis briefs.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an
+`--out-dir` inside the worktree can make the artifacts appear there:
+
+- `brief.txt` - the exact brief.
+- `events.jsonl` - raw pi stdout events (the session header, then every agent event).
+- `final.txt` - assistant text joined with a blank line between chunks; absent if none was emitted.
+- `stderr.txt` - complete stderr.
+- `result.json` - the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"pi"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `pi_unavailable`), `exitCode`, and
+  `signal` (`null` unless the child died on a signal).
+- `workdir`, `model` (the model pattern or `null`), `readOnly`, `resumed`, `piVersion`,
+  `sessionId`, `startedAt`, and `finishedAt`.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `sessionId` - parsed from the JSON stream's `session` header. Resume with `--session <id>`.
+  Note: `--continue` may mint a new session id for the continued run; the result always reports
+  the id of the run that just happened.
+- `finalMessage` - assistant text parts joined with `"\n\n"`; tool calls and tool results are
+  excluded.
+- `touchedFiles` - `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of pi's edits: anything already dirty before dispatch shows up too. Dispatch
+  from a clean tree when you want the list to read as "what pi changed". `null` means git could
+  not report; `[]` means git ran and the tree is clean.
+- `stderrTail` - the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
+- `error` - present for launch failures, preflight failures, when the relay watchdog fires
+  (`timeout`), and on an `aborted` run.
+
+Pi's stream carries thinking and message-update events the relay archives but does not parse;
+`result.json` has no `usage` field.
+
+## Waiting for completion
+
+The helper blocks. Use the orchestrator's background-command facility, or background it in a
+shell and poll for `result.json`. The run is done only when the process exits and the file
+contains a `status`. The result file is written atomically, so a partial read is impossible.
+
+A pre-run usage error exits 2 and writes no result. A missing `pi` exits 127 and writes
+`status: "pi_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "pi_unavailable"` (exit 127):** install pi (`npm install -g @earendil-works/pi-coding-agent`),
+  authenticate, and re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
+  causes: an unknown `--model` (`Model "<x>" not found`), an expired login, or a provider error.
+- **`status: "failed"` with an `error` mentioning `version preflight`:** the bounded `pi --version`
+  probe failed or hung, so pi was never dispatched. Check the install (`pi --version` yourself).
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to pi. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through
+  the OOM killer or a supervisor timeout. This is not a pi error; check host memory and
+  re-dispatch, or split the task into smaller briefs.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `pi did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout`
+  or split the task. The relay sends SIGTERM, waits 10 seconds, then sends SIGKILL if needed.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Tool execution events carry the write/edit arguments, but treat any
+reconstruction as unverified until it matches a working-tree diff — when the tree still holds the
+work, preserve the tree rather than replaying the log.
+
+## What the relay runs
+
+The launch is equivalent to:
+
+```bash
+cat brief.txt | pi --mode json [--model <pattern>] [--session <id> | --continue] \
+  [--tools read,grep,find,ls]
+```
+
+The brief rides stdin, so it is not visible in the host process list and no argv size cap
+applies. On native Windows `pi` is a `.cmd` shim, so the relay launches it with `shell:true`;
+only the token-validated `--model`/`--session` values ever ride argv. Before dispatch the relay
+runs a bounded `pi --version` preflight (10s cap) so a hung or crashing CLI fails fast and
+explicitly instead of hanging the run. The relay never passes `--approve`, so project `.pi`
+settings, extensions, and skills stay untrusted.
+
+## The commit boundary
+
+The relay never commits. Pi edits the working tree; the orchestrator reviews, re-runs the gates,
+and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/pi-delegate/references/multi-task-queues.md
+++ b/skills/pi-delegate/references/multi-task-queues.md
@@ -1,0 +1,59 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is
+the default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh pi sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture
+location, or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed pi session only for rework on the same task. Send a delta brief with
+`--resume-last`, or with `--session <id>` from that task's `result.json`. Start unrelated queue
+items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** - queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** - what landed, what you verified, and gate outcomes.
+- **Needs your eyes** - design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** - the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/pi-delegate/references/review-and-land.md
+++ b/skills/pi-delegate/references/review-and-land.md
@@ -1,0 +1,94 @@
+# Review and land
+
+Pi did the typing; you own the judgment. Verify against reality, never the self-report, and read
+the diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries pi's claims, not evidence. Re-run the project's actual test, lint, and build
+commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** - changes the brief excluded.
+- **Scope shortfall** - missed behavior, edges, or cleanup.
+- **Quiet judgment calls** - defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to pi as a delta brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer.
+Write a clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`,
+`git diff --cached` for anything the implementer staged (plain `git diff` is blind to the index),
+and open any untracked files (`??` in `git status`) directly — they are the implementer's new
+files, and no diff shows their contents. The tree is evidence, not clutter. After that inspection
+the verdict can legitimately be to discard — work built on a premise you have since corrected,
+for example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json` - the stable
+handle, since `--continue` may mint a new id for each continued run. The relay rejects
+`--resume-last` plus `--session` before launch. Rework gets the same gate rerun, test review,
+diff review, and implementer sweep.
+
+Pi has no permission modes, so a write-capable rework run executes with no prompts - keep rework
+briefs as narrow as the original. A `--read-only` run cannot write at all (the tool surface lacks
+write/edit/bash), so `touchedFiles: []` there is enforced, not measured.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep
+them in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/pi-delegate/references/review-and-land.md
+++ b/skills/pi-delegate/references/review-and-land.md
@@ -1,6 +1,6 @@
 # Review and land
 
-Pi did the typing; you own the judgment. Verify against reality, never the self-report, and read
+The implementer made the changes; you own the judgment. Verify against reality, never the self-report, and read
 the diff as generated code because a green gate cannot catch every failure mode.
 
 ## Check tests before trusting gates
@@ -78,8 +78,9 @@ handle, since `--continue` may mint a new id for each continued run. The relay r
 diff review, and implementer sweep.
 
 Pi has no permission modes, so a write-capable rework run executes with no prompts - keep rework
-briefs as narrow as the original. A `--read-only` run cannot write at all (the tool surface lacks
-write/edit/bash), so `touchedFiles: []` there is enforced, not measured.
+briefs as narrow as the original. A `--read-only` run removes write/edit/bash from Pi's callable
+tool surface, including extension/custom tools; installed extension code still runs with the
+user's host permissions, so inspect `touchedFiles` and the tree after every run.
 
 ## Surface, do not absorb
 

--- a/skills/pi-delegate/references/writing-the-brief.md
+++ b/skills/pi-delegate/references/writing-the-brief.md
@@ -59,7 +59,7 @@ Add extra blocks only when the task needs them:
   first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
   unknown).
 - **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences,
-  and open questions), and dispatch with `--read-only` so the run cannot write.
+  and open questions), and dispatch with `--read-only` so Pi cannot invoke write/edit/bash tools.
 
 ## Always ask for the report explicitly
 
@@ -123,7 +123,7 @@ Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outco
 
 ## Stdin delivery
 
-The relay pipes the brief to pi on stdin. Unlike CLIs that take the prompt as an argument, there
+The relay pipes the brief to pi on stdin. Unlike CLIs that take the brief as an argument, there
 is no OS argv size cap and the brief never appears in the host process list. Large context can be
 inlined, but prefer pointing pi at workspace files it can read itself. Keep secrets out of the
 brief anyway on shared machines - reference environment variables or files with tight permissions.

--- a/skills/pi-delegate/references/writing-the-brief.md
+++ b/skills/pi-delegate/references/writing-the-brief.md
@@ -1,0 +1,132 @@
+# Writing the brief
+
+A brief is the entire task as pi will see it. It runs in a separate session with **no memory of
+your conversation, no access to prior notes, and no shared context** - only the text you send and
+whatever it can inspect in the workspace. If a constraint is not in the brief or discoverable in
+the repo, it does not exist for pi.
+
+One shortcut: pi auto-loads `AGENTS.md` and `CLAUDE.md` context files from the workspace and its
+parent directories, so conventions written there reach pi without inlining. Restate the
+load-bearing rules in the brief anyway - the brief is the contract.
+
+## Model choice and resumed sessions
+
+Pi uses its configured default model when `--model` is omitted, so a fresh dispatch does not
+require it. Pass `--model <id>` only when the human asked for a specific model, choosing from
+`pi --list-models`. The relay forwards explicit ids and patterns (letters, digits, `. _ : / -`);
+glob patterns with `*` are rejected because the value reaches a shell on Windows.
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report pi must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** - add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences,
+  and open questions), and dispatch with `--read-only` so the run cannot write.
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from assistant text in pi's JSON event stream. Without a closing
+summary, the edits may exist but the result is hard to review. The `<structured_output_contract>`
+block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy
+the actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Pi can inspect the workspace (and auto-loads
+context files), but the important constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one pi run -> one reviewed commit keeps the diff and
+rollback clean. Split mixed implementation, review, documentation, and roadmap requests into
+separate dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Stdin delivery
+
+The relay pipes the brief to pi on stdin. Unlike CLIs that take the prompt as an argument, there
+is no OS argv size cap and the brief never appears in the host process list. Large context can be
+inlined, but prefer pointing pi at workspace files it can read itself. Keep secrets out of the
+brief anyway on shared machines - reference environment variables or files with tight permissions.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -150,6 +150,11 @@ function parseArgs(argv) {
     fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
   }
   if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
+  // setTimeout overflows past 2^31 - 1 ms (~24.8 days) and fires immediately,
+  // which would read as an instant spurious timeout — reject it up front.
+  if (parseDuration(opts.timeout) > 2_147_483_647) {
+    fail(`--timeout "${opts.timeout}" exceeds the maximum schedulable watchdog (~24.8 days)`);
+  }
   if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
     fail(`working directory not found: ${opts.cd}`);
   }
@@ -200,6 +205,20 @@ function killChild(child, signal = "SIGTERM") {
 function piVersion(timeoutMs) {
   // Bounded preflight: a hung or crashing CLI must not hang the relay or
   // masquerade as exit 127. Only a missing binary means "unavailable".
+  if (process.platform === "win32") {
+    // The probe below runs through a shell on win32 (the .cmd shim), and
+    // cmd.exe reports a missing binary as exit 1 — not ENOENT — so ask
+    // where.exe first to keep "not installed" classified as pi_unavailable.
+    // where.exe ships in System32 on every supported Windows; a non-ENOENT
+    // failure from it means it ran and found no pi on PATH.
+    try {
+      execFileSync("where.exe", ["pi"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    } catch (whereError) {
+      if (!whereError || whereError.code !== "ENOENT") return { version: null, error: null };
+      // where.exe itself missing is practically impossible; fall through to
+      // the normal probe rather than guess.
+    }
+  }
   try {
     return {
       version: execFileSync("pi", ["--version"], {

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -6,7 +6,7 @@
  * capture the JSON event stream, and write a structured result the orchestrating
  * agent can review. The orchestrator runs this one command and reads the result
  * JSON — every pi-specific mechanic lives in here, which keeps the skill
- * orchestrator-agnostic. Verified against pi 0.82.1 on macOS.
+ * orchestrator-agnostic. Smoke-tested against a current pi CLI on macOS.
  *
  * Trust posture: relay.mjs itself makes no network calls, reads or writes no
  * credentials, and sends no telemetry; it has no dependencies (Node built-ins
@@ -24,10 +24,11 @@
  *
  * Autonomy: pi has no sandbox and no permission modes — a default headless run
  * reads, writes, edits, and runs shell commands without asking. `--read-only`
- * restricts pi to its read-only tool surface (`--tools read,grep,find,ls`), an
- * allowlist pi enforces across built-in, extension, and custom tools. The relay
- * never passes `--approve`, so project `.pi` resources stay untrusted. The diff
- * reported in `touchedFiles` is the record of what changed.
+ * restricts pi's callable tool surface to `read,grep,find,ls` across built-in,
+ * extension, and custom tools; installed extension code still runs with the
+ * user's host permissions. The relay passes `--no-approve` unless `--approve`
+ * explicitly trusts project `.pi` resources. The diff reported in
+ * `touchedFiles` is the record of what changed.
  *
  * pi is installed from npm, so on native Windows `pi` is a `.cmd` shim this
  * relay launches with shell:true. Only token-validated flag values ride argv
@@ -40,11 +41,14 @@
  * Options:
  *   --brief <file>          Path to the brief. If omitted, read it from stdin.
  *   --cd <dir>              Working root for pi (default: current directory).
+ *   --provider <name>       pi provider name (default: pi's own default).
  *   --model <pattern>       pi model id or pattern (default: pi's own default).
  *                           Letters, digits, and . _ : / - only.
  *   --session <id>          Resume a specific pi session; send only the delta brief.
  *   --resume-last           Continue the most recent pi session for this cwd
  *                           (`pi --continue`); send only the delta brief.
+ *   --approve               Trust project-local files for this run. By default
+ *                           the relay passes --no-approve.
  *   --read-only             Restrict pi to read,grep,find,ls (no write/edit/bash).
  *   --timeout <dur>         Relay-side watchdog (default: 30m). pi has no timeout
  *                           flag; durations use h/m/s strings.
@@ -54,13 +58,15 @@
  *
  * Result: written to <out-dir>/result.json and summarized on stdout —
  *   status, exitCode, signal, piVersion, sessionId, finalMessage (pi's own
- *   report), touchedFiles (git porcelain, null if git cannot report), readOnly,
- *   and paths to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *   report), requested/actual provider and model, usage, touchedFiles (git
+ *   porcelain, null if git cannot report), readOnly, projectTrusted, and paths
+ *   to brief.txt, final.txt, events.jsonl, and stderr.txt.
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `pi` binary exits 127;
- * otherwise the exit code mirrors pi's own (0 success, non-zero failure). If
- * the child dies on a signal, the exit code is 128 plus the signal number and
+ * otherwise the exit code mirrors pi's own (0 success, non-zero failure), except
+ * a final assistant `error`/`aborted` event exits 1 even if pi exits 0. If the
+ * child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal. Once the brief validates, `result.json` is
  * written on every outcome — completed, failed, timeout (the --timeout watchdog
  * fired, or the bounded --version preflight hung), aborted (the relay itself
@@ -85,7 +91,7 @@ import { StringDecoder } from "node:string_decoder";
 const DEFAULT_TIMEOUT = "30m";
 const VERSION_TIMEOUT_MS = 10_000;
 const READ_ONLY_TOOLS = "read,grep,find,ls";
-// --model and --session values reach a shell on win32 (shell:true for the
+// --model, --provider, and --session values reach a shell on win32 (shell:true for the
 // .cmd shim), so they are restricted to safe tokens.
 const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
 
@@ -105,10 +111,12 @@ function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    provider: null,
     model: null,
     session: null,
     resumeLast: false,
     readOnly: false,
+    approve: false,
     timeout: DEFAULT_TIMEOUT,
     outDir: null,
   };
@@ -128,10 +136,12 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--provider": opts.provider = next(); break;
       case "--model": opts.model = next(); break;
       case "--session": opts.session = next(); break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--read-only": opts.readOnly = true; break;
+      case "--approve": opts.approve = true; break;
       case "--timeout": opts.timeout = next(); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
@@ -141,7 +151,7 @@ function parseArgs(argv) {
   if (opts.resumeLast && opts.session) {
     fail("--resume-last and --session are mutually exclusive; pass only one");
   }
-  for (const flag of ["model", "session"]) {
+  for (const flag of ["model", "provider", "session"]) {
     if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
       fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
     }
@@ -202,37 +212,60 @@ function killChild(child, signal = "SIGTERM") {
   }
 }
 
-function piVersion(timeoutMs) {
-  // Bounded preflight: a hung or crashing CLI must not hang the relay or
-  // masquerade as exit 127. Only a missing binary means "unavailable".
-  if (process.platform === "win32") {
-    // The probe below runs through a shell on win32 (the .cmd shim), and
-    // cmd.exe reports a missing binary as exit 1 — not ENOENT — so ask
-    // where.exe first to keep "not installed" classified as pi_unavailable.
-    // where.exe ships in System32 on every supported Windows; a non-ENOENT
-    // failure from it means it ran and found no pi on PATH.
-    try {
-      execFileSync("where.exe", ["pi"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
-    } catch (whereError) {
-      if (!whereError || whereError.code !== "ENOENT") return { version: null, error: null };
-      // where.exe itself missing is practically impossible; fall through to
-      // the normal probe rather than guess.
-    }
-  }
-  try {
-    return {
-      version: execFileSync("pi", ["--version"], {
-        encoding: "utf8",
-        shell: process.platform === "win32", // resolve the pi.cmd shim
-        timeout: Math.min(timeoutMs, VERSION_TIMEOUT_MS),
-        killSignal: "SIGKILL",
-      }).trim() || "unknown",
-      error: null,
+async function piVersion(timeoutMs, onChild) {
+  const limit = Math.min(timeoutMs, VERSION_TIMEOUT_MS);
+  const runProbe = (command, argv, options = {}) => new Promise((resolveProbe) => {
+    const child = spawn(command, argv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      ...options,
+    });
+    onChild(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timer;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveProbe({ stdout, stderr, ...result });
     };
-  } catch (error) {
-    if (error && error.code === "ENOENT") return { version: null, error: null };
-    return { version: null, error };
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => finish({ code: null, error, timedOut: false }));
+    child.on("close", (code) => finish({ code, error: null, timedOut }));
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+    }, limit);
+  });
+
+  // shell:true resolves pi.cmd, but a missing command is only an exit 1 from
+  // cmd.exe. Ask the in-box where.exe first so absence stays pi_unavailable.
+  if (process.platform === "win32") {
+    const wherePath = join(process.env.SystemRoot || process.env.WINDIR || "C:\\Windows", "System32", "where.exe");
+    const found = await runProbe(wherePath, ["pi"]);
+    if (found.timedOut) {
+      return { version: null, error: Object.assign(new Error("where.exe pi timed out"), { code: "ETIMEDOUT", stderr: found.stderr }) };
+    }
+    if (found.error && found.error.code !== "ENOENT") return { version: null, error: found.error };
+    if (!found.error && found.code !== 0) return { version: null, error: null };
   }
+
+  const probe = process.platform === "win32"
+    ? await runProbe("pi --version", [], { shell: true, detached: false })
+    : await runProbe("pi", ["--version"]);
+  if (probe.timedOut) {
+    return { version: null, error: Object.assign(new Error("pi --version timed out"), { code: "ETIMEDOUT", stderr: probe.stderr }) };
+  }
+  if (probe.error && probe.error.code === "ENOENT") return { version: null, error: null };
+  if (probe.error) return { version: null, error: probe.error };
+  if (probe.code !== 0) {
+    return { version: null, error: Object.assign(new Error("pi --version failed"), { status: probe.code, stderr: probe.stderr }) };
+  }
+  return { version: probe.stdout.trim() || "unknown", error: null };
 }
 
 function gitTouchedFiles(cwd) {
@@ -253,11 +286,13 @@ function timestamp() {
 
 function buildArgv(opts) {
   // The brief rides stdin, never argv. --mode json alone is non-interactive:
-  // pi reads the piped prompt, streams events, and exits.
+  // pi reads the piped brief, streams events, and exits.
   const argv = ["--mode", "json"];
+  if (opts.provider) argv.push("--provider", opts.provider);
   if (opts.model) argv.push("--model", opts.model);
   if (opts.session) argv.push("--session", opts.session);
   else if (opts.resumeLast) argv.push("--continue");
+  argv.push(opts.approve ? "--approve" : "--no-approve");
   if (opts.readOnly) argv.push("--tools", READ_ONLY_TOOLS);
   return argv;
 }
@@ -335,8 +370,10 @@ function makeResultWriter(opts, version, run) {
       schema: "delegate-relay.result.v1",
       tool: "pi",
       workdir: opts.cd,
+      provider: opts.provider,
       model: opts.model,
       readOnly: opts.readOnly,
+      projectTrusted: opts.approve,
       resumed: Boolean(opts.resumeLast || opts.session),
       piVersion: version,
       startedAt: run.startedAt,
@@ -361,6 +398,10 @@ function reportUnavailable(writeResult, resultPath) {
     exitCode: 127,
     signal: null,
     sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    stopReason: null,
     finalMessage: "",
     touchedFiles: null,
   });
@@ -381,6 +422,10 @@ function reportVersionFailure(writeResult, run, error, timeoutMs) {
     exitCode: timedOut ? 124 : Number.isInteger(error && error.status) ? error.status : 1,
     signal: null,
     sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    stopReason: null,
     finalMessage: "",
     touchedFiles: null,
     ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
@@ -391,18 +436,57 @@ function reportVersionFailure(writeResult, run, error, timeoutMs) {
   process.exit(result.exitCode);
 }
 
+function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: null,
+        actualProvider: null,
+        actualModel: null,
+        usage: null,
+        stopReason: null,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the pi version preflight; pi was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
 function dispatchToPi(opts, brief, run, writeResult) {
   const child = spawn("pi", buildArgv(opts), {
     cwd: opts.cd,
     stdio: ["pipe", "pipe", "pipe"],
     // shell:true on win32 so the pi.cmd shim resolves. Safe: the brief is fed
     // via stdin — never argv — and argv holds only the fixed flag names and
-    // token-validated --model/--session values.
+    // token-validated --provider/--model/--session values.
     shell: process.platform === "win32",
     detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
   });
 
   let sessionId = null;
+  let actualProvider = null;
+  let actualModel = null;
+  let usage = null;
+  let stopReason = null;
+  let assistantError = null;
   const textChunks = [];
   const stderrTail = [];
   const scan = makeEventScanner((event) => {
@@ -417,6 +501,11 @@ function dispatchToPi(opts, brief, run, writeResult) {
           if (part && part.type === "text" && typeof part.text === "string") textChunks.push(part.text);
         }
       }
+      if (typeof event.message.provider === "string") actualProvider = event.message.provider;
+      if (typeof event.message.model === "string") actualModel = event.message.model;
+      if (event.message.usage && typeof event.message.usage === "object") usage = event.message.usage;
+      if (typeof event.message.stopReason === "string") stopReason = event.message.stopReason;
+      if (typeof event.message.errorMessage === "string") assistantError = event.message.errorMessage;
     }
   });
 
@@ -488,6 +577,10 @@ function dispatchToPi(opts, brief, run, writeResult) {
         exitCode: 128 + (constants.signals[sig] || 15),
         signal: sig,
         sessionId,
+        actualProvider,
+        actualModel,
+        usage,
+        stopReason,
         finalMessage: assembleFinal(),
         touchedFiles: gitTouchedFiles(opts.cd),
         stderrTail: stderrTail.slice(-20),
@@ -515,6 +608,10 @@ function dispatchToPi(opts, brief, run, writeResult) {
       exitCode: 1,
       signal: null,
       sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      stopReason,
       finalMessage: assembleFinal(),
       touchedFiles: gitTouchedFiles(opts.cd),
       error: String(err && err.message ? err.message : err),
@@ -532,7 +629,8 @@ function dispatchToPi(opts, brief, run, writeResult) {
     if (watchdogFired) killChild(child, "SIGKILL");
     // A timed-out run is failed even if pi handles SIGTERM by exiting 0 —
     // orchestrators key off status and the relay exit code.
-    const succeeded = code === 0 && !watchdogFired;
+    const assistantFailed = stopReason === "error" || stopReason === "aborted";
+    const succeeded = code === 0 && !watchdogFired && !assistantFailed;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
     const result = writeResult({
@@ -540,33 +638,44 @@ function dispatchToPi(opts, brief, run, writeResult) {
       exitCode,
       signal: signal ?? null,
       sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      stopReason,
       finalMessage: assembleFinal(),
       touchedFiles: gitTouchedFiles(opts.cd),
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `pi did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...(!watchdogFired && assistantFailed ? { error: assistantError || `pi ended with stopReason "${stopReason}"` } : {}),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
   });
 }
 
-function main() {
+async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
 
   const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
   const run = prepareRunDir(opts, brief);
-  const probe = piVersion(timeoutMs);
-  const writeResult = makeResultWriter(opts, probe.version, run);
+  let writeResult = makeResultWriter(opts, null, run);
+  let preflightChild = null;
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const probe = await piVersion(timeoutMs, (child) => { preflightChild = child; });
+  writeResult = makeResultWriter(opts, probe.version, run);
   if (!probe.version && !probe.error) {
+    clearPreflightSignals();
     reportUnavailable(writeResult, run.resultPath);
     return;
   }
   if (!probe.version) {
+    clearPreflightSignals();
     reportVersionFailure(writeResult, run, probe.error, timeoutMs);
     return;
   }
+  clearPreflightSignals();
   dispatchToPi(opts, brief, run, writeResult);
 }
 
@@ -577,7 +686,9 @@ function printSummary(result, resultPath) {
   if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a pi error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated pi (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.readOnly) lines.push(`mode: read-only (tools ${READ_ONLY_TOOLS})`);
+  if (result.projectTrusted) lines.push("mode: project resources trusted (--approve)");
   if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.actualModel) lines.push(`model: ${result.actualProvider ? `${result.actualProvider}/` : ""}${result.actualModel}`);
   if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
   const touched = result.touchedFiles;
   if (touched === null) {

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -1,0 +1,585 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · pi-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Pi coding agent CLI (`pi --mode json`),
+ * capture the JSON event stream, and write a structured result the orchestrating
+ * agent can review. The orchestrator runs this one command and reads the result
+ * JSON — every pi-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against pi 0.82.1 on macOS.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `pi` and `git`, plus the platform
+ * process-termination utility when a Windows process-tree kill requires one.
+ * The `pi` process it launches does authenticate — exactly as you do at the
+ * terminal. Read this file before you run it.
+ *
+ * The brief is piped to pi on stdin, so it never appears in the host process
+ * list and no argv size cap applies. Keep secrets out of the brief anyway on
+ * shared machines — reference workspace files or environment variables instead.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Autonomy: pi has no sandbox and no permission modes — a default headless run
+ * reads, writes, edits, and runs shell commands without asking. `--read-only`
+ * restricts pi to its read-only tool surface (`--tools read,grep,find,ls`), an
+ * allowlist pi enforces across built-in, extension, and custom tools. The relay
+ * never passes `--approve`, so project `.pi` resources stay untrusted. The diff
+ * reported in `touchedFiles` is the record of what changed.
+ *
+ * pi is installed from npm, so on native Windows `pi` is a `.cmd` shim this
+ * relay launches with shell:true. Only token-validated flag values ride argv
+ * (the brief never does), which keeps that launch safe.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for pi (default: current directory).
+ *   --model <pattern>       pi model id or pattern (default: pi's own default).
+ *                           Letters, digits, and . _ : / - only.
+ *   --session <id>          Resume a specific pi session; send only the delta brief.
+ *   --resume-last           Continue the most recent pi session for this cwd
+ *                           (`pi --continue`); send only the delta brief.
+ *   --read-only             Restrict pi to read,grep,find,ls (no write/edit/bash).
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). pi has no timeout
+ *                           flag; durations use h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, piVersion, sessionId, finalMessage (pi's own
+ *   report), touchedFiles (git porcelain, null if git cannot report), readOnly,
+ *   and paths to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `pi` binary exits 127;
+ * otherwise the exit code mirrors pi's own (0 success, non-zero failure). If
+ * the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome — completed, failed, timeout (the --timeout watchdog
+ * fired, or the bounded --version preflight hung), aborted (the relay itself
+ * was killed and forwarded the kill to pi), or pi_unavailable.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_TIMEOUT = "30m";
+const VERSION_TIMEOUT_MS = 10_000;
+const READ_ONLY_TOOLS = "read,grep,find,ls";
+// --model and --session values reach a shell on win32 (shell:true for the
+// .cmd shim), so they are restricted to safe tokens.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    session: null,
+    resumeLast: false,
+    readOnly: false,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--read-only": opts.readOnly = true; break;
+      case "--timeout": opts.timeout = next(); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  for (const flag of ["model", "session"]) {
+    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
+  if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to pi --mode json\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  // The kill must reach the whole process family, not just the CLI — a tool subprocess left
+  // running would keep editing after the relay reports timeout/aborted. On Windows Node can't
+  // kill a process family without a Job Object, so kill the tree by pid with the OS tool
+  // (/t includes descendants, /f forces it — the tree-kill/npm idiom).
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
+    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
+    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
+    catch { /* already gone — nothing left to kill */ }
+  } else {
+    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
+    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
+    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+  }
+}
+
+function piVersion(timeoutMs) {
+  // Bounded preflight: a hung or crashing CLI must not hang the relay or
+  // masquerade as exit 127. Only a missing binary means "unavailable".
+  try {
+    return {
+      version: execFileSync("pi", ["--version"], {
+        encoding: "utf8",
+        shell: process.platform === "win32", // resolve the pi.cmd shim
+        timeout: Math.min(timeoutMs, VERSION_TIMEOUT_MS),
+        killSignal: "SIGKILL",
+      }).trim() || "unknown",
+      error: null,
+    };
+  } catch (error) {
+    if (error && error.code === "ENOENT") return { version: null, error: null };
+    return { version: null, error };
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git cannot report — git missing, or a non-repo run — so
+  // the caller can tell "git unavailable" apart from "pi changed nothing."
+  // [] means git ran and the working tree is clean.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts) {
+  // The brief rides stdin, never argv. --mode json alone is non-interactive:
+  // pi reads the piped prompt, streams events, and exits.
+  const argv = ["--mode", "json"];
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.session) argv.push("--session", opts.session);
+  else if (opts.resumeLast) argv.push("--continue");
+  if (opts.readOnly) argv.push("--tools", READ_ONLY_TOOLS);
+  return argv;
+}
+
+function makeEventScanner(onObject) {
+  // pi documents --mode json as newline-delimited JSON. This brace-aware
+  // scanner also tolerates chunk-split and concatenated objects plus non-JSON
+  // progress text without depending on documented event boundaries.
+  let buffer = "";
+  let cursor = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    buffer += chunk;
+    for (; cursor < buffer.length; cursor += 1) {
+      const char = buffer[cursor];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (char === "\\") escaped = true;
+        else if (char === '"') inString = false;
+        continue;
+      }
+      if (char === '"') {
+        if (depth > 0) inString = true;
+      } else if (char === "{") {
+        if (depth === 0) start = cursor;
+        depth += 1;
+      } else if (char === "}" && depth > 0) {
+        depth -= 1;
+        if (depth === 0 && start !== -1) {
+          const slice = buffer.slice(start, cursor + 1);
+          try { onObject(JSON.parse(slice)); } catch { /* ignore non-event text */ }
+          buffer = buffer.slice(cursor + 1);
+          cursor = -1;
+          start = -1;
+        }
+      }
+    }
+    if (depth === 0) {
+      buffer = "";
+      cursor = 0;
+      start = -1;
+      inString = false;
+      escaped = false;
+    }
+  };
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  // A reused --out-dir must not leak a previous run's artifacts into this one.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "pi",
+      workdir: opts.cd,
+      model: opts.model,
+      readOnly: opts.readOnly,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      piVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Atomic write: a polling orchestrator never reads a half-written result.
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "pi_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `pi` not found on PATH. Install with `npm install -g @earendil-works/pi-coding-agent`, then authenticate (`/login`, or an API-key environment variable).\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(writeResult, run, error, timeoutMs) {
+  const timedOut = error && error.code === "ETIMEDOUT";
+  const stderr = String((error && error.stderr) || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `pi --version preflight timed out after ${Math.min(timeoutMs, VERSION_TIMEOUT_MS)}ms; pi was not dispatched`
+    : `pi --version preflight failed${Number.isInteger(error && error.status) ? ` with exit ${error.status}` : ""}; pi was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error && error.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: null,
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToPi(opts, brief, run, writeResult) {
+  const child = spawn("pi", buildArgv(opts), {
+    cwd: opts.cd,
+    stdio: ["pipe", "pipe", "pipe"],
+    // shell:true on win32 so the pi.cmd shim resolves. Safe: the brief is fed
+    // via stdin — never argv — and argv holds only the fixed flag names and
+    // token-validated --model/--session values.
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = null;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (event.type === "session" && typeof event.id === "string") {
+      sessionId = event.id;
+    }
+    if (event.type === "message_end" && event.message && event.message.role === "assistant") {
+      const content = event.message.content;
+      if (typeof content === "string") textChunks.push(content);
+      if (Array.isArray(content)) {
+        for (const part of content) {
+          if (part && part.type === "text" && typeof part.text === "string") textChunks.push(part.text);
+        }
+      }
+    }
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  // A fast-exiting pi (usage error, crashed startup) closes the pipe before
+  // the write; swallow EPIPE here — the exit code reports the failure.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the pi child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; pi was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if pi handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `pi did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const run = prepareRunDir(opts, brief);
+  const probe = piVersion(timeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (!probe.version) {
+    reportVersionFailure(writeResult, run, probe.error, timeoutMs);
+    return;
+  }
+  dispatchToPi(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  pi ${result.piVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a pi error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated pi (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.readOnly) lines.push(`mode: read-only (tools ${READ_ONLY_TOOLS})`);
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- pi final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -128,15 +128,27 @@ if (process.env.SMOKE_MODE === "vibe-success") {
   console.log(JSON.stringify({ role: "assistant", content: "fake vibe completed" }));
   process.exit(0);
 }
-if (process.env.SMOKE_MODE === "pi-success") {
+if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
   let brief = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (chunk) => { brief += chunk; });
   process.stdin.on("end", () => {
+    const failed = process.env.SMOKE_MODE === "pi-error";
     fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify({ args, brief }));
     console.log(JSON.stringify({ type: "session", version: 3, id: "pi-session-1", timestamp: "2026-01-01T00:00:00.000Z", cwd: process.cwd() }));
     console.log(JSON.stringify({ type: "agent_start" }));
-    console.log(JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "fake pi completed" }] } }));
+    console.log(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: failed ? "fake pi failed" : "fake pi completed" }],
+        provider: "google",
+        model: "fake-model",
+        usage: { input: 7, output: 2, cacheRead: 1, cacheWrite: 0, totalTokens: 10, cost: { total: 0.001 } },
+        stopReason: failed ? "error" : "stop",
+        ...(failed ? { errorMessage: "fake provider failure" } : {}),
+      },
+    }));
     console.log(JSON.stringify({ type: "agent_end", messages: [] }));
     process.exit(0);
   });
@@ -932,6 +944,7 @@ for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h
     "--brief", briefPath,
     "--cd", workDir,
     "--out-dir", outDir,
+    "--provider", "google",
     "--model", "google/fake-model",
     "--read-only",
   ], {
@@ -943,7 +956,9 @@ for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h
   check("pi success: documented argv is exact",
     JSON.stringify(capture.args) === JSON.stringify([
       "--mode", "json",
+      "--provider", "google",
       "--model", "google/fake-model",
+      "--no-approve",
       "--tools", "read,grep,find,ls",
     ]));
   check("pi success: brief delivered through stdin", capture.brief === "smoke brief: run until killed.");
@@ -955,9 +970,61 @@ for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h
       value.sessionId === "pi-session-1" &&
       value.finalMessage === "fake pi completed" &&
       value.readOnly === true &&
+      value.projectTrusted === false &&
+      value.provider === "google" &&
       value.model === "google/fake-model" &&
+      value.actualProvider === "google" &&
+      value.actualModel === "fake-model" &&
+      value.usage?.input === 7 &&
+      value.usage?.output === 2 &&
+      value.stopReason === "stop" &&
       value.resumed === false);
   }
+
+  const approveOutDir = join(scratch, "out-approve-pi");
+  const approveArgsFile = join(scratch, "args-approve-pi");
+  const approveRun = spawnSync(process.execPath, [
+    relayPath("pi"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", approveOutDir,
+    "--approve",
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "pi-success", SMOKE_ARGS_FILE: approveArgsFile },
+    encoding: "utf8",
+  });
+  const approveCapture = existsSync(approveArgsFile) ? JSON.parse(readFileSync(approveArgsFile, "utf8")) : {};
+  check("pi project trust: --approve is explicit and recorded",
+    approveRun.status === 0 &&
+    JSON.stringify(approveCapture.args) === JSON.stringify(["--mode", "json", "--approve"]) &&
+    result(approveOutDir).projectTrusted === true);
+
+  const unsafeProvider = spawnSync(process.execPath, [
+    relayPath("pi"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--provider", "google & whoami",
+  ], { env: baseEnv, encoding: "utf8" });
+  check("pi provider: shell-unsafe value is rejected", unsafeProvider.status === 2);
+
+  const errorOutDir = join(scratch, "out-error-pi");
+  const errorArgsFile = join(scratch, "args-error-pi");
+  const errorRun = spawnSync(process.execPath, [
+    relayPath("pi"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", errorOutDir,
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "pi-error", SMOKE_ARGS_FILE: errorArgsFile },
+    encoding: "utf8",
+  });
+  const errorResult = existsSync(join(errorOutDir, "result.json")) ? result(errorOutDir) : {};
+  check("pi assistant error: exit-zero event is reported as failed",
+    errorRun.status === 1 &&
+    errorResult.status === "failed" &&
+    errorResult.exitCode === 1 &&
+    errorResult.stopReason === "error" &&
+    errorResult.error === "fake provider failure");
 
   const resumeOutDir = join(scratch, "out-resume-last-pi");
   const resumeArgsFile = join(scratch, "args-resume-last-pi");
@@ -1015,9 +1082,7 @@ for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h
 
   for (const [mode, expectedStatus, expectedExit] of [
     ["pi-version-fail", "failed", 7],
-    // The hang case is POSIX-only: on win32 the preflight kill fells cmd.exe
-    // but the fake's node grandchild would linger and pin the scratch dir.
-    ...(WIN ? [] : [["pi-version-hang", "timeout", 124]]),
+    ["pi-version-hang", "timeout", 124],
   ]) {
     const preflightOutDir = join(scratch, `out-${mode}`);
     const preflight = spawnSync(process.execPath, [
@@ -1035,6 +1100,30 @@ for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h
       preflightResult.status === expectedStatus &&
       preflightResult.error?.includes("version preflight") &&
       preflightResult.error?.includes("was not dispatched"));
+  }
+
+  if (!WIN) {
+    const preflightOutDir = join(scratch, "out-abort-preflight-pi");
+    const preflight = runRelay("pi", workDir, preflightOutDir, ["--timeout", "1s"], {
+      SMOKE_MODE: "pi-version-hang",
+    });
+    check("pi preflight abort: run artifacts are prepared",
+      await until(() => existsSync(join(preflightOutDir, "events.jsonl")), 2000));
+    preflight.kill("SIGTERM");
+    const exited = await new Promise((resolveExit) => {
+      const timer = setTimeout(() => resolveExit(false), 5000);
+      preflight.on("close", () => {
+        clearTimeout(timer);
+        resolveExit(true);
+      });
+    });
+    const value = existsSync(join(preflightOutDir, "result.json")) ? result(preflightOutDir) : {};
+    check("pi preflight abort: result is aborted and dispatch never starts",
+      exited &&
+      value.status === "aborted" &&
+      value.signal === "SIGTERM" &&
+      value.error?.includes("version preflight") &&
+      value.error?.includes("was not dispatched"));
   }
 }
 

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -526,6 +526,29 @@ const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"],
   check("pi validation: zero timeout is rejected before artifacts",
     zeroTimeout.status === 2 && !existsSync(zeroTimeoutOutDir));
 
+  const hugeTimeoutOutDir = join(scratch, "out-huge-timeout-pi");
+  const hugeTimeout = spawnSync(process.execPath, [
+    relayPath("pi"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", hugeTimeoutOutDir,
+    "--timeout", "10000h",
+  ], { env: baseEnv, encoding: "utf8" });
+  check("pi validation: a timeout beyond Node's timer range is rejected before artifacts",
+    hugeTimeout.status === 2 && !existsSync(hugeTimeoutOutDir));
+
+  const missingOutDir = join(scratch, "out-unavailable-pi");
+  const missing = spawnSync(process.execPath, [
+    relayPath("pi"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", missingOutDir,
+  ], { env: { ...process.env, PATH: "" }, encoding: "utf8" });
+  check("pi unavailable: missing binary writes the structured result",
+    missing.status === 127 &&
+    existsSync(join(missingOutDir, "result.json")) &&
+    result(missingOutDir).status === "pi_unavailable");
+
   for (const [mode, expectedStatus, expectedExit] of [
     ["pi-version-fail", "failed", 7],
     // The hang case is POSIX-only: on win32 the preflight kill fells cmd.exe

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -7,10 +7,10 @@
  * not complete:
  *
  *   1. timeout  — the watchdog kills the implementer's WHOLE process tree and
- *                 result.json reports status "timeout". Driven for all seven
+ *                 result.json reports status "timeout". Driven for all eight
  *                 relays on both platforms. On Windows, claude launches a .cmd
  *                 shim through a serialized cmd.exe invocation, while
- *                 codex/opencode/grok use shell:true. These are exactly the
+ *                 codex/opencode/grok/pi use shell:true. These are exactly the
  *                 cases a plain child.kill would miss; agy, kimi, and qoder spawn a
  *                 native binary directly — a .cmd stand-in cannot represent them,
  *                 so the smoke compiles a real fake .exe with the C# compiler
@@ -25,13 +25,13 @@
  *   2. aborted  — killing the relay itself still produces result.json with
  *                 status "aborted", and files the implementer flushes during
  *                 the shutdown grace window appear in the refreshed
- *                 touchedFiles. Driven for all seven relays on POSIX; Windows
+ *                 touchedFiles. Driven for all eight relays on POSIX; Windows
  *                 delivers no catchable SIGTERM, so the scenario cannot be
  *                 driven there (the skill docs carry the same caveat).
  *
  * Every fake answers each relay's version preflight (--version, `version`,
- * `changelog`). Quick Claude and Qoder success cases verify brief delivery,
- * launch arguments, environment handling, and result-event parsing. The
+ * `changelog`). Quick Claude, Qoder, and pi success cases verify brief
+ * delivery, launch arguments, environment handling, and result-event parsing. The
  * timeout/abort cases otherwise run until killed and spawn a subprocess of
  * their own; both assert that this grandchild dies with the implementer.
  * Node built-ins only.
@@ -43,7 +43,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder"];
+const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder", "pi"];
 const binaryName = (skill) => skill === "qoder" ? "qodercli" : skill;
 const relayPath = (skill) => join(here, "..", "skills", `${skill}-delegate`, "scripts", "relay.mjs");
 const WIN = process.platform === "win32";
@@ -86,9 +86,9 @@ for (const skill of SKILLS) {
 // ---- one fake CLI, planted on PATH under every relay's binary name ----
 const FAKE = `const fs = require("node:fs");
 const args = process.argv.slice(2);
-if (args.includes("--version") && process.env.SMOKE_MODE === "qoder-version-hang") {
+if (args.includes("--version") && /-version-hang$/.test(process.env.SMOKE_MODE || "")) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
-} else if (args.includes("--version") && process.env.SMOKE_MODE === "qoder-version-fail") {
+} else if (args.includes("--version") && /-version-fail$/.test(process.env.SMOKE_MODE || "")) {
   console.error("fake qoder version failure");
   process.exit(7);
 } else if (args.includes("--version") || args[0] === "version" || args[0] === "changelog") {
@@ -123,7 +123,19 @@ if (process.env.SMOKE_MODE === "qoder-success") {
   }));
   process.exit(0);
 }
-if (["claude-success", "claude-read-only-write", "claude-read-only-clean", "claude-chunked"].includes(process.env.SMOKE_MODE)) {
+if (process.env.SMOKE_MODE === "pi-success") {
+  let brief = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => { brief += chunk; });
+  process.stdin.on("end", () => {
+    fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify({ args, brief }));
+    console.log(JSON.stringify({ type: "session", version: 3, id: "pi-session-1", timestamp: "2026-01-01T00:00:00.000Z", cwd: process.cwd() }));
+    console.log(JSON.stringify({ type: "agent_start" }));
+    console.log(JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "fake pi completed" }] } }));
+    console.log(JSON.stringify({ type: "agent_end", messages: [] }));
+    process.exit(0);
+  });
+} else if (["claude-success", "claude-read-only-write", "claude-read-only-clean", "claude-chunked"].includes(process.env.SMOKE_MODE)) {
   let brief = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (chunk) => { brief += chunk; });
@@ -233,7 +245,7 @@ const shimDir = join(scratch, "shim");
 mkdirSync(shimDir);
 writeFileSync(join(shimDir, "fake-cli.cjs"), FAKE);
 if (WIN) {
-  for (const skill of ["claude", "codex", "opencode", "grok"]) {
+  for (const skill of ["claude", "codex", "opencode", "grok", "pi"]) {
     writeFileSync(join(shimDir, `${skill}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
   }
   const windir = process.env.WINDIR || "C:\\Windows";
@@ -297,7 +309,7 @@ const emptyEffortRun = spawnSync(process.execPath,
 check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
 
 // opencode refuses a fresh run without an explicit model
-const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [] };
+const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [], pi: [] };
 
 // ---- Qoder's documented print-mode argv and structured result ----
 {
@@ -439,6 +451,99 @@ const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"],
       ? result(preflightOutDir)
       : {};
     check(`qoder preflight: ${mode} is explicit and prevents dispatch`,
+      preflight.status === expectedExit &&
+      preflightResult.status === expectedStatus &&
+      preflightResult.error?.includes("version preflight") &&
+      preflightResult.error?.includes("was not dispatched"));
+  }
+}
+
+// ---- pi's stdin brief, JSON event stream, and bounded preflight ----
+{
+  const outDir = join(scratch, "out-success-pi");
+  const workDir = freshRepo("work-success-pi");
+  const argsFile = join(scratch, "args-success-pi");
+  const run = spawnSync(process.execPath, [
+    relayPath("pi"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--model", "google/fake-model",
+    "--read-only",
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "pi-success", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  const capture = existsSync(argsFile) ? JSON.parse(readFileSync(argsFile, "utf8")) : {};
+  check("pi success: relay exits zero", run.status === 0);
+  check("pi success: documented argv is exact",
+    JSON.stringify(capture.args) === JSON.stringify([
+      "--mode", "json",
+      "--model", "google/fake-model",
+      "--tools", "read,grep,find,ls",
+    ]));
+  check("pi success: brief delivered through stdin", capture.brief === "smoke brief: run until killed.");
+  check("pi success: result.json exists", existsSync(join(outDir, "result.json")));
+  if (existsSync(join(outDir, "result.json"))) {
+    const value = result(outDir);
+    check("pi success: session header and message_end parsed",
+      value.status === "completed" &&
+      value.sessionId === "pi-session-1" &&
+      value.finalMessage === "fake pi completed" &&
+      value.readOnly === true &&
+      value.model === "google/fake-model" &&
+      value.resumed === false);
+  }
+
+  const resumeOutDir = join(scratch, "out-resume-last-pi");
+  const resumeArgsFile = join(scratch, "args-resume-last-pi");
+  const resume = spawnSync(process.execPath, [
+    relayPath("pi"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", resumeOutDir,
+    "--resume-last",
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "pi-success", SMOKE_ARGS_FILE: resumeArgsFile },
+    encoding: "utf8",
+  });
+  const resumeCapture = existsSync(resumeArgsFile) ? JSON.parse(readFileSync(resumeArgsFile, "utf8")) : {};
+  check("pi resume-last: uses documented --continue",
+    resume.status === 0 &&
+    resumeCapture.args.includes("--continue") &&
+    !resumeCapture.args.includes("--session") &&
+    existsSync(join(resumeOutDir, "result.json")) &&
+    result(resumeOutDir).resumed === true);
+
+  const zeroTimeoutOutDir = join(scratch, "out-zero-timeout-pi");
+  const zeroTimeout = spawnSync(process.execPath, [
+    relayPath("pi"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", zeroTimeoutOutDir,
+    "--timeout", "0s",
+  ], { env: baseEnv, encoding: "utf8" });
+  check("pi validation: zero timeout is rejected before artifacts",
+    zeroTimeout.status === 2 && !existsSync(zeroTimeoutOutDir));
+
+  for (const [mode, expectedStatus, expectedExit] of [
+    ["pi-version-fail", "failed", 7],
+    // The hang case is POSIX-only: on win32 the preflight kill fells cmd.exe
+    // but the fake's node grandchild would linger and pin the scratch dir.
+    ...(WIN ? [] : [["pi-version-hang", "timeout", 124]]),
+  ]) {
+    const preflightOutDir = join(scratch, `out-${mode}`);
+    const preflight = spawnSync(process.execPath, [
+      relayPath("pi"),
+      "--brief", briefPath,
+      "--cd", workDir,
+      "--out-dir", preflightOutDir,
+      "--timeout", "1s",
+    ], { env: { ...baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
+    const preflightResult = existsSync(join(preflightOutDir, "result.json"))
+      ? result(preflightOutDir)
+      : {};
+    check(`pi preflight: ${mode} is explicit and prevents dispatch`,
       preflight.status === expectedExit &&
       preflightResult.status === expectedStatus &&
       preflightResult.error?.includes("version preflight") &&
@@ -626,6 +731,7 @@ const TIMEOUT_CASES = [
   { skill: "grok", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "kimi", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "qoder", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "pi", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "agy", flags: ["--print-timeout", "1s"], exitDeadline: 120_000 },
 ];
 async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag) {


### PR DESCRIPTION
## Summary

Adds `pi-delegate` as the tenth delegation skill, driving the [Pi coding agent CLI](https://github.com/earendil-works/pi-mono) (`pi`) through the same brief → dispatch → review → land loop as the existing skills.

- `skills/pi-delegate/` contains `SKILL.md`, four progressively disclosed references, and a Node-built-ins-only `scripts/relay.mjs`.
- The brief rides stdin to `pi --mode json`, so it does not appear in the process list or encounter argv length limits.
- `--provider`, `--model`, `--session`, and `--resume-last` expose Pi's provider/model and session controls.
- The relay passes `--no-approve` by default; `--approve` explicitly trusts project `.pi` resources.
- Pi has no sandbox or permission modes. `--read-only` restricts callable tools to `read,grep,find,ls`; installed extension code still runs with the user's host permissions.
- `result.json` records the requested and actual provider/model, usage, stop reason, session id, final report, and final worktree state. A final assistant `error` or `aborted` event fails the run even when Pi exits zero.
- The bounded asynchronous version preflight, atomic artifact writes, stale-artifact replacement, relay timeout, abort handling, and process-tree termination follow the repository's current relay lifecycle contract.
- Native Windows uses `shell:true` for the npm-installed `pi.cmd` shim. Provider/model/session values are token-validated, and the bounded `where.exe` preflight preserves `pi_unavailable` classification.
- Current `master` is merged additively: all ten skills and their existing smoke coverage remain present.

## Verification

- `node test/relay-smoke.mjs` — all green on macOS after merging current `master`. The suite covers all ten relays and Pi's success, explicit project trust, assistant-error, timeout, timeout-yield, abort, preflight failure/hang/abort, unavailable, validation, and atomic-artifact paths.
- Native macOS read-only run against the current installed Pi CLI with an explicitly selected configured provider/model — completed, returned the expected marker, captured session/provider/model/usage, and left the worktree clean.
- A native run through the saved default provider timed out upstream; the relay correctly reported the actual provider/model, `stopReason: "error"`, provider error, session id, and clean worktree.
- `npx --yes skills add . --list` — validates the package and discovers all ten skills.
- `node --check` for the Pi relay and shared smoke suite, relay `--help`, `git diff --check`, manifest parsing, and trigger-description length validation — clean.
- Native Windows launch smoke remains unverified; the shared suite exercises Windows `.cmd` resolution and lifecycle behavior with a stand-in Pi binary.

## Notes

- The relay never commits. The orchestrator reviews the diff, reruns the project gates, and lands the work.
- Pi's `--continue` may create a new session id. `result.json` always reports the session id of the run that occurred; `--session <id>` is the stable explicit resume path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `pi-delegate` skill, including a dispatch→review→land workflow and multi-task queue guidance using Pi in JSON mode with resume support.
* **Documentation**
  * Updated delegate-skill rosters and Pi terminology/conventions; added comprehensive `pi-delegate` docs covering the brief contract, `result.json` artifacts, review/landing validation, and Windows launch/smoke-test expectations.
* **Tests**
  * Expanded relay smoke tests to include Pi end-to-end validation, stdin brief capture, `--resume-last`/continue behavior, preflight failures, timeouts, abort handling, and platform-specific shim behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->