### PR TITLE
feat(agy): add --timeout as an explicit relay watchdog

### DIFF
--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -36,7 +36,8 @@ Options:
 | `--conversation <id>` | Continue a specific Antigravity conversation; send only the delta brief. |
 | `--sandbox` | Enable Antigravity's terminal sandbox for the run. |
 | `--dangerously-skip-permissions` | Pass Antigravity's permission-bypass flag. Never use this unless the human explicitly accepts it. |
-| `--print-timeout <duration>` | Timeout for print mode (default: `30m`). |
+| `--print-timeout <duration>` | Timeout agy itself applies to print mode (default: `30m`). |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`); overrides the default of `--print-timeout` plus a 60s grace. On expiry the agy process tree is killed and `result.json` gets `status: "timeout"`. Set it explicitly when agy may hang past its own print timeout. A malformed or zero duration is rejected rather than silently firing immediately. |
 | `--add-dir <dir>` | Add an extra workspace directory. Repeatable; relative paths resolve against `--cd`. Fresh runs always add the `--cd` repo (absolute path) as a workspace dir. Edits inside extra workspaces are not reported in `touchedFiles`. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
 

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -37,7 +37,7 @@ Options:
 | `--sandbox` | Enable Antigravity's terminal sandbox for the run. |
 | `--dangerously-skip-permissions` | Pass Antigravity's permission-bypass flag. Never use this unless the human explicitly accepts it. |
 | `--print-timeout <duration>` | Timeout agy itself applies to print mode (default: `30m`). |
-| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`); overrides the default of `--print-timeout` plus a 60s grace. On expiry the agy process tree is killed and `result.json` gets `status: "timeout"`. Set it explicitly when agy may hang past its own print timeout. A malformed or zero duration is rejected rather than silently firing immediately. |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`); overrides the default of `--print-timeout` plus a 60s grace. On expiry the agy process tree is killed and `result.json` gets `status: "timeout"`. Set it explicitly when agy may hang past its own print timeout. Malformed, zero, and out-of-range durations are rejected; the maximum is `596h31m23s`. |
 | `--add-dir <dir>` | Add an extra workspace directory. Repeatable; relative paths resolve against `--cd`. Fresh runs always add the `--cd` repo (absolute path) as a workspace dir. Edits inside extra workspaces are not reported in `touchedFiles`. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
 
@@ -87,9 +87,9 @@ process has exited and `result.json` is written.
 
 - **`status: agy_unavailable` (exit 127):** `agy` is not on PATH. Install the Antigravity CLI and run
   its first-launch setup, then re-dispatch.
-- **`status: timeout`:** the `--print-timeout` watchdog killed the run. The working tree may hold a
-  half-applied change — inspect it before deciding between a longer `--print-timeout`, a smaller
-  brief, or a resume.
+- **`status: timeout`:** the relay watchdog killed the run. Inspect `error` to see whether the selected
+  limit was explicit `--timeout` or the derived `--print-timeout` plus 60s grace. The working tree may
+  hold a half-applied change — inspect it before changing that limit, reducing the brief, or resuming.
 - **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
   closed terminal) and forwarded the kill to agy. The result is written before the relay exits;
   inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -144,8 +144,8 @@ function parseArgs(argv) {
     }
   }
   const printTimeoutMs = parseDuration(opts.printTimeout);
-  if (printTimeoutMs !== null && printTimeoutMs + 60_000 > MAX_TIMER_MS) {
-    fail(`--print-timeout "${opts.printTimeout}" exceeds the relay watchdog limit after its 60s grace; use at most 596h30m23s`);
+  if (printTimeoutMs === null || printTimeoutMs <= 0 || printTimeoutMs + 60_000 > MAX_TIMER_MS) {
+    fail(`--print-timeout "${opts.printTimeout}" must be an h/m/s duration from 1s through 596h30m23s so its 60s grace fits the relay watchdog limit`);
   }
   if (opts.project && (opts.resumeLast || opts.conversation)) {
     fail("--project cannot be combined with --resume-last or --conversation");
@@ -357,7 +357,7 @@ function reportUnavailable(writeResult, resultPath) {
 
 function dispatchToAgy(opts, brief, run, writeResult) {
   const argv = buildArgv(opts, brief, run);
-  const printTimeoutMs = parseDuration(opts.printTimeout) ?? parseDuration(DEFAULT_PRINT_TIMEOUT);
+  const printTimeoutMs = parseDuration(opts.printTimeout);
   // An explicit --timeout wins over the default print-timeout-plus-grace: agy can hang well
   // past its own print timeout, which is exactly the case the grace window cannot cover.
   const watchdogMs = opts.timeout !== null ? parseDuration(opts.timeout) : printTimeoutMs + 60_000;

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -63,9 +63,9 @@
  * If the child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome -
- * completed, failed, timeout (the relay watchdog fired after --print-timeout
- * plus 60s grace), aborted (the relay itself was killed and forwarded the kill
- * to agy), or agy_unavailable. An orchestrator that polls for the
+ * completed, failed, timeout (the relay watchdog fired after explicit --timeout,
+ * or after --print-timeout plus 60s grace), aborted (the relay itself was killed
+ * and forwarded the kill to agy), or agy_unavailable. An orchestrator that polls for the
  * file must therefore also treat a non-zero exit with no file as a usage error.
  */
 
@@ -76,6 +76,8 @@ import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_PRINT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const MAX_TIMER_DURATION = "596h31m23s";
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -137,9 +139,13 @@ function parseArgs(argv) {
   // failure mode a watchdog has. Zero is rejected for the same reason.
   if (opts.timeout !== null) {
     const milliseconds = parseDuration(opts.timeout);
-    if (milliseconds === null || milliseconds <= 0) {
-      fail(`--timeout "${opts.timeout}" is not a positive duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+    if (milliseconds === null || milliseconds <= 0 || milliseconds > MAX_TIMER_MS) {
+      fail(`--timeout "${opts.timeout}" must be an h/m/s duration from 1s through ${MAX_TIMER_DURATION}`);
     }
