### PR TITLE
fix: publish result.json atomically in the five older relays

### DIFF
--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -66,7 +66,7 @@
  */
 
 import { spawn, execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
@@ -324,7 +324,11 @@ function makeResultWriter(opts, version, run) {
       stderrPath: run.stderrPath,
       ...extra,
     };
-    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
     return result;
   };
 }

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -62,7 +62,7 @@
  */
 
 import { spawn, execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
@@ -292,7 +292,11 @@ function makeResultWriter(opts, version, run) {
       finalPath: existsSync(run.finalPath) ? run.finalPath : null,
       ...extra,
     };
-    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
     return result;
   };
 }

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -77,7 +77,7 @@
  */
 
 import { spawn, execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
@@ -398,7 +398,11 @@ function makeResultWriter(opts, version, run) {
       finalPath: existsSync(run.finalPath) ? run.finalPath : null,
       ...extra,
     };
-    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
     return result;
   };
 }

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -65,7 +65,7 @@
  */
 
 import { spawn, execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
@@ -295,7 +295,11 @@ function makeResultWriter(opts, version, run) {
       stderrPath: run.stderrPath,
       ...extra,
     };
-    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
     return result;
   };
 }

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -67,7 +67,7 @@
  */
 
 import { spawn, execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
@@ -336,7 +336,11 @@ function makeResultWriter(opts, version, run) {
       finalPath: existsSync(run.finalPath) ? run.finalPath : null,
       ...extra,
     };
-    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
     return result;
   };
 }

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -214,6 +214,10 @@ class FakeCli {
       Console.WriteLine("fake-cli 0.0.0-smoke");
       return 0;
     }
