### PR TITLE
feat(codex): add --session <id> for exact-thread resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Eight skills ship today — same loop, different implementer:
 | Skill | Drives | Autonomy | Resume |
 | --- | --- | --- | --- |
 | `claude-delegate` | [Claude Code CLI](https://code.claude.com/docs/en/overview) | explicit tools + `acceptEdits`; strict shell-sandbox settings where supported; shell-free `--read-only`; bypass opt-in | `--resume-last`, `--session <id>` |
-| `codex-delegate` | [OpenAI Codex CLI](https://github.com/openai/codex) | Codex `--sandbox` enum (`workspace-write` default) | `--resume-last` |
+| `codex-delegate` | [OpenAI Codex CLI](https://github.com/openai/codex) | Codex `--sandbox` enum (`workspace-write` default) | `--resume-last`, `--session <id>` |
 | `opencode-delegate` | [OpenCode CLI](https://opencode.ai) | agent: `build` (write) / `plan` (read-only) | `--resume-last`, `--session <id>` |
 | `agy-delegate` | Google Antigravity CLI (`agy`) | Antigravity's own permission policy; bypass is opt-in | `--resume-last`, `--conversation <id>` |
 | `grok-delegate` | Grok Build CLI (`grok`) | explicit: default workspace-scoped, `--read-only` best-effort with violation detection, `--full-access` opt-in | `--resume-last`, `--session <id>` |

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -64,7 +64,8 @@ orchestrators use that same directory — if unsure where it landed, run
 ```bash
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # read-only (review/diagnosis, no edits):   add --read-only
-# continue the previous Codex session:      add --resume-last  (send only the delta brief)
+# continue the exact Codex session:         add --session <threadId>  (from result.json; send only the delta brief)
+# fallback when no thread id is available:  add --resume-last
 # hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
 # see all options:                          node .../relay.mjs --help
 ```
@@ -110,8 +111,8 @@ Because Codex's sandbox cannot reliably write `.git` (it varies by version, OS, 
 orchestrator commits.** Only after the gates pass and the diff holds:
 
 - Commit the verified work yourself, with a clear message.
-- If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
-  review again.
+- If it needs changes, send a delta brief with `--session <threadId>` from the prior `result.json`
+  (use `--resume-last` only when no thread id is available), and review again.
 
 ## Read-only second opinions
 
@@ -139,6 +140,6 @@ is in [references/review-and-land.md](references/review-and-land.md).
 - [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
   `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
 - [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
-  boundary, and the rework cycle via `--resume-last`.
+  boundary, and the exact-session rework cycle.
 - [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
   carrying constraints forward, progress tracking, and the end-of-run coherence check.

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -60,7 +60,7 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 - `finalMessage` — Codex's own final report (the `<structured_output_contract>` you asked for)
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report — `git` missing, or a non-repo run under `--skip-git-repo-check`; `[]` means git ran and the tree is clean
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSONL event stream, and the final-message file
-- `workdir`, `sandbox`, `model`, `effort`, `resumeLast`, `startedAt`, `finishedAt`
+- `workdir`, `sandbox`, `model`, `effort`, `resumeLast`, `session`, `startedAt`, `finishedAt` — `session` is the explicit session id, or `null` for fresh and `--resume-last` runs
 - `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `codex_unavailable`, and launch failures
 - `error` — present on a launch failure, and on `timeout` and `aborted` runs
 

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -38,7 +38,8 @@ Options:
 | `--effort <level>` | Reasoning effort, passed to Codex as `-c model_reasoning_effort=<level>` (default: Codex's own configured default). The relay accepts a bare token; Codex and the model own the supported levels. Applies to fresh and resumed runs. |
 | `--sandbox <mode>` | `read-only` \| `workspace-write` \| `danger-full-access` (default: `workspace-write`). |
 | `--read-only` | Shortcut for `--sandbox read-only` — review/diagnosis with no edits. |
-| `--resume-last` | Continue the most recent Codex session; send only the delta brief (see review-and-land). |
+| `--resume-last` | Continue the most recent Codex session; send only the delta brief (see review-and-land). "Most recent" is global, so an unrelated Codex run can steal it — prefer `--session`. |
+| `--session <id>` | Continue one specific thread by id (the `threadId` from a prior `result.json`); send only the delta brief. Mutually exclusive with `--resume-last`; an empty id is rejected. |
 | `--skip-git-repo-check` | Allow running outside a git repo. |
 | `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
@@ -55,7 +56,7 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 - `exitCode` — mirrors Codex's exit code; `128` plus the signal number if the child was killed; `127` if `codex` isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
 - `signal` — the signal that killed the child, otherwise `null`
 - `codexVersion` — the binary that actually ran
-- `threadId` — feed this to a later `codex exec resume <id>` (or use `--resume-last`)
+- `threadId` — feed this to a later `--session <id>` (exact thread; preferred) or `--resume-last` (global "most recent", which another Codex run can steal)
 - `finalMessage` — Codex's own final report (the `<structured_output_contract>` you asked for)
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report — `git` missing, or a non-repo run under `--skip-git-repo-check`; `[]` means git ran and the tree is clean
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSONL event stream, and the final-message file

--- a/skills/codex-delegate/references/review-and-land.md
+++ b/skills/codex-delegate/references/review-and-land.md
@@ -108,7 +108,7 @@ drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-las
 
 (`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
 
-`--resume-last` keeps Codex's context from the first run, so a short delta is enough. Then review
+`--session <threadId>` (or `--resume-last`) keeps Codex's context from the first run, so a short delta is enough. Then review
 again — rework gets the same gate-rerun, test check, diff-read, and sweep as the original, no
 shortcuts. Repeat until it's right, then commit.
 

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -72,6 +72,7 @@ import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
+const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -134,10 +135,10 @@ function parseArgs(argv) {
   if (opts.session !== null && opts.resumeLast) {
     fail("--session and --resume-last are mutually exclusive; pass only one");
   }
-  // An empty id is not a resume: buildArgv treats "" as falsy and would launch a fresh run
-  // while every other code path still reports the run as resumed.
-  if (opts.session !== null && !opts.session.trim()) {
-    fail("--session requires a non-empty thread id");
+  // This value reaches cmd.exe on win32 (shell:true for the codex.cmd shim), so
+  // accept only the same shell-safe session token shape used by sibling relays.
+  if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
+    fail("--session must be a shell-safe thread id (letters, digits, . _ : -)");
   }
   return opts;
 }

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -35,6 +35,10 @@
  *   --read-only             Shortcut for --sandbox read-only (review/diagnosis, no edits).
  *   --resume-last           Continue the most recent Codex session; send only the delta brief.
  *                           (Inherits the original session's sandbox and working root.)
+ *   --session <id>          Continue a specific Codex session by thread id (from a prior
+ *                           result.json). Safer than --resume-last when other Codex runs
+ *                           may have happened since - "last" is global, not per-repo.
+ *                           Mutually exclusive with --resume-last.
  *   --skip-git-repo-check   Allow running outside a git repository.
  *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
  *                           strings like 30m or 2h. On expiry the codex child is killed
@@ -82,6 +86,7 @@ function parseArgs(argv) {
     effort: null,
     sandbox: "workspace-write",
     resumeLast: false,
+    session: null,
     skipGitRepoCheck: false,
     timeout: null,
     outDir: null,
@@ -107,6 +112,7 @@ function parseArgs(argv) {
       case "--sandbox": opts.sandbox = next(); break;
       case "--read-only": opts.sandbox = "read-only"; break;
       case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
       case "--skip-git-repo-check": opts.skipGitRepoCheck = true; break;
       case "--timeout": opts.timeout = next(); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
@@ -124,6 +130,14 @@ function parseArgs(argv) {
   // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
   if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
     fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  if (opts.session !== null && opts.resumeLast) {
+    fail("--session and --resume-last are mutually exclusive; pass only one");
+  }
+  // An empty id is not a resume: buildArgv treats "" as falsy and would launch a fresh run
+  // while every other code path still reports the run as resumed.
+  if (opts.session !== null && !opts.session.trim()) {
+    fail("--session requires a non-empty thread id");
   }
   return opts;
 }
@@ -212,7 +226,8 @@ function timestamp() {
 
 function buildArgv(opts, finalPath) {
   const argv = ["exec"];
-  if (opts.resumeLast) argv.push("resume", "--last");
+  if (opts.session) argv.push("resume", opts.session);
+  else if (opts.resumeLast) argv.push("resume", "--last");
   // ponytail: shell:true on win32 (needed for the codex.cmd shim) doesn't quote
   // args, so a temp path with spaces (C:\Users\First Last\...) splits and the
   // trailing "-" misparses (issue #3). Quote the only spaceable arg in argv.
@@ -221,7 +236,7 @@ function buildArgv(opts, finalPath) {
   argv.push("--json", "-o", outPath);
   // `-s`/`-C` are not accepted by `exec resume`; resume inherits the original
   // session's sandbox and working root, and we set the child process cwd below.
-  if (!opts.resumeLast) {
+  if (!opts.resumeLast && !opts.session) {
     argv.push("-s", opts.sandbox);
   }
   if (opts.model) argv.push("-m", opts.model);
@@ -280,10 +295,11 @@ function makeResultWriter(opts, version, run) {
     const result = {
       schema: "delegate-relay.result.v1",
       workdir: opts.cd,
-      sandbox: opts.resumeLast ? "(inherited from resumed session)" : opts.sandbox,
+      sandbox: opts.resumeLast || opts.session ? "(inherited from resumed session)" : opts.sandbox,
       model: opts.model,
       effort: opts.effort,
       resumeLast: opts.resumeLast,
+      session: opts.session,
       codexVersion: version,
       startedAt: run.startedAt,
       finishedAt: new Date().toISOString(),
@@ -469,7 +485,8 @@ function printSummary(result, resultPath) {
   if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a codex error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated codex (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumeLast) lines.push("mode: resumed most recent session");
-  if (result.threadId) lines.push(`thread id (resume with: codex exec resume ${result.threadId}): ${result.threadId}`);
+  if (result.session) lines.push(`mode: resumed session ${result.session}`);
+  if (result.threadId) lines.push(`thread id (resume with: --session ${result.threadId}): ${result.threadId}`);
   const touched = result.touchedFiles;
   if (touched === null) {
     lines.push("touched files: git unavailable — inspect the working tree directly");

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -344,10 +344,16 @@ const bothResumeRun = spawnSync(process.execPath,
   [relayPath("codex"), "--brief", briefPath, "--session", "thread-abc", "--resume-last"],
   { env: baseEnv, encoding: "utf8" });
 check("codex session: --session with --resume-last is rejected", bothResumeRun.status === 2);
-const emptySessionRun = spawnSync(process.execPath,
-  [relayPath("codex"), "--brief", briefPath, "--session", ""],
-  { env: baseEnv, encoding: "utf8" });
-check("codex session: an empty id is rejected", emptySessionRun.status === 2);
+for (const [name, value] of [
+  ["an empty id", ""],
+  ["an option-like id", "--resume-last"],
+  ["a shell-unsafe id", "thread & whoami"],
+]) {
+  const invalidSessionRun = spawnSync(process.execPath,
+    [relayPath("codex"), "--brief", briefPath, "--session", value],
+    { env: baseEnv, encoding: "utf8" });
+  check(`codex session: ${name} is rejected`, invalidSessionRun.status === 2);
+}
 
 const emptyEffortRun = spawnSync(process.execPath,
   [relayPath("codex"), "--brief", briefPath, "--effort", ""],

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -291,6 +291,28 @@ check("codex effort: forwarded as a config override",
   effortRun.status === 0 && effortArgs.includes("-c") && effortArgs[effortArgs.indexOf("-c") + 1] === "model_reasoning_effort=low");
 check("codex effort: recorded in result.json",
   existsSync(join(effortOutDir, "result.json")) && result(effortOutDir).effort === "low");
+// ---- codex --session resumes one exact thread ----
+const sessionOutDir = join(scratch, "out-session-codex");
+const sessionArgsFile = join(scratch, "args-session-codex");
+const sessionWorkDir = freshRepo("work-session-codex");
+const sessionRun = spawnSync(process.execPath,
+  [relayPath("codex"), "--brief", briefPath, "--cd", sessionWorkDir, "--out-dir", sessionOutDir, "--session", "thread-abc"],
+  { env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: sessionArgsFile }, encoding: "utf8" });
+const sessionArgs = existsSync(sessionArgsFile) ? JSON.parse(readFileSync(sessionArgsFile, "utf8")) : [];
+check("codex session: resumes the named thread",
+  sessionRun.status === 0 && sessionArgs[0] === "exec" && sessionArgs[1] === "resume" && sessionArgs[2] === "thread-abc");
+check("codex session: no -s on a resume (exec resume rejects it)", !sessionArgs.includes("-s"));
+check("codex session: recorded in result.json",
+  existsSync(join(sessionOutDir, "result.json")) && result(sessionOutDir).session === "thread-abc");
+const bothResumeRun = spawnSync(process.execPath,
+  [relayPath("codex"), "--brief", briefPath, "--session", "thread-abc", "--resume-last"],
+  { env: baseEnv, encoding: "utf8" });
+check("codex session: --session with --resume-last is rejected", bothResumeRun.status === 2);
+const emptySessionRun = spawnSync(process.execPath,
+  [relayPath("codex"), "--brief", briefPath, "--session", ""],
+  { env: baseEnv, encoding: "utf8" });
+check("codex session: an empty id is rejected", emptySessionRun.status === 2);
+
 const emptyEffortRun = spawnSync(process.execPath,
   [relayPath("codex"), "--brief", briefPath, "--effort", ""],
   { env: baseEnv, encoding: "utf8" });


### PR DESCRIPTION
## Problem

`--resume-last` resolves to the most recent Codex session **globally** — not per repo, not per relay run. If anything else invokes `codex` between the two legs of a delegation (another delegate run in a different repo, a manual `codex exec`, another agent), the delta brief resumes the wrong thread.

The relay already records `threadId` in `result.json`, and `dispatch-and-poll.md` tells the orchestrator to "feed this to a later `codex exec resume <id>`" — but doing so means bypassing the relay entirely, losing `result.json`, `touchedFiles`, and the summary.

## Change

`--session <id>` resumes that exact thread through the relay.

- Mutually exclusive with `--resume-last`.
- An empty id is rejected: `buildArgv` treats `""` as falsy and would launch a **fresh** run while `result.json` still reported it as resumed.
- Same argv path as `--resume-last`, so `-s` stays withheld (`exec resume` rejects it) and the working root still comes from the child cwd.
- Recorded as `session` in `result.json`; the summary now prints `--session <threadId>` as the resume hint.

## Tests

Five new assertions in `test/relay-smoke.mjs`: argv shape (`exec resume <id>`), `-s` withheld on resume, the recorded field, and both rejections. Full suite green locally on macOS (7 relays).

## Notes

Docs updated in `references/dispatch-and-poll.md` (flag table + the `threadId` bullet) and the relay header. No behavior change for existing flags.

Found while using these skills daily to drive multi-round delegations; happy to adjust naming or split anything out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--session <id>` to resume a specific prior Codex thread/session (mutually exclusive with `--resume-last`).
  * Resumed runs now preserve the prior session’s configuration and surface the active session in outputs.
* **Bug Fixes**
  * Improved validation for `--session` values and rejected invalid or conflicting flag combinations.
* **Documentation**
  * Updated delegate skill instructions, reference docs, and the `result.json` contract to document `session` and exact-session continuation vs `--resume-last`.
* **Tests**
  * Added smoke tests covering resume argv behavior, suppression of `-s` on resume, and invalid flag/ID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->