+  }
+  const printTimeoutMs = parseDuration(opts.printTimeout);
+  if (printTimeoutMs !== null && printTimeoutMs + 60_000 > MAX_TIMER_MS) {
+    fail(`--print-timeout "${opts.printTimeout}" exceeds the relay watchdog limit after its 60s grace; use at most 596h30m23s`);
   }
   if (opts.project && (opts.resumeLast || opts.conversation)) {
     fail("--project cannot be combined with --resume-last or --conversation");
@@ -215,15 +221,9 @@ function agyVersion() {
 }
 
 function parseDuration(duration) {
-  let milliseconds = 0;
-  let matched = false;
-  for (const match of duration.matchAll(/(\d+)h|(\d+)m|(\d+)s/g)) {
-    matched = true;
-    if (match[1]) milliseconds += Number(match[1]) * 60 * 60 * 1000;
-    if (match[2]) milliseconds += Number(match[2]) * 60 * 1000;
-    if (match[3]) milliseconds += Number(match[3]) * 1000;
-  }
-  return matched ? milliseconds : null;
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
 }
 
 function gitTouchedFiles(cwd) {

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -78,6 +78,7 @@ import { StringDecoder } from "node:string_decoder";
 const DEFAULT_PRINT_TIMEOUT = "30m";
 const MAX_TIMER_MS = 2_147_483_647;
 const MAX_TIMER_DURATION = "596h31m23s";
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -206,9 +207,13 @@ function killChild(child, signal = "SIGTERM") {
   }
 }
 
-function agyVersion() {
+function agyVersion(timeoutMs) {
   try {
-    const out = execFileSync("agy", ["changelog"], { encoding: "utf8" }).trim();
+    const out = execFileSync("agy", ["changelog"], {
+      encoding: "utf8",
+      timeout: Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS),
+      killSignal: "SIGKILL",
+    }).trim();
     const firstLine = out.split("\n").find(Boolean) || "";
     const match = firstLine.match(/^([^:\s]+):/);
     return match ? match[1] : firstLine || null;
@@ -216,6 +221,7 @@ function agyVersion() {
     // Only a missing binary means "unavailable"; any other changelog failure
     // (permissions, a broken subcommand) must not masquerade as exit 127.
     if (err && err.code === "ENOENT") return null;
+    if (err && err.code === "ETIMEDOUT") throw err;
     return "unknown";
   }
 }
@@ -355,12 +361,26 @@ function reportUnavailable(writeResult, resultPath) {
   process.exit(127);
 }
 
-function dispatchToAgy(opts, brief, run, writeResult) {
+function reportVersionTimeout(writeResult, run, timeoutMs, error) {
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = `agy changelog version preflight timed out after ${Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS)}ms; agy was not dispatched`;
+  const result = writeResult({
+    status: "timeout",
+    exitCode: 124,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: null,
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToAgy(opts, brief, run, writeResult, watchdogMs) {
   const argv = buildArgv(opts, brief, run);
-  const printTimeoutMs = parseDuration(opts.printTimeout);
-  // An explicit --timeout wins over the default print-timeout-plus-grace: agy can hang well
-  // past its own print timeout, which is exactly the case the grace window cannot cover.
-  const watchdogMs = opts.timeout !== null ? parseDuration(opts.timeout) : printTimeoutMs + 60_000;
   // Antigravity's installer provides a native `agy` binary. Launch directly so
   // multi-line briefs and paths with spaces are passed as argv, not shell text.
   const child = spawn("agy", argv, {
@@ -507,8 +527,19 @@ function main() {
     fail(`brief is ${Math.round(briefBytes / 1024)}KB; agy passes the prompt as a CLI argument, which the OS caps (~128KB on Linux). Trim it, or have agy read large context from the workspace instead of inlining it.`);
   }
 
-  const version = agyVersion();
+  const printTimeoutMs = parseDuration(opts.printTimeout);
+  // An explicit --timeout wins over the default print-timeout-plus-grace: agy can hang well
+  // past its own print timeout, which is exactly the case the grace window cannot cover.
+  const watchdogMs = opts.timeout !== null ? parseDuration(opts.timeout) : printTimeoutMs + 60_000;
   const run = prepareRunDir(opts, brief);
+  let version;
+  try {
+    version = agyVersion(watchdogMs);
+  } catch (error) {
+    const writeResult = makeResultWriter(opts, "unknown", run);
+    reportVersionTimeout(writeResult, run, watchdogMs, error);
+    return;
+  }
   const writeResult = makeResultWriter(opts, version, run);
 
   if (!version) {
@@ -516,7 +547,7 @@ function main() {
     return;
   }
 
-  dispatchToAgy(opts, brief, run, writeResult);
+  dispatchToAgy(opts, brief, run, writeResult, watchdogMs);
 }
 
 function printSummary(result, resultPath) {

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -42,7 +42,11 @@
  *   --sandbox               Enable Antigravity's terminal sandbox for this run.
  *   --dangerously-skip-permissions
  *                           Auto-approve Antigravity tool permission requests. Use only with human approval.
- *   --print-timeout <dur>   Timeout for print mode (default: 30m).
+ *   --print-timeout <dur>   Timeout agy itself applies to print mode (default: 30m).
+ *   --timeout <dur>         Relay-side watchdog, h/m/s like 30m (default: --print-timeout
+ *                           plus a 60s grace). On expiry the agy process tree is killed and
+ *                           result.json gets status "timeout". Set it explicitly when agy
+ *                           may hang past its own print timeout.
  *   --add-dir <dir>         Add an extra workspace directory. Repeatable.
  *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
  *                           the system temp dir, so the repo under review stays clean).
@@ -90,6 +94,7 @@ function parseArgs(argv) {
     sandbox: false,
     dangerouslySkipPermissions: false,
     printTimeout: DEFAULT_PRINT_TIMEOUT,
+    timeout: null,
     addDirs: [],
     outDir: null,
   };
@@ -117,6 +122,7 @@ function parseArgs(argv) {
       case "--sandbox": opts.sandbox = true; break;
       case "--dangerously-skip-permissions": opts.dangerouslySkipPermissions = true; break;
       case "--print-timeout": opts.printTimeout = next(); break;
+      case "--timeout": opts.timeout = next(); break;
       case "--add-dir": opts.addDirs.push(next()); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
@@ -125,6 +131,15 @@ function parseArgs(argv) {
   }
   if (opts.resumeLast && opts.conversation) {
     fail("--resume-last and --conversation are mutually exclusive; pass only one");
+  }
+  // A malformed --timeout must fail loudly: parseDuration returns null for it, and a null
+  // delay makes setTimeout fire on the next tick - a silent instant "timeout", the worst
+  // failure mode a watchdog has. Zero is rejected for the same reason.
+  if (opts.timeout !== null) {
+    const milliseconds = parseDuration(opts.timeout);
+    if (milliseconds === null || milliseconds <= 0) {
+      fail(`--timeout "${opts.timeout}" is not a positive duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+    }
   }
   if (opts.project && (opts.resumeLast || opts.conversation)) {
     fail("--project cannot be combined with --resume-last or --conversation");
@@ -338,7 +353,10 @@ function reportUnavailable(writeResult, resultPath) {
 
 function dispatchToAgy(opts, brief, run, writeResult) {
   const argv = buildArgv(opts, brief, run);
-  const timeoutMs = parseDuration(opts.printTimeout) ?? parseDuration(DEFAULT_PRINT_TIMEOUT);
+  const printTimeoutMs = parseDuration(opts.printTimeout) ?? parseDuration(DEFAULT_PRINT_TIMEOUT);
+  // An explicit --timeout wins over the default print-timeout-plus-grace: agy can hang well
+  // past its own print timeout, which is exactly the case the grace window cannot cover.
+  const watchdogMs = opts.timeout !== null ? parseDuration(opts.timeout) : printTimeoutMs + 60_000;
   // Antigravity's installer provides a native `agy` binary. Launch directly so
   // multi-line briefs and paths with spaces are passed as argv, not shell text.
   const child = spawn("agy", argv, {
@@ -363,7 +381,7 @@ function dispatchToAgy(opts, brief, run, writeResult) {
     sigkillTimer = setTimeout(() => {
       if (!settled) killChild(child, "SIGKILL");
     }, 10_000);
-  }, timeoutMs + 60_000);
+  }, watchdogMs);
 
   // The relay's own death must still produce a result: without this, a kill from the
   // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
@@ -458,7 +476,13 @@ function dispatchToAgy(opts, brief, run, writeResult) {
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
-      ...(watchdogFired ? { error: `agy did not exit within --print-timeout ${opts.printTimeout} plus 60s grace; killed by the relay watchdog` } : {}),
+      ...(watchdogFired
+        ? {
+            error: opts.timeout !== null
+              ? `agy did not finish within --timeout ${opts.timeout}; killed by the relay watchdog`
+              : `agy did not exit within --print-timeout ${opts.printTimeout} plus 60s grace; killed by the relay watchdog`,
+          }
+        : {}),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -15,10 +15,8 @@
  *                 native binary directly — a .cmd stand-in cannot represent them,
  *                 so the smoke compiles a real fake .exe with the C# compiler
  *                 that ships in-box with Windows (no install, no network) and
- *                 puts it on PATH under their names. agy's watchdog is
- *                 --print-timeout plus a fixed 60s grace, so its scenario is
- *                 the slow one (about a minute) on every platform. A POSIX
- *                 variant repeats each run with a parent that complies with
+ *                 puts it on PATH under their names. A POSIX variant repeats
+ *                 each run with a parent that complies with
  *                 SIGTERM while its grandchild ignores it — the sweep at close
  *                 must fell the survivor even though the parent's exit
  *                 cancelled the pending escalation timer.
@@ -553,12 +551,16 @@ for (const skill of SKILLS) {
 // ---- agy --timeout is validated before it can silently fire ----
 // parseDuration returns null for a malformed value, and setTimeout(fn, null) fires on the next
 // tick: an unvalidated flag would turn a typo into an instant, silent "timeout".
-for (const bad of ["NONSENSE", "0s", "", "10"]) {
+for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "600h"]) {
   const badRun = spawnSync(process.execPath,
     [relayPath("agy"), "--brief", briefPath, "--timeout", bad],
     { env: baseEnv, encoding: "utf8" });
   check(`agy timeout: "${bad}" is rejected`, badRun.status === 2);
 }
+const oversizedPrintTimeoutRun = spawnSync(process.execPath,
+  [relayPath("agy"), "--brief", briefPath, "--print-timeout", "600h"],
+  { env: baseEnv, encoding: "utf8" });
+check("agy timeout: an unschedulable derived watchdog is rejected", oversizedPrintTimeoutRun.status === 2);
 
 // ---- Qoder's documented print-mode argv and structured result ----
 {
@@ -878,8 +880,8 @@ for (const scenario of [
 }
 
 // ---- 1. the watchdog fells the whole tree ----
-// agy's watchdog flag is --print-timeout, and it always adds a fixed 60s grace on top,
-// so its run needs about a minute wherever it executes.
+// Use agy's explicit watchdog here: this is the path that bounds a server-side hang
+// beyond agy's own --print-timeout, and it keeps the shared smoke fast.
 const TIMEOUT_CASES = [
   { skill: "claude", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "codex", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
@@ -888,7 +890,7 @@ const TIMEOUT_CASES = [
   { skill: "kimi", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "qoder", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "vibe", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
-  { skill: "agy", flags: ["--print-timeout", "1s"], exitDeadline: 120_000 },
+  { skill: "agy", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
 ];
 async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag) {
   const outDir = join(scratch, `out-${tag}-${skill}`);
@@ -911,6 +913,9 @@ async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag)
     const r = result(outDir);
     check(`${skill} ${tag}: status is "timeout" (got ${r.status})`, r.status === "timeout");
     check(`${skill} ${tag}: relay exit code is non-zero`, r.exitCode !== 0);
+    if (skill === "agy") {
+      check("agy timeout: explicit limit is named in the result", r.error?.includes("--timeout 6s"));
+    }
   }
   check(`${skill} ${tag}: the implementer process is dead`,
     implementerPid !== null && await until(() => !alive(implementerPid), 20_000));

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -84,7 +84,8 @@ for (const skill of SKILLS) {
 // ---- one fake CLI, planted on PATH under every relay's binary name ----
 const FAKE = `const fs = require("node:fs");
 const args = process.argv.slice(2);
-if (args.includes("--version") && ["qoder-version-hang", "vibe-version-hang"].includes(process.env.SMOKE_MODE)) {
+if ((args.includes("--version") && ["qoder-version-hang", "vibe-version-hang"].includes(process.env.SMOKE_MODE))
+    || (args[0] === "changelog" && process.env.SMOKE_MODE === "agy-version-hang")) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
 } else if (args.includes("--version") && ["qoder-version-fail", "vibe-version-fail"].includes(process.env.SMOKE_MODE)) {
   console.error("fake version failure");
@@ -200,7 +201,8 @@ using System.IO;
 using System.Threading;
 class FakeCli {
   static int Main(string[] args) {
-    if (Array.IndexOf(args, "--version") >= 0 && (Environment.GetEnvironmentVariable("SMOKE_MODE") == "qoder-version-hang" || Environment.GetEnvironmentVariable("SMOKE_MODE") == "vibe-version-hang")) {
+    if ((Array.IndexOf(args, "--version") >= 0 && (Environment.GetEnvironmentVariable("SMOKE_MODE") == "qoder-version-hang" || Environment.GetEnvironmentVariable("SMOKE_MODE") == "vibe-version-hang"))
+        || (args.Length > 0 && args[0] == "changelog" && Environment.GetEnvironmentVariable("SMOKE_MODE") == "agy-version-hang")) {
       Thread.Sleep(Timeout.Infinite);
       return 1;
     }
@@ -562,6 +564,21 @@ for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h
     [relayPath("agy"), "--brief", briefPath, "--print-timeout", bad],
     { env: baseEnv, encoding: "utf8" });
   check(`agy print timeout: "${bad}" is rejected`, badRun.status === 2);
+}
+{
+  const outDir = join(scratch, "out-agy-version-hang");
+  const preflight = spawnSync(process.execPath, [
+    relayPath("agy"),
+    "--brief", briefPath,
+    "--out-dir", outDir,
+    "--timeout", "1s",
+  ], { env: { ...baseEnv, SMOKE_MODE: "agy-version-hang" }, encoding: "utf8", timeout: 5000 });
+  const value = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+  check("agy preflight: explicit watchdog bounds a hung version probe",
+    preflight.status === 124 &&
+    value.status === "timeout" &&
+    value.error?.includes("version preflight") &&
+    value.error?.includes("was not dispatched"));
 }
 
 // ---- Qoder's documented print-mode argv and structured result ----

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -557,10 +557,12 @@ for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "600h
     { env: baseEnv, encoding: "utf8" });
   check(`agy timeout: "${bad}" is rejected`, badRun.status === 2);
 }
-const oversizedPrintTimeoutRun = spawnSync(process.execPath,
-  [relayPath("agy"), "--brief", briefPath, "--print-timeout", "600h"],
-  { env: baseEnv, encoding: "utf8" });
-check("agy timeout: an unschedulable derived watchdog is rejected", oversizedPrintTimeoutRun.status === 2);
+for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h30m24s", "600h"]) {
+  const badRun = spawnSync(process.execPath,
+    [relayPath("agy"), "--brief", briefPath, "--print-timeout", bad],
+    { env: baseEnv, encoding: "utf8" });
+  check(`agy print timeout: "${bad}" is rejected`, badRun.status === 2);
+}
 
 // ---- Qoder's documented print-mode argv and structured result ----
 {
@@ -914,7 +916,11 @@ async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag)
     check(`${skill} ${tag}: status is "timeout" (got ${r.status})`, r.status === "timeout");
     check(`${skill} ${tag}: relay exit code is non-zero`, r.exitCode !== 0);
     if (skill === "agy") {
-      check("agy timeout: explicit limit is named in the result", r.error?.includes("--timeout 6s"));
+      const timeoutIndex = flags.indexOf("--timeout");
+      const expectedLimit = timeoutIndex === -1
+        ? `--print-timeout ${flags[flags.indexOf("--print-timeout") + 1]} plus 60s grace`
+        : `--timeout ${flags[timeoutIndex + 1]}`;
+      check(`agy ${tag}: selected limit is named in the result`, r.error?.includes(expectedLimit));
     }
   }
   check(`${skill} ${tag}: the implementer process is dead`,
@@ -927,6 +933,12 @@ async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag)
 for (const tc of TIMEOUT_CASES) {
   await driveTimeout(tc, "timeout", {}, "timeout");
 }
+await driveTimeout(
+  { skill: "agy", flags: ["--print-timeout", "1s", "--timeout", "4s"], exitDeadline: 45_000 },
+  "timeout",
+  {},
+  "timeout-precedence",
+);
 
 // A compliant parent must not shield a defiant descendant: the parent exits on the group
 // SIGTERM, its grandchild ignores it, and the sweep at close must still fell the grandchild

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -299,6 +299,16 @@ check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
 // opencode refuses a fresh run without an explicit model
 const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [] };
 
+// ---- agy --timeout is validated before it can silently fire ----
+// parseDuration returns null for a malformed value, and setTimeout(fn, null) fires on the next
+// tick: an unvalidated flag would turn a typo into an instant, silent "timeout".
+for (const bad of ["NONSENSE", "0s", "", "10"]) {
+  const badRun = spawnSync(process.execPath,
+    [relayPath("agy"), "--brief", briefPath, "--timeout", bad],
+    { env: baseEnv, encoding: "utf8" });
+  check(`agy timeout: "${bad}" is rejected`, badRun.status === 2);
+}
+
 // ---- Qoder's documented print-mode argv and structured result ----
 {
   const outDir = join(scratch, "out-success-qoder");


### PR DESCRIPTION
## Problem

The agy relay's watchdog is derived: `--print-timeout` plus a fixed 60s grace. That assumes agy always honors its own print timeout — and it does not always. Driving multi-round consultations through this relay I have had conversations hang server-side well past the print timeout (agy's own log showing the stream never completing), which a fixed grace window can't bound.

Every other relay already exposes `--timeout` for this. This closes the gap rather than inventing a mechanism.

## Change

- `--timeout <dur>` overrides the derived watchdog. Omit it and behavior is unchanged.
- The value is validated at parse time. This matters more than usual here: `parseDuration` returns `null` for a malformed value and `setTimeout(fn, null)` fires on the **next tick**, so an unvalidated flag turns a typo into an instant, silent `"timeout"` — the worst failure mode a watchdog has. Zero is rejected for the same reason.
- The `timeout` error message names whichever limit actually fired.

## Tests

Four assertions covering the rejected forms (`NONSENSE`, `0s`, empty, and a bare `10` — worth rejecting explicitly since `--print-timeout` takes Go durations and a bare number there makes agy dump its help and exit 2). Existing agy timeout/abort assertions still green; full suite green locally on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a relay-side `--timeout <dur>` watchdog (h/m/s format) that enforces an independent upper bound from `--print-timeout`.
  * On expiry, the relay kills the full `agy` process tree and writes `status: "timeout"` to `result.json`, with improved error details to differentiate explicit vs derived timeouts.

* **Bug Fixes**
  * Tightened duration parsing/validation for both `--timeout` and `--print-timeout`, including unit-order and range checks.

* **Tests**
  * Expanded relay smoke tests for malformed inputs, version-hang bounded behavior, timeout precedence, and timeout-limit error-message accuracy.

* **Documentation**
  * Clarified `dispatch-and-poll.md` timeout semantics and interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->