+    if (Environment.GetEnvironmentVariable("SMOKE_MODE") == "capture") {
+      File.WriteAllLines(Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE"), args);
+      return 0;
+    }
     if (Environment.GetEnvironmentVariable("SMOKE_MODE") == "qoder-success") {
       File.WriteAllLines(Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE"), args);
       Console.WriteLine("{\\"type\\":\\"system\\",\\"subtype\\":\\"init\\",\\"session_id\\":\\"qoder-session-1\\",\\"model\\":\\"performance\\",\\"permissionMode\\":\\"auto\\"}");
@@ -276,6 +280,24 @@ if (WIN) {
 const briefPath = join(scratch, "brief.txt");
 writeFileSync(briefPath, "smoke brief: run until killed.");
 const baseEnv = { ...process.env, PATH: shimDir + delimiter + process.env.PATH, SMOKE_NODE: process.execPath };
+const slowWriteHook = join(scratch, "slow-result-write.cjs");
+writeFileSync(slowWriteHook, `const fs = require("node:fs");
+const { syncBuiltinESMExports } = require("node:module");
+const writeFileSync = fs.writeFileSync;
+fs.writeFileSync = function (path, data, options) {
+  if (!String(path).includes("result.json")) return writeFileSync.apply(this, arguments);
+  const encoding = typeof options === "string" ? options : options?.encoding;
+  const bytes = Buffer.isBuffer(data) ? data : Buffer.from(data, encoding);
+  const split = Math.max(1, Math.floor(bytes.length / 2));
+  writeFileSync(path, bytes.subarray(0, split));
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
+  writeFileSync(path, bytes.subarray(split), { flag: "a" });
+};
+syncBuiltinESMExports();
+`);
+const slowWriteNodeOptions = [process.env.NODE_OPTIONS, `--require=${JSON.stringify(slowWriteHook.replaceAll("\\", "/"))}`]
+  .filter(Boolean)
+  .join(" ");
 
 const freshRepo = (name) => {
   const dir = join(scratch, name);
@@ -464,18 +486,40 @@ if (WIN) {
 }
 
 // ---- every relay publishes result.json atomically ----
-// A poller that waits for the file must never read a half-written one: each relay writes a
-// pid-suffixed temporary and renames it into place, so no .tmp file may survive a finished run.
+// Slow the filesystem write inside each relay and parse any visible result while it is still
+// running. A direct result.json write exposes half-written JSON; temp + rename never does.
 for (const skill of SKILLS) {
   const atomicOutDir = join(scratch, `out-atomic-${skill}`);
   const atomicWorkDir = freshRepo(`work-atomic-${skill}`);
-  spawnSync(process.execPath,
-    [relayPath(skill), "--brief", briefPath, "--cd", atomicWorkDir, "--out-dir", atomicOutDir, ...EXTRA_ARGS[skill]],
-    { env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: join(scratch, `args-atomic-${skill}`) }, encoding: "utf8" });
+  const resultPath = join(atomicOutDir, "result.json");
+  const child = runRelay(skill, atomicWorkDir, atomicOutDir, EXTRA_ARGS[skill], {
+    NODE_OPTIONS: slowWriteNodeOptions,
+    SMOKE_MODE: "capture",
+    SMOKE_ARGS_FILE: join(scratch, `args-atomic-${skill}`),
+  });
+  let exitCode;
+  let parseFailed = false;
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.on("close", (code) => { exitCode = code; });
+  const deadline = Date.now() + 15_000;
+  while (exitCode === undefined && Date.now() < deadline) {
+    if (existsSync(resultPath)) {
+      try { result(atomicOutDir); } catch { parseFailed = true; }
+    }
+    await sleep(5);
+  }
+  const timedOut = exitCode === undefined;
+  if (timedOut) child.kill();
+  await until(() => exitCode !== undefined, 5_000);
+  let finalResultValid = false;
+  try { finalResultValid = Boolean(result(atomicOutDir)); } catch {}
   const leftovers = existsSync(atomicOutDir) ? readdirSync(atomicOutDir).filter((f) => f.includes(".tmp")) : [];
-  check(`${skill} atomic: result.json exists`, existsSync(join(atomicOutDir, "result.json")));
-  result(atomicOutDir);
+  check(`${skill} atomic: relay exits`, !timedOut);
+  check(`${skill} atomic: result.json is never partially published`, !parseFailed && finalResultValid);
   check(`${skill} atomic: no temporary result file survives the run`, leftovers.length === 0);
+  if (timedOut) console.error(`${skill} atomic relay stderr:\n${stderr}`);
 }
 
 // ---- Qoder's documented print-mode argv and structured result ----

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -37,7 +37,7 @@
  * Node built-ins only.
  */
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, mkdirSync, copyFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync, existsSync, rmSync, chmodSync, mkdirSync, copyFileSync } from "node:fs";
 import { join, delimiter, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -279,6 +279,7 @@ const runRelay = (skill, workDir, outDir, extraArgs, extraEnv) =>
 
 const result = (outDir) => JSON.parse(readFileSync(join(outDir, "result.json"), "utf8"));
 
+
 // ---- codex effort is validated, forwarded, and recorded ----
 const effortOutDir = join(scratch, "out-effort-codex");
 const effortArgsFile = join(scratch, "args-effort-codex");
@@ -298,6 +299,20 @@ check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
 
 // opencode refuses a fresh run without an explicit model
 const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [] };
+
+// ---- every relay publishes result.json atomically ----
+// A poller that waits for the file must never read a half-written one: each relay writes a
+// pid-suffixed temporary and renames it into place, so no .tmp file may survive a finished run.
+for (const skill of SKILLS) {
+  const atomicOutDir = join(scratch, `out-atomic-${skill}`);
+  const atomicWorkDir = freshRepo(`work-atomic-${skill}`);
+  spawnSync(process.execPath,
+    [relayPath(skill), "--brief", briefPath, "--cd", atomicWorkDir, "--out-dir", atomicOutDir, ...EXTRA_ARGS[skill]],
+    { env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: join(scratch, `args-atomic-${skill}`) }, encoding: "utf8" });
+  const leftovers = existsSync(atomicOutDir) ? readdirSync(atomicOutDir).filter((f) => f.includes(".tmp")) : [];
+  check(`${skill} atomic: result.json exists`, existsSync(join(atomicOutDir, "result.json")));
+  check(`${skill} atomic: no temporary result file survives the run`, leftovers.length === 0);
+}
 
 // ---- Qoder's documented print-mode argv and structured result ----
 {


### PR DESCRIPTION
## Problem

`dispatch-and-poll.md` tells orchestrators that a backgrounded run is finished when `result.json` exists with a `status` — so polling for the file is the documented way to consume it, not an edge case. But `codex`, `opencode`, `agy`, `grok` and `kimi` write that file directly:

```js
writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
```

A poller that stats the path between `open` and the final flush reads truncated JSON and throws. I hit this driving background runs from Claude Code.

`claude-delegate` (`writeJsonAtomic`) and `qoder-delegate` already avoid it — they write a pid-suffixed temporary and `renameSync` it into place.

## Change

The same idiom, applied to the other five. No new dependency, no behavior change beyond the file appearing complete-or-not-at-all.

## Tests

Two assertions per relay in `test/relay-smoke.mjs` (all seven): `result.json` exists after a run, and no `.tmp` artifact survives it. Full suite green locally on macOS.

## Notes

Split deliberately from two related hardening ideas I can send separately if you want them: a private (0700) default artifact directory, and rejecting a non-empty explicit `--out-dir` so a previous run's `final.txt` can't be read as this run's report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated relay workflows across skills to publish `result.json` atomically by writing to a temporary file and then renaming it into place, avoiding partially written results during polling.
* **Tests**
  * Expanded the relay smoke test to verify `result.json` is always parseable and that no temporary `.tmp` artifacts remain.
  * Enhanced test harness behavior for capture mode (including platform-specific behavior) and added filesystem checks to support the new validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->