### PR TITLE
feat(codex): add opt-in inherited environment filtering

### DIFF
--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -39,6 +39,7 @@ Options:
 | `--sandbox <mode>` | `read-only` \| `workspace-write` \| `danger-full-access` (default: `workspace-write`). |
 | `--read-only` | Shortcut for `--sandbox read-only` — review/diagnosis with no edits. |
 | `--resume-last` | Continue the most recent Codex session; send only the delta brief (see review-and-land). |
+| `--clean-env` | Launch Codex (and the version preflight) with a minimal environment — PATH, HOME, locale, temp, `CODEX_HOME` — instead of the caller's whole shell profile, so unrelated credentials never reach the implementer. Also passes `-c mcp_servers={}` for the run: configured MCP servers burn tokens and can hang at startup under a minimal environment. |
 | `--skip-git-repo-check` | Allow running outside a git repo. |
 | `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
 | `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -52,10 +52,11 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 
 `--clean-env` is not a broader security boundary: Codex can still access files and other same-user
 secrets available through `HOME`, `CODEX_HOME`, OS facilities, and the selected sandbox. File- or
-OS-backed auth and normal configuration still load, but environment-backed auth (`CODEX_API_KEY`,
-`OPENAI_API_KEY`, or `CODEX_ACCESS_TOKEN`) and provider, proxy, certificate, or MCP settings that
-reference a stripped variable need that variable named with `--keep-env`. The same filtered
-environment is used for preflight and dispatch.
+OS-backed auth and normal configuration still load, but direct environment-backed auth
+(`CODEX_API_KEY` or `CODEX_ACCESS_TOKEN`) needs that variable named with `--keep-env`.
+`OPENAI_API_KEY` can still matter as a custom-provider credential; provider, proxy, certificate, or
+MCP settings that reference any stripped variable likewise need it named with `--keep-env`. The same
+filtered environment is used for preflight and dispatch.
 
 ## The result
 

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -35,6 +35,12 @@
  *   --read-only             Shortcut for --sandbox read-only (review/diagnosis, no edits).
  *   --resume-last           Continue the most recent Codex session; send only the delta brief.
  *                           (Inherits the original session's sandbox and working root.)
+ *   --clean-env             Launch codex (and the version preflight) with a minimal environment
+ *                           - PATH, HOME, locale, temp, CODEX_HOME - instead of inheriting every
+ *                           variable in the caller's shell. Keeps unrelated credentials out of
+ *                           the implementer process. Also passes -c mcp_servers={} for the run:
+ *                           configured MCP servers are token consumers and can hang at startup
+ *                           under a minimal environment.
  *   --skip-git-repo-check   Allow running outside a git repository.
  *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
  *                           strings like 30m or 2h. On expiry the codex child is killed
@@ -83,6 +89,7 @@ function parseArgs(argv) {
     sandbox: "workspace-write",
     resumeLast: false,
     skipGitRepoCheck: false,
+    cleanEnv: false,
     timeout: null,
     outDir: null,
   };
@@ -108,6 +115,7 @@ function parseArgs(argv) {
       case "--read-only": opts.sandbox = "read-only"; break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--skip-git-repo-check": opts.skipGitRepoCheck = true; break;
+      case "--clean-env": opts.cleanEnv = true; break;
       case "--timeout": opts.timeout = next(); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       default:
@@ -133,6 +141,20 @@ function parseDuration(duration) {
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
   return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+}
+
+function minimalEnv() {
+  // --clean-env: enough for codex to run and read its own auth, nothing else. An orchestrator's
+  // shell profile routinely holds cloud and provider credentials that the delegated task has no
+  // use for; this keeps them out of the child process.
+  const keep = ["PATH", "HOME", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "LC_CTYPE", "TERM",
+    "TMPDIR", "CODEX_HOME", "NO_COLOR", "SystemRoot", "SystemDrive", "USERPROFILE", "APPDATA",
+    "LOCALAPPDATA", "TEMP", "TMP", "PATHEXT", "COMSPEC"];
+  const env = {};
+  for (const key of keep) {
+    if (process.env[key] !== undefined) env[key] = process.env[key];
+  }
+  return env;
 }
 
 function killChild(child, signal = "SIGTERM") {
@@ -181,13 +203,15 @@ function readBrief(opts) {
   return stdin;
 }
 
-function codexVersion() {
+function codexVersion(cleanEnv) {
   try {
     // On Windows, npm installs `codex` as a .cmd shim; Node's CreateProcess only
     // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
     // ENOENTs on a working install. POSIX is unaffected. (git installs a real
     // git.exe and must NOT get this flag — see gitTouchedFiles.)
-    return execFileSync("codex", ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
+    // The preflight launches the same binary, so --clean-env has to cover it too - otherwise
+    // the full environment reaches codex before dispatch even runs.
+    return execFileSync("codex", ["--version"], { encoding: "utf8", shell: process.platform === "win32", env: cleanEnv ? minimalEnv() : process.env }).trim();
   } catch {
     return null;
   }
@@ -228,6 +252,9 @@ function buildArgv(opts, finalPath) {
   // `-c` is accepted by `exec resume` (unlike `-s`/`-C`), so the effort override
   // applies to fresh and resumed runs alike.
   if (opts.effort !== null) argv.push("-c", `model_reasoning_effort=${opts.effort}`);
+  // --clean-env is hermetic: MCP servers are token consumers and can hang at startup under a
+  // minimal environment, so disable them for the run.
+  if (opts.cleanEnv) argv.push("-c", "mcp_servers={}");
   if (opts.skipGitRepoCheck) argv.push("--skip-git-repo-check");
   argv.push("-"); // read the prompt from stdin
   return argv;
@@ -284,6 +311,7 @@ function makeResultWriter(opts, version, run) {
       model: opts.model,
       effort: opts.effort,
       resumeLast: opts.resumeLast,
+      cleanEnv: opts.cleanEnv,
       codexVersion: version,
       startedAt: run.startedAt,
       finishedAt: new Date().toISOString(),
@@ -310,7 +338,7 @@ function dispatchToCodex(opts, brief, run, writeResult) {
   // the brief is fed via child.stdin below — never argv — and argv holds only
   // sandbox enums, model names, the pattern-checked effort, and file paths.
   // detached on POSIX: the child leads a new process group so killChild can fell the whole tree
-  const child = spawn("codex", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32", detached: process.platform !== "win32" });
+  const child = spawn("codex", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32", detached: process.platform !== "win32", env: opts.cleanEnv ? minimalEnv() : process.env });
 
   let threadId = null;
   let stdoutBuf = "";
@@ -450,7 +478,7 @@ function main() {
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
 
-  const version = codexVersion();
+  const version = codexVersion(opts.cleanEnv);
   const run = prepareRunDir(opts, brief);
   const writeResult = makeResultWriter(opts, version, run);
 

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -95,8 +95,18 @@ if (args.includes("--version") && process.env.SMOKE_MODE === "qoder-version-hang
   console.log("fake-cli 0.0.0-smoke");
   process.exit(0);
 }
+// A relay may deliberately strip the environment (codex --clean-env), which would also strip
+// the SMOKE_* control variables. Fall back to a config file planted next to this fake so the
+// harness can still drive it — and so stripping itself stays observable.
+if (!process.env.SMOKE_MODE) {
+  try {
+    const fallback = JSON.parse(fs.readFileSync(require("path").join(__dirname, "smoke-fallback.json"), "utf8"));
+    for (const key of Object.keys(fallback)) if (!process.env[key]) process.env[key] = fallback[key];
+  } catch { /* no fallback planted */ }
+}
 if (process.env.SMOKE_MODE === "capture") {
   fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
+  if (process.env.SMOKE_ENV_FILE) fs.writeFileSync(process.env.SMOKE_ENV_FILE, JSON.stringify(process.env));
   process.exit(0);
 }
 if (process.env.SMOKE_MODE === "qoder-success") {
@@ -298,6 +308,37 @@ check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
 
 // opencode refuses a fresh run without an explicit model
 const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [] };
+
+// ---- codex --clean-env keeps unrelated credentials out of the child ----
+const cleanEnvOutDir = join(scratch, "out-cleanenv-codex");
+const cleanEnvArgsFile = join(scratch, "args-cleanenv-codex");
+const cleanEnvWorkDir = freshRepo("work-cleanenv-codex");
+const cleanEnvEnvFile = join(scratch, "env-cleanenv-codex");
+const fallbackPath = join(shimDir, "smoke-fallback.json");
+writeFileSync(fallbackPath, JSON.stringify({ SMOKE_MODE: "capture", SMOKE_ARGS_FILE: cleanEnvArgsFile, SMOKE_ENV_FILE: cleanEnvEnvFile }));
+const cleanEnvRun = spawnSync(process.execPath,
+  [relayPath("codex"), "--brief", briefPath, "--cd", cleanEnvWorkDir, "--out-dir", cleanEnvOutDir, "--clean-env"],
+  { env: { ...baseEnv, SMOKE_SECRET_TOKEN: "must-not-leak" }, encoding: "utf8" });
+rmSync(fallbackPath, { force: true });
+const cleanEnvCapture = existsSync(cleanEnvEnvFile) ? JSON.parse(readFileSync(cleanEnvEnvFile, "utf8")) : null;
+check("codex clean-env: the run completes", cleanEnvRun.status === 0);
+check("codex clean-env: an unrelated variable does not reach the child",
+  cleanEnvCapture !== null && cleanEnvCapture.SMOKE_SECRET_TOKEN === undefined);
+check("codex clean-env: PATH and HOME still reach the child",
+  cleanEnvCapture !== null && typeof cleanEnvCapture.PATH === "string" && cleanEnvCapture.PATH.length > 0);
+check("codex clean-env: disables MCP servers for the run", (() => {
+  const a = existsSync(cleanEnvArgsFile) ? JSON.parse(readFileSync(cleanEnvArgsFile, "utf8")) : [];
+  return a.some((v, i) => v === "-c" && a[i + 1] === "mcp_servers={}");
+})());
+check("codex clean-env: recorded in result.json",
+  existsSync(join(cleanEnvOutDir, "result.json")) && result(cleanEnvOutDir).cleanEnv === true);
+const inheritEnvFile = join(scratch, "env-inherit-codex");
+spawnSync(process.execPath,
+  [relayPath("codex"), "--brief", briefPath, "--cd", freshRepo("work-inherit-codex"), "--out-dir", join(scratch, "out-inherit-codex")],
+  { env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: join(scratch, "args-inherit-codex"), SMOKE_ENV_FILE: inheritEnvFile, SMOKE_SECRET_TOKEN: "inherited" }, encoding: "utf8" });
+const inheritCapture = existsSync(inheritEnvFile) ? JSON.parse(readFileSync(inheritEnvFile, "utf8")) : null;
+check("codex clean-env: control - without the flag the variable is inherited",
+  inheritCapture !== null && inheritCapture.SMOKE_SECRET_TOKEN === "inherited");
 
 // ---- Qoder's documented print-mode argv and structured result ----
 {


### PR DESCRIPTION
**Claim:** `--clean-env` filters inherited environment variables for both the Codex version preflight and dispatch. It is not a filesystem or same-user secret boundary and does not disable loaded configuration or configured MCP servers. Repeatable `--keep-env <name>` retains explicitly required variables.

**What ran:** macOS 26.5.2, Node 22.22.0, Codex 0.146.0.

- `node --check skills/codex-delegate/scripts/relay.mjs`
- `node --check test/fixtures/fake-cli.cjs`
- `node --check test/relay/codex.mjs`
- `node --check test/relay-smoke.mjs`
- `git diff --check`
- `node test/relay-smoke.mjs --only codex`
- `node test/relay-smoke.mjs`
- `node test/relay-parity.mjs`
- `node test/relay-isolated.mjs`
- `npx skills add . --list`
- `docker run --rm -v "$PWD:/repo:ro" -w /repo node:22-bookworm node test/relay-smoke.mjs --only codex`
- Real Codex relay probe with `--clean-env --read-only --timeout 2m` against a throwaway repository: `status: completed`, `touchedFiles: []`.
- Independent spec/correctness and standards/security reviews: PASS.

Exact-head GitHub Actions [run 256](https://github.com/amElnagdy/delegate-skills/actions/runs/31300171919) passed the full Node 22 smoke on Ubuntu and native Windows. Native Windows live Codex dispatch, custom-provider authentication, proxies/certificates, and configured MCP startup were not exercised; their environment forwarding is covered by the focused fake-CLI smoke.

## Change

Original implementation by @webdivs. Maintainer follow-up merged current `master` non-destructively and ported the behavior to the current relay and split smoke harness.

- `--clean-env` passes only runtime basics to both `codex --version` and dispatch.
- Repeatable `--keep-env <name>` preserves an explicitly required environment-backed auth, provider, proxy, certificate, or MCP variable. Names are validated and must be set.
- Without `--clean-env`, behavior is unchanged.
- `result.json` records `cleanEnv` and kept variable names, never values.
- The earlier `-c mcp_servers={}` override was removed: current Codex merges that empty table with configured servers, so it did not disable them.

## Boundary

This filters inherited environment variables only. It does not protect files or other same-user secrets; Codex still has the access allowed by `HOME`, `CODEX_HOME`, OS facilities, and the selected sandbox. File- and OS-backed auth and normal config files still load. Direct environment-backed auth (`CODEX_API_KEY` or `CODEX_ACCESS_TOKEN`) requires `--keep-env`; `OPENAI_API_KEY` can still matter as a custom-provider credential. Provider, proxy, certificate, or MCP configuration that refers to any stripped variable likewise requires `--keep-env`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--clean-env` to run delegated tasks with a filtered environment.
  * Added repeatable `--keep-env` options for explicitly retaining required environment variables.
  * Applied environment filtering consistently during version checks and task execution.
  * Added environment settings to result metadata.

* **Documentation**
  * Documented environment filtering, retained variables, credential handling, and configuration limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->