### PR TITLE
Add cursor-delegate: delegate to the Cursor Agent CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Seven skills ship today: `claude-delegate` (Claude Code), `codex-delegate` (OpenAI
+and land the result. Eight skills ship today: `claude-delegate` (Claude Code), `codex-delegate` (OpenAI
 Codex), `opencode-delegate` (OpenCode), `agy-delegate` (Google Antigravity), `grok-delegate` (Grok
-Build), `kimi-delegate` (Kimi Code), and `qoder-delegate` (Qoder CLI); siblings like
-`gemini-delegate` can be added later without renaming the repo.
+Build), `kimi-delegate` (Kimi Code), `qoder-delegate` (Qoder CLI), and `cursor-delegate` (Cursor Agent
+CLI); siblings like `gemini-delegate` can be added later without renaming the repo.
 
 ## Vocabulary
 
@@ -27,6 +27,7 @@ jargon. Use these terms; don't invent synonyms.
 | `project`, `conversation`, `model`, `permissions`, `sandbox`, `TUI`, `tasks`, `subagents` | Antigravity's own terms — use verbatim when discussing `agy` | don't use `subagents` as a generic synonym for implementer |
 | `session`, `sandbox` (`workspace`/`read-only`/`off`), `permission-mode`, `effort`, `streaming-json` | Grok Build's own terms — use verbatim when discussing `grok` | don't paraphrase them |
 | `session`, `--continue`, `model alias`, `auto permission mode`, `plan mode`, `--yolo` | Kimi Code's own terms — use verbatim when discussing `kimi` | don't paraphrase them |
+| `session`, `--continue`, `--resume`, `plan mode`, `--force`, `--trust`, `models` | Cursor Agent's own terms — use verbatim when discussing `cursor-agent` | don't paraphrase them |
 | `session`, `--continue`, `--resume`, `permission mode` (`acceptEdits`/`plan`/`bypassPermissions`), `sandbox`, `subagents`, `agent teams`, `background sessions` | Claude Code's own terms — use verbatim when discussing Claude | never use `subagents` as a generic synonym for implementer |
 | `session`, `-c`, `--resume`, `permission mode` (`default`/`accept_edits`/`auto`/`bypass_permissions`/`dont_ask`/`plan`), `print mode`, `stream-json`, `model`, `context window` | Qoder CLI's own terms — use verbatim when discussing Qoder | don't paraphrase them |
 
@@ -34,7 +35,7 @@ Banned on sight: coined umbrella terms in user-facing surfaces (README headings,
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
 version-neutral); and claims that can't be verified ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
-`codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli`) and the skill's `relay.mjs`.
+`codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `cursor-agent`) and the skill's `relay.mjs`.
 
 ## Conventions
 
@@ -51,8 +52,9 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   when needed.
 - **Executables:** keep them minimal and inspectable. Today there is one per skill — a
   `scripts/relay.mjs` under each of `skills/claude-delegate/`, `skills/codex-delegate/`,
-  `skills/opencode-delegate/`, `skills/agy-delegate/`, `skills/grok-delegate/`, and
-  `skills/kimi-delegate/`, and `skills/qoder-delegate/` — each Node built-ins only, no dependencies,
+  `skills/opencode-delegate/`, `skills/agy-delegate/`, `skills/grok-delegate/`,
+  `skills/kimi-delegate/`, `skills/qoder-delegate/`, and `skills/cursor-delegate/` — each Node
+  built-ins only, no dependencies,
   no network calls of its own, no credentials, no telemetry. New scripts must hold the same line,
   and the README's trust section must stay accurate.
 
@@ -64,8 +66,9 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
   PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, and `grok` launches need
   `shell:true` on win32 to resolve the `.cmd` shim (which is why their spaceable args are quoted and
-  value flags token-validated); the `claude` launch resolves a native `.exe` or separately serializes
-  a `.cmd` shim; `agy`, `kimi`, and current `qodercli` installs use native binaries. Each changed
+  value flags token-validated); the `claude` and `cursor-agent` launches serialize a pre-joined
+  command string through the shell on win32 for the same shim reason; `agy`, `kimi`, and current
+  `qodercli` installs use native binaries. Each changed
   launch still needs its own Windows smoke before claiming support.
 - Keep the README's "Verification status" honest — claim only what's been run.
 

--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ This package is intentionally inspectable:
   `--session <id>` resume applying a delta brief in the same session; usage errors exiting 2 without
   a result file). The shared relay-smoke suite covers model/session/add-directory forwarding,
   `--no-force`, usage, bounded version preflight, atomic artifacts, and timeout/abort handling, and
-  is configured in CI on Linux and Windows. A native macOS plan-mode smoke against the same version
-  completed with model/session/usage capture and no touched files; a native Linux run is unverified.
+  is configured in CI on Linux and Windows. A maintainer-run native macOS plan-mode smoke against
+  the same version completed with model/session/usage capture and no touched files; a native Linux
+  run is unverified.
 - `vibe-delegate` — contract-tested for launch-mode, resume, tool-filter, and turn/price/token
   forwarding; bounded version preflight; result parsing; and whole-process-tree timeout/abort
   cleanup. A live Vibe run and native Windows launch are unverified.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Nine skills ship today — same loop, different implementer:
 | `grok-delegate` | Grok Build CLI (`grok`) | explicit: default workspace-scoped, `--read-only` best-effort with violation detection, `--full-access` opt-in | `--resume-last`, `--session <id>` |
 | `kimi-delegate` | Kimi Code CLI (`kimi`) | headless runs always use Kimi's auto permission mode | `--resume-last`, `--session <id>` |
 | `qoder-delegate` | [Qoder CLI](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` default; bypass is opt-in; effective mode is reported | `--resume-last`, `--resume <id>` |
-| `cursor-delegate` | [Cursor Agent CLI](https://cursor.com/cli) (`cursor-agent`) | `--force` write default; `--read-only` is Cursor's plan mode with a violation tripwire; `--trust` always | `--resume-last`, `--session <id>` |
+| `cursor-delegate` | [Cursor Agent CLI](https://cursor.com/cli) (`cursor-agent`) | `--force` write default; `--no-force` withholds command approval; `--read-only` selects plan mode; `--trust` always | `--resume-last`, `--session <id>` |
 | `vibe-delegate` | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits` default; `--full-access` selects `auto-approve`; `--plan-only` selects `plan` | `--resume-last`, `--session <id>` |
 
 ## Install
@@ -132,11 +132,10 @@ relay records both the requested and effective modes.
 
 Same loop for the Cursor Agent CLI (`cursor-agent`). The brief rides stdin (no process-list
 exposure, no argv-size cap). A fresh run is write-capable with `--force` — Cursor runs commands
-without approval unless the user's Cursor config denies them — and `--read-only` switches to
-Cursor's plan mode, backed by a porcelain tripwire that flags `readOnlyViolation: true` if a
-read-only run wrote anyway. The relay always passes `--trust`, so `--cd` must only point at
-repositories the user trusts. The model Cursor actually served and the permission mode it applied
-are recorded in `result.json` as `resolvedModel` and `permissionMode`.
+without approval unless the user's Cursor config denies them. `--no-force` withholds automatic
+command approval while retaining file edits, and `--read-only` switches to Cursor's plan mode. The
+relay always passes `--trust`, so `--cd` must only point at repositories the user trusts. The model
+Cursor actually served, permission mode, and usage are recorded in `result.json`.
 
 ### vibe-delegate
 
@@ -179,6 +178,7 @@ bundled `relay.mjs` is the default because it needs nothing but the `codex` bina
   [`kimi`](https://moonshotai.github.io/kimi-code/en/) (`brew install kimi-code`, then `kimi login`) ·
   [`qodercli`](https://docs.qoder.com/en/cli/quick-start) (`qodercli login`, or
   `QODER_PERSONAL_ACCESS_TOKEN` for automation) ·
+  [`cursor-agent`](https://cursor.com/cli) (`cursor-agent login`) ·
   [`vibe`](https://github.com/mistralai/mistral-vibe) ([install `uv`](https://docs.astral.sh/uv/getting-started/installation/),
   then run `uv tool install mistral-vibe` and configure `MISTRAL_API_KEY`).
 - Node 18+ and `git`.
@@ -198,7 +198,7 @@ This package is intentionally inspectable:
 
 **Verification status** — claims here are backed by runs, not assumptions:
 
-- The five previously shipped relays' mechanics are verified: argument handling, exit codes,
+- The previously shipped relays' mechanics are verified: argument handling, exit codes,
   `result.json`, resume, signal reporting, and the implementer-specific guards.
 - `claude-delegate` — verified end-to-end on macOS against `claude` 2.1.220 (write run under
   `acceptEdits`; plan mode refusing an edit, with the porcelain tripwire true on a violation and false
@@ -217,12 +217,13 @@ This package is intentionally inspectable:
   macOS by the contributor against `qodercli` 1.0.47 (Lite edit run, `accept_edits`, explicit model
   and 32768-token context window, no commit).
 - `opencode-delegate` — requires `--model`, since OpenCode has no safe default.
-- `cursor-delegate` — verified end-to-end on Windows against a current `cursor-agent` (write run
-  under `--force` editing real files; plan-mode `--read-only` run touching nothing, with the
-  porcelain tripwire false on the clean run; `--session <id>` resume applying a delta brief in the
-  same session; usage errors exiting 2 without a result file). CI drives its launch, timeout, and
-  abort paths against a stand-in binary on Linux and Windows; a native macOS/Linux launch of the
-  real CLI is designed-for but not yet run.
+- `cursor-delegate` — verified end-to-end on Windows against `cursor-agent` 2026.07.23-e383d2b (write run
+  under `--force` editing real files; plan-mode `--read-only` run touching nothing;
+  `--session <id>` resume applying a delta brief in the same session; usage errors exiting 2 without
+  a result file). The shared relay-smoke suite covers model/session/add-directory forwarding,
+  `--no-force`, usage, bounded version preflight, atomic artifacts, and timeout/abort handling, and
+  is configured in CI on Linux and Windows. A native macOS plan-mode smoke against the same version
+  completed with model/session/usage capture and no touched files; a native Linux run is unverified.
 - `vibe-delegate` — contract-tested for launch-mode, resume, tool-filter, and turn/price/token
   forwarding; bounded version preflight; result parsing; and whole-process-tree timeout/abort
   cleanup. A live Vibe run and native Windows launch are unverified.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Skills for **delegating coding work to a separate CLI agent and landing it yours
 orchestrator) writes a self-contained brief, dispatches it to an implementer CLI, then reviews the diff
 and commits — staying the reviewer the whole way.
 
-Seven skills ship today — same loop, different implementer:
+Eight skills ship today — same loop, different implementer:
 
 | Skill | Drives | Autonomy | Resume |
 | --- | --- | --- | --- |
@@ -17,6 +17,7 @@ Seven skills ship today — same loop, different implementer:
 | `grok-delegate` | Grok Build CLI (`grok`) | explicit: default workspace-scoped, `--read-only` best-effort with violation detection, `--full-access` opt-in | `--resume-last`, `--session <id>` |
 | `kimi-delegate` | Kimi Code CLI (`kimi`) | headless runs always use Kimi's auto permission mode | `--resume-last`, `--session <id>` |
 | `qoder-delegate` | [Qoder CLI](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` default; bypass is opt-in; effective mode is reported | `--resume-last`, `--resume <id>` |
+| `cursor-delegate` | [Cursor Agent CLI](https://cursor.com/cli) (`cursor-agent`) | `--force` write default; `--read-only` is Cursor's plan mode with a violation tripwire; `--trust` always | `--resume-last`, `--session <id>` |
 
 ## Install
 
@@ -126,6 +127,16 @@ models that support explicit sizing. Non-interactive runs use Qoder's `auto` per
 default; bypass remains opt-in. Qoder falls back to `default` outside a trusted directory, so the
 relay records both the requested and effective modes.
 
+### cursor-delegate
+
+Same loop for the Cursor Agent CLI (`cursor-agent`). The brief rides stdin (no process-list
+exposure, no argv-size cap). A fresh run is write-capable with `--force` — Cursor runs commands
+without approval unless the user's Cursor config denies them — and `--read-only` switches to
+Cursor's plan mode, backed by a porcelain tripwire that flags `readOnlyViolation: true` if a
+read-only run wrote anyway. The relay always passes `--trust`, so `--cd` must only point at
+repositories the user trusts. The model Cursor actually served and the permission mode it applied
+are recorded in `result.json` as `resolvedModel` and `permissionMode`.
+
 ### gemini-delegate
 
 *Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
@@ -193,7 +204,14 @@ This package is intentionally inspectable:
   macOS by the contributor against `qodercli` 1.0.47 (Lite edit run, `accept_edits`, explicit model
   and 32768-token context window, no commit).
 - `opencode-delegate` — requires `--model`, since OpenCode has no safe default.
-- Windows: the codex/opencode launches handle the `.cmd` shim (`shell:true` + quoting); the Qoder
+- `cursor-delegate` — verified end-to-end on Windows against a current `cursor-agent` (write run
+  under `--force` editing real files; plan-mode `--read-only` run touching nothing, with the
+  porcelain tripwire false on the clean run; `--session <id>` resume applying a delta brief in the
+  same session; usage errors exiting 2 without a result file). CI drives its launch, timeout, and
+  abort paths against a stand-in binary on Linux and Windows; a native macOS/Linux launch of the
+  real CLI is designed-for but not yet run.
+- Windows: the codex/opencode launches handle the `.cmd` shim (`shell:true` + quoting); the cursor
+  launch serializes a pre-joined, quoted command string through the shell for the same shim; the Qoder
   relay targets its currently documented native `qodercli.exe`. Native Windows launch smokes for
   `claude`/`agy`/`grok`/`kimi`/`qoder` are still pending. Claude's own shell sandbox is unsupported on
   native Windows regardless of launch mechanics.

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -12,7 +12,8 @@
         "grok-delegate",
         "kimi-delegate",
         "qoder-delegate",
-        "vibe-delegate"
+        "vibe-delegate",
+        "cursor-delegate"
       ]
     }
   ]

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   through Cursor while staying the reviewer. DO NOT USE for tasks small enough to do inline, or when
   the user wants the code written directly without delegating.
 license: MIT
-compatibility: Requires the `cursor-agent` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+compatibility: Requires the `cursor-agent` CLI installed and authenticated, Node 18+, and git. The optional `--add-dir` flag requires cursor-agent 2026.07.23 or newer. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
   version: 0.1.0
 ---
@@ -30,9 +30,9 @@ The loop needs only a shell command and file access, so any comparable orchestra
 
 ## Prerequisites (check once)
 
-1. `cursor-agent --version` succeeds. If not, install the Cursor CLI
-   (`curl https://cursor.com/install -fsS | bash` on macOS/Linux, the PowerShell installer from
-   [cursor.com/cli](https://cursor.com/cli) on Windows) and authenticate with `cursor-agent login`.
+1. `cursor-agent --version` succeeds. If not, follow the installer for your platform at
+   [cursor.com/cli](https://cursor.com/cli), inspect what it will run, and authenticate with
+   `cursor-agent login`.
 2. `cursor-agent status` shows you logged in.
 3. You are in (or will point `--cd` at) the target git repository. The relay passes `--trust`, so
    point it only at repositories you trust.
@@ -65,6 +65,7 @@ this `SKILL.md`.)
 ```bash
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # read-only (plan mode — review/diagnosis, no edits):  add --read-only
+# write-capable without automatic command approval:   add --no-force
 # pin a model from `cursor-agent models`:              add --model <name>
 # resume the most recent session:                      add --resume-last  (delta brief only)
 # resume a specific session:                           add --session <id> (delta brief only)
@@ -72,9 +73,10 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # see all options:                                     node .../relay.mjs --help
 ```
 
-The child process's cwd pins the workspace. Use repeatable `--add-dir` flags only for extra
-workspace directories. The relay writes artifacts under the system temp dir by default and never
-commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+The child process's cwd pins the workspace. On Cursor `2026.07.23` or newer, use repeatable
+`--add-dir` flags only for extra workspace directories. The relay writes artifacts under the system
+temp dir by default and never commits. See
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
 
 ### 3. Wait for completion
 
@@ -113,12 +115,12 @@ pass and the diff holds. If rework is needed, send a delta brief with `--resume-
 
 A fresh run defaults to **write-capable with `--force`**: Cursor runs commands without approval
 unless your Cursor config explicitly denies them, so ordinary gates (tests, linters, builds) run
-headlessly. `--read-only` switches to Cursor's **plan mode** (read-only analysis, no edits, no
-`--force`); the relay also snapshots the tree before dispatch and flags `readOnlyViolation: true` in
-`result.json` if a read-only run changed it anyway — verify that flag and `touchedFiles` came back
-clean instead of assuming. The relay always passes `--trust` to keep headless runs from stalling on
-the workspace-trust prompt, which is why `--cd` must only ever point at repositories you trust. The
-permission mode Cursor actually applied is recorded as `permissionMode` in `result.json`.
+headlessly. `--no-force` keeps the run write-capable but withholds automatic command approval;
+commands that require approval are refused because a headless run cannot prompt. `--read-only`
+switches to Cursor's **plan mode** (read-only analysis, no edits, no `--force`). The relay always
+passes `--trust` to keep headless runs from stalling on the workspace-trust prompt, which is why
+`--cd` must only ever point at repositories you trust. The permission mode Cursor actually applied
+is recorded as `permissionMode` in `result.json`; inspect `touchedFiles` and the diff after every run.
 
 ## Read-only second opinions
 

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: cursor-delegate
+description: >-
+  Delegate a coding task to the Cursor Agent CLI (`cursor-agent`) as a background implementer, then
+  review its diff and land it yourself. Use this whenever the user wants to hand implementation work
+  to Cursor — phrasings like "have Cursor implement X", "delegate this to Cursor", "run it through
+  Cursor Agent", or "use Cursor to implement/fix/refactor" — or wants to run a queue of coding tasks
+  through Cursor while staying the reviewer. DO NOT USE for tasks small enough to do inline, or when
+  the user wants the code written directly without delegating.
+license: MIT
+compatibility: Requires the `cursor-agent` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.1.0
+---
+
+# Cursor Delegate
+
+You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** — the Cursor
+Agent CLI — then review what it produced and land it yourself. You write the brief and own the
+judgment; Cursor does the typing in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `cursor-agent` CLI is not installed or authenticated (run `cursor-agent login`).
+- You want to write the code yourself, or you only need Cursor's opinion on code you wrote (a
+  `--read-only` dispatch covers that — see below — but a plain review may not need delegation at all).
+
+## Prerequisites (check once)
+
+1. `cursor-agent --version` succeeds. If not, install the Cursor CLI
+   (`curl https://cursor.com/install -fsS | bash` on macOS/Linux, the PowerShell installer from
+   [cursor.com/cli](https://cursor.com/cli) on Windows) and authenticate with `cursor-agent login`.
+2. `cursor-agent status` shows you logged in.
+3. You are in (or will point `--cd` at) the target git repository. The relay passes `--trust`, so
+   point it only at repositories you trust.
+
+## Choose the model
+
+Omitting `--model` uses your Cursor default (usually `auto` — Cursor picks). To pin one, pass
+`--model <name>` with a name from the account's live `cursor-agent models` output — select from that
+list rather than inventing a name. Parameterized forms like `<name>[context=1m,effort=high]` are
+forwarded as-is. The model that actually served the run is recorded as `resolvedModel` in
+`result.json`.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Cursor sees only the text you send plus what it can inspect in the workspace — no chat history or
+shared context. Include the goal, current state, what to change, what to leave untouched, the
+project's **actual** gates, and a report contract. Tell Cursor not to commit. Keep one task per
+brief. See [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled helper. It wraps `cursor-agent -p`, feeds the brief on stdin, captures the
+structured event stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing
+this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (plan mode — review/diagnosis, no edits):  add --read-only
+# pin a model from `cursor-agent models`:              add --model <name>
+# resume the most recent session:                      add --resume-last  (delta brief only)
+# resume a specific session:                           add --session <id> (delta brief only)
+# hard time limit (watchdog):                          add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                                     node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. Use repeatable `--add-dir` flags only for extra
+workspace directories. The relay writes artifacts under the system temp dir by default and never
+commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Cursor finishes. Run it with the orchestrator's background-command facility,
+or background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `cursor-agent` exits 127 and writes `status: "cursor_agent_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process exited
+and `result.json` exists. Cursor's full report is the `finalMessage` field in `result.json` (also
+printed in full on stdout between the report markers).
+
+### 4. Review — do not trust the self-report
+
+Treat Cursor's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates
+pass and the diff holds. If rework is needed, send a delta brief with `--resume-last` or
+`--session <id>`, then review again.
+
+## Autonomy and permissions
+
+A fresh run defaults to **write-capable with `--force`**: Cursor runs commands without approval
+unless your Cursor config explicitly denies them, so ordinary gates (tests, linters, builds) run
+headlessly. `--read-only` switches to Cursor's **plan mode** (read-only analysis, no edits, no
+`--force`); the relay also snapshots the tree before dispatch and flags `readOnlyViolation: true` in
+`result.json` if a read-only run changed it anyway — verify that flag and `touchedFiles` came back
+clean instead of assuming. The relay always passes `--trust` to keep headless runs from stalling on
+the workspace-trust prompt, which is why `--cd` must only ever point at repositories you trust. The
+permission mode Cursor actually applied is recorded as `permissionMode` in `result.json`.
+
+## Read-only second opinions
+
+`--read-only` doubles as a clean way to get an adversarial second opinion with no write risk:
+dispatch a brief that lists the agreed points, then each contested point with both positions, and ask
+Cursor to defend or concede each — deliverable in its final message, touching no files.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't absorb**
+(report Cursor's design decisions, defensible-but-unasked turns, and non-blocking nitpicks) and
+**stop for scope changes** (if correct completion needs going beyond the brief, ask instead of
+expanding the mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — structure, report contract,
+  real gates, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) — review checklist, commit boundary,
+  and rework through Cursor sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — sequential queues, constraint
+  carry-forward, progress tracking, and the final coherence pass.

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -86,6 +86,12 @@ Trust process state and the working tree over a progress display. Completion mea
 and `result.json` exists. Cursor's full report is the `finalMessage` field in `result.json` (also
 printed in full on stdout between the report markers).
 
+**Windows + hooks caveat:** if the user has Cursor hooks configured (`~/.cursor/hooks.json`, or
+Claude Code `PreToolUse` hooks, which cursor-agent imports), dispatching from a Git Bash (MSYS)
+console makes cursor-agent feed PowerShell-syntax hook wrappers to bash, so every command Cursor
+tries to run is blocked — edits still land, gates do not run. Dispatch from a PowerShell or cmd
+console instead. Details: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
 ### 4. Review — do not trust the self-report
 
 Treat Cursor's final message and gate claims as claims:

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -112,6 +112,16 @@ A pre-run usage error exits 2 and writes no result. A missing `cursor-agent` exi
   needed (on Windows a single process-tree kill).
 - **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
   `<structured_output_contract>` to the next brief to require a closing report.
+- **Every command Cursor runs is rejected with "Hook blocked with message: … eval: … syntax error
+  near unexpected token `&`" (or Cursor reports "the terminal hook failed"):** a cursor-agent bug,
+  not a hook bug. When cursor-agent is launched from a Git Bash (MSYS) console on Windows — which
+  is what an orchestrator's bash tool uses — it selects `bash.exe` as its persistent shell while
+  still generating its hook wrappers in PowerShell syntax, so every configured hook (its own
+  `~/.cursor/hooks.json` and any imported Claude Code `PreToolUse` hooks) errors and Cursor blocks
+  the command, fail-closed. File edits still work; command execution does not — which also means
+  Cursor cannot run the gates, only claim it could not. Workaround: dispatch the relay from a
+  PowerShell or cmd console instead (observed fixed there); or temporarily remove the hook entries
+  for the run. Verified on cursor-agent 2026.07.23.
 
 ## Recovering lost work
 

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -11,10 +11,9 @@ cursor-agent --version
 cursor-agent status
 ```
 
-Install with `curl https://cursor.com/install -fsS | bash` on macOS/Linux, or the PowerShell
-installer from [cursor.com/cli](https://cursor.com/cli) on Windows, then authenticate with
-`cursor-agent login`. On Windows the CLI installs as a `.cmd` shim; the relay handles that launch
-itself, no setup needed.
+Follow the installer for your platform at [cursor.com/cli](https://cursor.com/cli), inspect what it
+will run, then authenticate with `cursor-agent login`. On Windows the CLI installs as a `.cmd` shim;
+the relay handles that launch itself, no setup needed.
 
 ## Dispatching
 
@@ -30,9 +29,10 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | `--cd <dir>` | Working root and child process cwd (default: current directory). |
 | `--model <name>` | Cursor model for this run (default: your Cursor default, usually `auto`). Names come from `cursor-agent models`. |
 | `--read-only` | Run in Cursor's plan mode: read-only analysis, no edits, no `--force`. |
-| `--session <id>` | Resume a specific Cursor chat (`--resume=<id>`); send only the delta brief. |
+| `--no-force` | Keep the run write-capable but withhold `--force`; commands requiring approval are refused. |
+| `--session <id>` | Resume a specific Cursor chat (`--resume <id>`); send only the delta brief. |
 | `--resume-last` | Resume the most recent Cursor chat (`--continue`); send only the delta brief. |
-| `--add-dir <dir>` | Add an extra workspace root. Repeatable. Edits there are not reported in `touchedFiles`. |
+| `--add-dir <dir>` | Add an extra workspace root on Cursor `2026.07.23` or newer. Repeatable. Edits there are not reported in `touchedFiles`. |
 | `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). cursor-agent has no timeout flag. |
 | `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
 | `-h`, `--help` | Print the relay's header help. |
@@ -41,9 +41,9 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 `--add-dir` adds extra workspace roots only.
 
 A fresh run defaults to write-capable with `--force` (commands run without approval unless your
-Cursor config denies them). `--read-only` switches to plan mode instead. The relay always passes
-`--trust` so a headless run never stalls on the workspace-trust prompt — point `--cd` only at
-repositories you trust.
+Cursor config denies them). `--no-force` withholds automatic command approval while retaining file
+edits; `--read-only` switches to plan mode instead. The relay always passes `--trust` so a headless
+run never stalls on the workspace-trust prompt — point `--cd` only at repositories you trust.
 
 ## Artifacts and result fields
 
@@ -62,7 +62,7 @@ inside the worktree can make the artifacts appear there:
   `cursor_agent_unavailable`), `exitCode`, and `signal` (`null` unless the child died on a signal).
 - `workdir`, `model` (the requested name or `null`), `resolvedModel` (the model Cursor actually
   served, from its init event), `permissionMode` (the mode Cursor reported applying), `readOnly`,
-  `resumed`, `cursorAgentVersion`, `sessionId`, `startedAt`, and `finishedAt`.
+  `force`, `resumed`, `cursorAgentVersion`, `sessionId`, `startedAt`, and `finishedAt`.
 - `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
 - `finalMessage` — the `result` field of Cursor's closing event; when the run died before emitting
   one, the assistant text chunks joined with `"\n\n"` instead. Tool calls and tool results are
@@ -72,9 +72,8 @@ inside the worktree can make the artifacts appear there:
   edits Cursor makes inside `--add-dir` roots do not show up at all — inspect those trees yourself.
   Dispatch from a clean tree when you want the list to read as "what Cursor changed". `null` means
   git could not report; `[]` means git ran and the tree is clean.
-- `readOnlyViolation` — only on `--read-only` runs: `true` if the porcelain snapshot changed between
-  dispatch and finish, `false` if it did not, `null` if git could not report on either side. Absent
-  on write runs.
+- `usage` — Cursor's token-usage object from the closing result event, or `null` if no result event
+  supplied one.
 - `stderrTail` — the last 20 non-empty stderr lines on any run that did not complete (`failed`,
   `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
 - `error` — present for launch failures, when the relay watchdog fires (`timeout`), on an `aborted`
@@ -97,6 +96,9 @@ A pre-run usage error exits 2 and writes no result. A missing `cursor-agent` exi
   result event carried `is_error: true` the relay reports `failed` even on a zero exit; Cursor's own
   message is in `finalMessage`. An unknown `--model` name fails fast — re-check against
   `cursor-agent models`.
+- **A version-preflight failure:** the relay writes `failed` with the probe's exit code, or `timeout`
+  with exit 124 when the probe exceeds the smaller of the run watchdog and 10 seconds. Cursor is not
+  dispatched.
 - **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
   closed terminal) and forwarded the kill to cursor-agent. The result is written before the relay
   exits; inspect the working tree before re-dispatching. On native Windows a hard kill of the relay
@@ -138,13 +140,16 @@ The argv is equivalent to:
 
 ```bash
 cursor-agent --print --output-format stream-json --trust \
-  [--force | --mode plan] [--model <name>] [--resume=<id> | --continue] \
+  [--force | --mode plan] [--model <name>] [--resume <id> | --continue] \
   [--add-dir <dir> ...]   # brief on stdin
 ```
 
+`--no-force` omits both `--force` and `--mode plan`; the run can edit files, but approval-gated
+commands are refused.
+
 The brief rides stdin, so it is not visible in the host process list and has no OS argument-size
 cap. On Windows the launch goes through the shell so the `cursor-agent.cmd` shim resolves; the brief
-still travels on stdin, and the model and directory values are quoted.
+still travels on stdin, and model, session, and directory values are validated and quoted.
 
 ## The commit boundary
 

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,142 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps Cursor's headless print mode (`cursor-agent -p`), captures its structured
+stream, and writes a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v cursor-agent
+cursor-agent --version
+cursor-agent status
+```
+
+Install with `curl https://cursor.com/install -fsS | bash` on macOS/Linux, or the PowerShell
+installer from [cursor.com/cli](https://cursor.com/cli) on Windows, then authenticate with
+`cursor-agent login`. On Windows the CLI installs as a `.cmd` shim; the relay handles that launch
+itself, no setup needed.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--model <name>` | Cursor model for this run (default: your Cursor default, usually `auto`). Names come from `cursor-agent models`. |
+| `--read-only` | Run in Cursor's plan mode: read-only analysis, no edits, no `--force`. |
+| `--session <id>` | Resume a specific Cursor chat (`--resume=<id>`); send only the delta brief. |
+| `--resume-last` | Resume the most recent Cursor chat (`--continue`); send only the delta brief. |
+| `--add-dir <dir>` | Add an extra workspace root. Repeatable. Edits there are not reported in `touchedFiles`. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). cursor-agent has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The child cwd pins the primary workspace;
+`--add-dir` adds extra workspace roots only.
+
+A fresh run defaults to write-capable with `--force` (commands run without approval unless your
+Cursor config denies them). `--read-only` switches to plan mode instead. The relay always passes
+`--trust` so a headless run never stalls on the workspace-trust prompt — point `--cd` only at
+repositories you trust.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an `--out-dir`
+inside the worktree can make the artifacts appear there:
+
+- `brief.txt` — the exact brief.
+- `events.jsonl` — raw cursor-agent stdout events.
+- `final.txt` — the final report; absent if none was emitted.
+- `stderr.txt` — complete stderr.
+- `result.json` — the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"cursor-agent"`), `status` (`completed` | `failed` | `timeout` | `aborted` |
+  `cursor_agent_unavailable`), `exitCode`, and `signal` (`null` unless the child died on a signal).
+- `workdir`, `model` (the requested name or `null`), `resolvedModel` (the model Cursor actually
+  served, from its init event), `permissionMode` (the mode Cursor reported applying), `readOnly`,
+  `resumed`, `cursorAgentVersion`, `sessionId`, `startedAt`, and `finishedAt`.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `finalMessage` — the `result` field of Cursor's closing event; when the run died before emitting
+  one, the assistant text chunks joined with `"\n\n"` instead. Tool calls and tool results are
+  excluded.
+- `touchedFiles` — `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of Cursor's edits: anything already dirty before dispatch shows up too, and
+  edits Cursor makes inside `--add-dir` roots do not show up at all — inspect those trees yourself.
+  Dispatch from a clean tree when you want the list to read as "what Cursor changed". `null` means
+  git could not report; `[]` means git ran and the tree is clean.
+- `readOnlyViolation` — only on `--read-only` runs: `true` if the porcelain snapshot changed between
+  dispatch and finish, `false` if it did not, `null` if git could not report on either side. Absent
+  on write runs.
+- `stderrTail` — the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
+- `error` — present for launch failures, when the relay watchdog fires (`timeout`), on an `aborted`
+  run, and when Cursor's own result event carries `is_error: true`.
+
+## Waiting for completion
+
+The helper blocks. Use the orchestrator's background-command facility, or background it in a shell
+and poll for `result.json`. The run is done only when the process exits and the file contains a
+`status`.
+
+A pre-run usage error exits 2 and writes no result. A missing `cursor-agent` exits 127 and writes
+`status: "cursor_agent_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "cursor_agent_unavailable"` (exit 127):** install the Cursor CLI, authenticate with
+  `cursor-agent login`, and re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. If the
+  result event carried `is_error: true` the relay reports `failed` even on a zero exit; Cursor's own
+  message is in `finalMessage`. An unknown `--model` name fails fast — re-check against
+  `cursor-agent models`.
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to cursor-agent. The result is written before the relay
+  exits; inspect the working tree before re-dispatching. On native Windows a hard kill of the relay
+  is uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written —
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working tree
+  and `events.jsonl` directly.
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through the
+  OOM killer or a supervisor timeout. This is not a Cursor error; check host memory and re-dispatch,
+  or split the task into smaller briefs.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `cursor-agent did not finish within --timeout <dur>; killed by the relay watchdog`. Increase
+  `--timeout` or split the task. The relay sends SIGTERM, waits 10 seconds, then sends SIGKILL if
+  needed (on Windows a single process-tree kill).
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Whether it also carries the edit contents depends on what the CLI streams,
+so treat any reconstruction as unverified until it matches a working-tree diff — when the tree
+still holds the work, preserve the tree rather than replaying the log.
+
+## What the relay runs
+
+The argv is equivalent to:
+
+```bash
+cursor-agent --print --output-format stream-json --trust \
+  [--force | --mode plan] [--model <name>] [--resume=<id> | --continue] \
+  [--add-dir <dir> ...]   # brief on stdin
+```
+
+The brief rides stdin, so it is not visible in the host process list and has no OS argument-size
+cap. On Windows the launch goes through the shell so the `cursor-agent.cmd` shim resolves; the brief
+still travels on stdin, and the model and directory values are quoted.
+
+## The commit boundary
+
+The relay never commits. Cursor edits the working tree; the orchestrator reviews, re-runs the gates,
+and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/cursor-delegate/references/multi-task-queues.md
+++ b/skills/cursor-delegate/references/multi-task-queues.md
@@ -1,0 +1,59 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is the
+default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh Cursor sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture
+location, or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed Cursor session only for rework on the same task. Send a delta brief with
+`--resume-last`, or with `--session <id>` from that task's `result.json`. Start unrelated queue items
+in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** — queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** — what landed, what you verified, and gate outcomes.
+- **Needs your eyes** — design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** — the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/cursor-delegate/references/review-and-land.md
+++ b/skills/cursor-delegate/references/review-and-land.md
@@ -1,0 +1,92 @@
+# Review and land
+
+Cursor did the typing; you own the judgment. Verify against reality, never the self-report, and read
+the diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries Cursor's claims, not evidence. Re-run the project's actual test, lint, and
+build commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** — changes the brief excluded.
+- **Scope shortfall** — missed behavior, edges, or cleanup.
+- **Quiet judgment calls** — defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to Cursor as a delta brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer. Write a
+clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json`. The relay
+rejects `--resume-last` plus `--session` before launch. Rework gets the same gate rerun, test
+review, diff review, and implementer sweep.
+
+A resumed run carries the same autonomy flags as a fresh one — write-capable with `--force` by
+default, plan mode under `--read-only`. Confirm `touchedFiles` after every fresh or resumed run.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep them
+in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/cursor-delegate/references/review-and-land.md
+++ b/skills/cursor-delegate/references/review-and-land.md
@@ -77,7 +77,8 @@ rejects `--resume-last` plus `--session` before launch. Rework gets the same gat
 review, diff review, and implementer sweep.
 
 A resumed run carries the same autonomy flags as a fresh one — write-capable with `--force` by
-default, plan mode under `--read-only`. Confirm `touchedFiles` after every fresh or resumed run.
+default, write-capable without automatic command approval under `--no-force`, or plan mode under
+`--read-only`. Confirm `touchedFiles` after every fresh or resumed run.
 
 ## Surface, do not absorb
 

--- a/skills/cursor-delegate/references/writing-the-brief.md
+++ b/skills/cursor-delegate/references/writing-the-brief.md
@@ -1,0 +1,126 @@
+# Writing the brief
+
+A brief is the entire task as Cursor will see it. It runs in a separate session with **no memory of
+your conversation, no access to prior notes, and no shared context** — only the text you send and
+whatever it can inspect in the workspace. If a constraint is not in the brief or discoverable in the
+repo, it does not exist for Cursor.
+
+## Model choice and resumed sessions
+
+Omitting `--model` uses your Cursor default (usually `auto` — Cursor picks the model). Pass
+`--model <name>` only with a name from the account's live `cursor-agent models` output. Do not
+invent a name.
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report Cursor must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** — add `<completeness_contract>` (resolve fully, not just the first
+  plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is unknown).
+- **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences, and
+  open questions).
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from Cursor's closing result event, falling back to its assistant
+text stream. Without a closing summary, the edits may exist but the result is hard to review. The
+`<structured_output_contract>` block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy the
+actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Cursor reads the repo's `.cursor/rules` and can
+inspect the workspace, but the important constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one Cursor run -> one reviewed commit keeps the diff and
+rollback clean. Split mixed implementation, review, documentation, and roadmap requests into separate
+dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Delivery
+
+The relay reads the brief from a file or stdin and feeds it to `cursor-agent` on stdin — it never
+rides argv, so it is not visible in the host process list and has no OS argument-size cap. Large
+context is still better referenced than inlined: put it in the workspace and tell Cursor which file
+to read.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -24,10 +24,8 @@
  * Autonomy: a fresh run defaults to write-capable with `--force` (Cursor runs
  * commands without approval unless your Cursor config denies them). Pass
  * `--read-only` to run in Cursor's plan mode (read-only/planning, no edits)
- * instead; the relay additionally snapshots `git status --porcelain` before
- * dispatch and flags `readOnlyViolation: true` if the tree changed anyway.
- * The relay always passes `--trust` so a headless run never stalls on the
- * workspace-trust prompt — point --cd only at repositories you trust.
+ * instead. The relay always passes `--trust` so a headless run never stalls
+ * on the workspace-trust prompt — point --cd only at repositories you trust.
  *
  * Usage:
  *   node relay.mjs --brief <file> [options]
@@ -40,11 +38,14 @@
  *                           auto). List names with `cursor-agent models`.
  *   --read-only             Run in Cursor's plan mode: read-only analysis, no
  *                           edits, no --force.
- *   --session <id>          Resume a specific Cursor chat (`--resume=<id>`);
+ *   --no-force              Withhold --force on a write-capable run; commands
+ *                           that require approval are refused instead of run.
+ *   --session <id>          Resume a specific Cursor chat (`--resume <id>`);
  *                           send only the delta brief.
  *   --resume-last           Resume the most recent Cursor chat (`--continue`);
  *                           send only the delta brief.
- *   --add-dir <dir>         Add an extra workspace root. Repeatable.
+ *   --add-dir <dir>         Add an extra workspace root. Repeatable; requires
+ *                           cursor-agent 2026.07.23 or newer.
  *   --timeout <dur>         Relay-side watchdog (default: 30m; h/m/s strings
  *                           like 90s, 45m, 2h). cursor-agent has no timeout flag.
  *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
@@ -53,9 +54,9 @@
  *
  * Result: written to <out-dir>/result.json and summarized on stdout —
  *   status, exitCode, signal, cursorAgentVersion, sessionId, resolvedModel,
- *   permissionMode, finalMessage (Cursor's own report), touchedFiles (git
- *   porcelain, null if git cannot report), readOnlyViolation (read-only runs),
- *   and paths to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *   permissionMode, force, usage, finalMessage (Cursor's own report),
+ *   touchedFiles (git porcelain, null if git cannot report), and paths to
+ *   brief.txt, final.txt, events.jsonl, and stderr.txt.
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `cursor-agent` binary
@@ -69,12 +70,16 @@
  */
 
 import { spawn, execSync, execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, rmSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:@/[\],=-]*$/;
+const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -87,6 +92,7 @@ function parseArgs(argv) {
     cd: process.cwd(),
     model: null,
     readOnly: false,
+    force: true,
     session: null,
     resumeLast: false,
     addDirs: [],
@@ -111,6 +117,7 @@ function parseArgs(argv) {
       case "--cd": opts.cd = resolve(next()); break;
       case "--model": opts.model = next(); break;
       case "--read-only": opts.readOnly = true; break;
+      case "--no-force": opts.force = false; break;
       case "--session": opts.session = next(); break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--add-dir": opts.addDirs.push(next()); break;
@@ -123,15 +130,24 @@ function parseArgs(argv) {
   if (opts.resumeLast && opts.session) {
     fail("--resume-last and --session are mutually exclusive; pass only one");
   }
+  if (opts.model !== null && !SAFE_MODEL.test(opts.model)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, . _ : @ / [ ] , = -)");
+  }
+  if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
+    fail("--session contains unsupported characters (allowed: letters, digits, . _ : -)");
+  }
   // cursor-agent resolves a relative --add-dir against ITS cwd, so resolve
   // against --cd (not the relay's own cwd) — and only after the loop, since
   // --add-dir may appear before --cd on the command line. resolve() passes
   // absolutes through.
   opts.addDirs = opts.addDirs.map((dir) => resolve(opts.cd, dir));
+  if (process.platform === "win32" && opts.addDirs.some((dir) => /[\0\r\n"%!]/.test(dir))) {
+    fail("--add-dir cannot contain %, !, a quote, or a newline when cursor-agent launches through cmd.exe");
+  }
   // The watchdog is relay-only (cursor-agent has no timeout flag), so a
   // malformed --timeout must fail loudly here — a silent 30m fallback would be wrong.
   if (parseDuration(opts.timeout) === null) {
-    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
   }
   return opts;
 }
@@ -181,19 +197,29 @@ function killChild(child, signal = "SIGTERM") {
   }
 }
 
-function cursorAgentVersion() {
+function cursorAgentVersion(timeoutMs) {
   try {
     // On Windows, cursor-agent installs as a .cmd shim; Node's CreateProcess only
     // auto-appends .exe, never .cmd, so launching it needs a shell there or it
     // ENOENTs on a working install. A pre-joined string (not shell:true + args)
     // avoids Node's DEP0190 warning. POSIX is unaffected. (git installs a real
     // git.exe and must NOT go through a shell — see gitTouchedFiles.)
+    const options = {
+      encoding: "utf8",
+      timeout: Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS),
+      killSignal: "SIGKILL",
+    };
     const out = process.platform === "win32"
-      ? execSync("cursor-agent --version", { encoding: "utf8" }).trim()
-      : execFileSync("cursor-agent", ["--version"], { encoding: "utf8" }).trim();
-    return out || "unknown";
-  } catch {
-    return null;
+      ? execSync("cursor-agent --version", options).trim()
+      : execFileSync("cursor-agent", ["--version"], options).trim();
+    return { version: out || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    return { version: null, error };
   }
 }
 
@@ -201,7 +227,17 @@ function parseDuration(duration) {
   // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
-  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
 }
 
 function gitTouchedFiles(cwd) {
@@ -232,9 +268,9 @@ function winq(value) {
 function buildArgv(opts) {
   const argv = ["--print", "--output-format", "stream-json", "--trust"];
   if (opts.readOnly) argv.push("--mode", "plan");
-  else argv.push("--force");
+  else if (opts.force) argv.push("--force");
   if (opts.model) argv.push("--model", winq(opts.model));
-  if (opts.session) argv.push(`--resume=${opts.session}`);
+  if (opts.session) argv.push("--resume", winq(opts.session));
   else if (opts.resumeLast) argv.push("--continue");
   for (const dir of opts.addDirs) argv.push("--add-dir", winq(dir));
   return argv;
@@ -293,6 +329,8 @@ function prepareRunDir(opts, brief) {
     stderrPath: join(outDir, "stderr.txt"),
     resultPath: join(outDir, "result.json"),
   };
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
   writeFileSync(run.briefPath, brief, "utf8");
   writeFileSync(run.eventsPath, "", "utf8");
   writeFileSync(run.stderrPath, "", "utf8");
@@ -307,6 +345,7 @@ function makeResultWriter(opts, version, run) {
       workdir: opts.cd,
       model: opts.model,
       readOnly: opts.readOnly,
+      force: opts.force && !opts.readOnly,
       resumed: Boolean(opts.resumeLast || opts.session),
       cursorAgentVersion: version,
       startedAt: run.startedAt,
@@ -317,7 +356,9 @@ function makeResultWriter(opts, version, run) {
       stderrPath: run.stderrPath,
       ...extra,
     };
-    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
     return result;
   };
 }
@@ -330,6 +371,7 @@ function reportUnavailable(writeResult, resultPath) {
     sessionId: null,
     resolvedModel: null,
     permissionMode: null,
+    usage: null,
     finalMessage: "",
     touchedFiles: null,
   });
@@ -338,18 +380,63 @@ function reportUnavailable(writeResult, resultPath) {
   process.exit(127);
 }
 
-function readOnlyViolation(opts, baseline, touched) {
-  // Plan mode is Cursor-enforced, but measure anyway: compare the post-run
-  // porcelain snapshot to the pre-dispatch one. Only meaningful for --read-only
-  // runs; null when git cannot report on either side.
-  if (!opts.readOnly) return undefined;
-  if (baseline === null || touched === null) return null;
-  const before = new Set(baseline);
-  return touched.some((line) => !before.has(line));
+function reportVersionFailure(opts, writeResult, run, error, timeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `cursor-agent --version preflight timed out after ${Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS)}ms; Cursor was not dispatched`
+    : `cursor-agent --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Cursor was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    resolvedModel: null,
+    permissionMode: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: null,
+        resolvedModel: null,
+        permissionMode: null,
+        usage: null,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the cursor-agent version preflight; Cursor was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
 }
 
 function dispatchToCursor(opts, brief, run, writeResult) {
-  const baseline = opts.readOnly ? gitTouchedFiles(opts.cd) : null;
   // A shell launch on Windows so the cursor-agent.cmd shim resolves (see
   // cursorAgentVersion) — as a pre-joined string, which sidesteps Node's
   // DEP0190 warning about shell:true with an args array. Safe: the brief is
@@ -364,6 +451,7 @@ function dispatchToCursor(opts, brief, run, writeResult) {
   let sessionId = null;
   let resolvedModel = null;
   let permissionMode = null;
+  let usage = null;
   let resultMessage = null;
   let resultIsError = false;
   const textChunks = [];
@@ -382,6 +470,7 @@ function dispatchToCursor(opts, brief, run, writeResult) {
     if (event.type === "result") {
       if (typeof event.result === "string") resultMessage = event.result;
       if (event.is_error === true) resultIsError = true;
+      if (event.usage && typeof event.usage === "object") usage = event.usage;
     }
   });
 
@@ -453,9 +542,9 @@ function dispatchToCursor(opts, brief, run, writeResult) {
         sessionId,
         resolvedModel,
         permissionMode,
+        usage,
         finalMessage: assembleFinal(),
         touchedFiles: touched,
-        readOnlyViolation: readOnlyViolation(opts, baseline, touched),
         stderrTail: stderrTail.slice(-20),
         error: `the relay was killed by ${sig}; cursor-agent was terminated with it — inspect the working tree before re-dispatching`,
       };
@@ -467,7 +556,7 @@ function dispatchToCursor(opts, brief, run, writeResult) {
         // the child may flush files during the grace window; refresh the snapshot so the
         // artifact matches the tree the orchestrator will actually find
         const late = gitTouchedFiles(opts.cd);
-        writeResult({ ...abortedFields, touchedFiles: late, readOnlyViolation: readOnlyViolation(opts, baseline, late) });
+        writeResult({ ...abortedFields, touchedFiles: late });
         process.exit(result.exitCode);
       }, 2000);
     });
@@ -486,9 +575,9 @@ function dispatchToCursor(opts, brief, run, writeResult) {
       sessionId,
       resolvedModel,
       permissionMode,
+      usage,
       finalMessage: assembleFinal(),
       touchedFiles: touched,
-      readOnlyViolation: readOnlyViolation(opts, baseline, touched),
       stderrTail: stderrTail.slice(-20),
       error: String(err && err.message ? err.message : err),
     });
@@ -518,9 +607,9 @@ function dispatchToCursor(opts, brief, run, writeResult) {
       sessionId,
       resolvedModel,
       permissionMode,
+      usage,
       finalMessage: assembleFinal(),
       touchedFiles: touched,
-      readOnlyViolation: readOnlyViolation(opts, baseline, touched),
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `cursor-agent did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
       ...(resultIsError && !watchdogFired ? { error: "cursor-agent reported an error result (is_error: true in its result event)" } : {}),
@@ -530,18 +619,31 @@ function dispatchToCursor(opts, brief, run, writeResult) {
   });
 }
 
-function main() {
+async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
 
-  const version = cursorAgentVersion();
+  const timeoutMs = parseDuration(opts.timeout);
   const run = prepareRunDir(opts, brief);
-  const writeResult = makeResultWriter(opts, version, run);
-  if (!version) {
+  let writeResult = makeResultWriter(opts, null, run);
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult);
+  const probe = cursorAgentVersion(timeoutMs);
+  // Synchronous child-process calls defer JavaScript signal handlers. Yield once
+  // so a signal received during the bounded probe becomes "aborted" before dispatch.
+  await new Promise((resolve) => setImmediate(resolve));
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
     reportUnavailable(writeResult, run.resultPath);
     return;
   }
+  if (probe.error) {
+    clearPreflightSignals();
+    reportVersionFailure(opts, writeResult, run, probe.error, timeoutMs);
+    return;
+  }
+  clearPreflightSignals();
   dispatchToCursor(opts, brief, run, writeResult);
 }
 
@@ -552,7 +654,7 @@ function printSummary(result, resultPath) {
   if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a cursor-agent error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated cursor-agent (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
   if (result.resumed) lines.push("mode: resumed an existing session");
-  if (result.readOnly) lines.push(`mode: read-only (plan)${result.readOnlyViolation ? " — VIOLATION: the tree changed during a read-only run" : ""}`);
+  if (result.readOnly) lines.push("mode: read-only (plan)");
   if (result.resolvedModel) lines.push(`model: ${result.resolvedModel}${result.permissionMode ? `  ·  permission mode: ${result.permissionMode}` : ""}`);
   if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
   const touched = result.touchedFiles;

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -1,0 +1,580 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · cursor-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Cursor Agent CLI (`cursor-agent -p`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Cursor-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against cursor-agent 2026.07.23 on Windows.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `cursor-agent` and `git` (plus taskkill on
+ * Windows for process-tree termination). The `cursor-agent` process it
+ * launches does authenticate — exactly as you do at the terminal. Read this
+ * file before you run it.
+ *
+ * The brief is fed on the child's stdin, never argv, so it is not visible in
+ * the host process list and has no OS argument-size cap.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Autonomy: a fresh run defaults to write-capable with `--force` (Cursor runs
+ * commands without approval unless your Cursor config denies them). Pass
+ * `--read-only` to run in Cursor's plan mode (read-only/planning, no edits)
+ * instead; the relay additionally snapshots `git status --porcelain` before
+ * dispatch and flags `readOnlyViolation: true` if the tree changed anyway.
+ * The relay always passes `--trust` so a headless run never stalls on the
+ * workspace-trust prompt — point --cd only at repositories you trust.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for Cursor (default: current directory).
+ *   --model <name>          Cursor model (default: your Cursor default, usually
+ *                           auto). List names with `cursor-agent models`.
+ *   --read-only             Run in Cursor's plan mode: read-only analysis, no
+ *                           edits, no --force.
+ *   --session <id>          Resume a specific Cursor chat (`--resume=<id>`);
+ *                           send only the delta brief.
+ *   --resume-last           Resume the most recent Cursor chat (`--continue`);
+ *                           send only the delta brief.
+ *   --add-dir <dir>         Add an extra workspace root. Repeatable.
+ *   --timeout <dur>         Relay-side watchdog (default: 30m; h/m/s strings
+ *                           like 90s, 45m, 2h). cursor-agent has no timeout flag.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, cursorAgentVersion, sessionId, resolvedModel,
+ *   permissionMode, finalMessage (Cursor's own report), touchedFiles (git
+ *   porcelain, null if git cannot report), readOnlyViolation (read-only runs),
+ *   and paths to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `cursor-agent` binary
+ * exits 127 and writes status `cursor_agent_unavailable`; otherwise the exit
+ * code mirrors cursor-agent's own (0 success, non-zero failure). If the child
+ * dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome — completed, failed, timeout (the --timeout
+ * watchdog fired), aborted (the relay itself was killed and forwarded the kill
+ * to cursor-agent), or cursor_agent_unavailable.
+ */
+
+import { spawn, execSync, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_TIMEOUT = "30m";
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    readOnly: false,
+    session: null,
+    resumeLast: false,
+    addDirs: [],
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--read-only": opts.readOnly = true; break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--add-dir": opts.addDirs.push(next()); break;
+      case "--timeout": opts.timeout = next(); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  // cursor-agent resolves a relative --add-dir against ITS cwd, so resolve
+  // against --cd (not the relay's own cwd) — and only after the loop, since
+  // --add-dir may appear before --cd on the command line. resolve() passes
+  // absolutes through.
+  opts.addDirs = opts.addDirs.map((dir) => resolve(opts.cd, dir));
+  // The watchdog is relay-only (cursor-agent has no timeout flag), so a
+  // malformed --timeout must fail loudly here — a silent 30m fallback would be wrong.
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to cursor-agent -p\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function killChild(child, signal = "SIGTERM") {
+  // The kill must reach the whole process family, not just the immediate child — a tool
+  // subprocess left running would keep editing after the relay reports timeout/aborted.
+  // On Windows the child is the cursor-agent.cmd shim (the shell:true launch below), Windows
+  // has no process-group signals, and Node can't kill a process family without a Job Object,
+  // so kill the tree by pid with the OS tool (/t includes descendants, /f forces it — the
+  // tree-kill/npm idiom).
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
+    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
+    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
+    catch { /* already gone — nothing left to kill */ }
+  } else {
+    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
+    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
+    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+  }
+}
+
+function cursorAgentVersion() {
+  try {
+    // On Windows, cursor-agent installs as a .cmd shim; Node's CreateProcess only
+    // auto-appends .exe, never .cmd, so launching it needs a shell there or it
+    // ENOENTs on a working install. A pre-joined string (not shell:true + args)
+    // avoids Node's DEP0190 warning. POSIX is unaffected. (git installs a real
+    // git.exe and must NOT go through a shell — see gitTouchedFiles.)
+    const out = process.platform === "win32"
+      ? execSync("cursor-agent --version", { encoding: "utf8" }).trim()
+      : execFileSync("cursor-agent", ["--version"], { encoding: "utf8" }).trim();
+    return out || "unknown";
+  } catch {
+    return null;
+  }
+}
+
+function parseDuration(duration) {
+  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git cannot report — git missing, or a non-repo run — so
+  // the caller can tell "git unavailable" apart from "Cursor changed nothing."
+  // [] means git ran and the working tree is clean.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function winq(value) {
+  // shell:true on win32 (needed for the cursor-agent.cmd shim) doesn't quote
+  // args, so a path with spaces (C:\Users\First Last\...) would split, and a
+  // parameterized model ("opus[context=1m,effort=high]") would be re-tokenized
+  // by the shim's PowerShell hop. Quote the spaceable/parameterized values on
+  // Windows only — on POSIX the quotes would become literal characters.
+  return process.platform === "win32" ? `"${value}"` : value;
+}
+
+function buildArgv(opts) {
+  const argv = ["--print", "--output-format", "stream-json", "--trust"];
+  if (opts.readOnly) argv.push("--mode", "plan");
+  else argv.push("--force");
+  if (opts.model) argv.push("--model", winq(opts.model));
+  if (opts.session) argv.push(`--resume=${opts.session}`);
+  else if (opts.resumeLast) argv.push("--continue");
+  for (const dir of opts.addDirs) argv.push("--add-dir", winq(dir));
+  return argv;
+}
+
+function makeEventScanner(onObject) {
+  // stream-json is newline-delimited JSON, but this brace-aware scan also
+  // tolerates junk prefixes and concatenated objects if the format drifts.
+  let buf = "";
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    buf += chunk;
+    for (let i = 0; i < buf.length; i += 1) {
+      const ch = buf[i];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (ch === "\\") escaped = true;
+        else if (ch === '"') inString = false;
+        continue;
+      }
+      if (ch === '"') { if (depth > 0) inString = true; continue; }
+      if (ch === "{") {
+        if (depth === 0) start = i;
+        depth += 1;
+      } else if (ch === "}") {
+        if (depth > 0) {
+          depth -= 1;
+          if (depth === 0 && start !== -1) {
+            const slice = buf.slice(start, i + 1);
+            try { onObject(JSON.parse(slice)); } catch { /* ignore non-objects */ }
+            start = -1;
+          }
+        }
+      }
+    }
+    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
+    start = -1;
+    depth = 0;
+    inString = false;
+    escaped = false;
+  };
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      tool: "cursor-agent",
+      workdir: opts.cd,
+      model: opts.model,
+      readOnly: opts.readOnly,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      cursorAgentVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    writeFileSync(run.resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "cursor_agent_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    resolvedModel: null,
+    permissionMode: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `cursor-agent` not found on PATH. Install the Cursor CLI (https://cursor.com/cli) and run `cursor-agent login`.\n");
+  process.exit(127);
+}
+
+function readOnlyViolation(opts, baseline, touched) {
+  // Plan mode is Cursor-enforced, but measure anyway: compare the post-run
+  // porcelain snapshot to the pre-dispatch one. Only meaningful for --read-only
+  // runs; null when git cannot report on either side.
+  if (!opts.readOnly) return undefined;
+  if (baseline === null || touched === null) return null;
+  const before = new Set(baseline);
+  return touched.some((line) => !before.has(line));
+}
+
+function dispatchToCursor(opts, brief, run, writeResult) {
+  const baseline = opts.readOnly ? gitTouchedFiles(opts.cd) : null;
+  // A shell launch on Windows so the cursor-agent.cmd shim resolves (see
+  // cursorAgentVersion) — as a pre-joined string, which sidesteps Node's
+  // DEP0190 warning about shell:true with an args array. Safe: the brief is
+  // fed via child.stdin below — never argv — and argv holds only fixed flags
+  // plus the win32-quoted model and directory values. detached on POSIX: the
+  // child leads a new process group so killChild can fell the whole tree.
+  const argv = buildArgv(opts);
+  const child = process.platform === "win32"
+    ? spawn(["cursor-agent", ...argv].join(" "), { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: true })
+    : spawn("cursor-agent", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], detached: true });
+
+  let sessionId = null;
+  let resolvedModel = null;
+  let permissionMode = null;
+  let resultMessage = null;
+  let resultIsError = false;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (typeof event.session_id === "string") sessionId = event.session_id;
+    if (event.type === "system" && event.subtype === "init") {
+      if (typeof event.model === "string") resolvedModel = event.model;
+      if (typeof event.permissionMode === "string") permissionMode = event.permissionMode;
+    }
+    if (event.type === "assistant" && event.message && Array.isArray(event.message.content)) {
+      for (const part of event.message.content) {
+        if (part && part.type === "text" && typeof part.text === "string") textChunks.push(part.text);
+      }
+    }
+    if (event.type === "result") {
+      if (typeof event.result === "string") resultMessage = event.result;
+      if (event.is_error === true) resultIsError = true;
+    }
+  });
+
+  // The brief rides stdin: no process-list exposure, no OS argv-size cap.
+  child.stdin.on("error", () => { /* child exited before reading the brief; its exit code tells the story */ });
+  child.stdin.write(brief);
+  child.stdin.end();
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    // Prefer the result event's own report; fall back to the assistant text
+    // stream when the run died before emitting one.
+    const message = resultMessage && resultMessage.trim() ? resultMessage : textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the cursor-agent child running or dying mid-edit with
+  // nothing recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdogTimer);
+      if (sigkillTimer) clearTimeout(sigkillTimer);
+      const touched = gitTouchedFiles(opts.cd);
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        resolvedModel,
+        permissionMode,
+        finalMessage: assembleFinal(),
+        touchedFiles: touched,
+        readOnlyViolation: readOnlyViolation(opts, baseline, touched),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; cursor-agent was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        const late = gitTouchedFiles(opts.cd);
+        writeResult({ ...abortedFields, touchedFiles: late, readOnlyViolation: readOnlyViolation(opts, baseline, late) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    const touched = gitTouchedFiles(opts.cd);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      resolvedModel,
+      permissionMode,
+      finalMessage: assembleFinal(),
+      touchedFiles: touched,
+      readOnlyViolation: readOnlyViolation(opts, baseline, touched),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if cursor-agent handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code. A result event with
+    // is_error true is failed even on exit 0.
+    const succeeded = code === 0 && !watchdogFired && !resultIsError;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const touched = gitTouchedFiles(opts.cd);
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      resolvedModel,
+      permissionMode,
+      finalMessage: assembleFinal(),
+      touchedFiles: touched,
+      readOnlyViolation: readOnlyViolation(opts, baseline, touched),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `cursor-agent did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...(resultIsError && !watchdogFired ? { error: "cursor-agent reported an error result (is_error: true in its result event)" } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const version = cursorAgentVersion();
+  const run = prepareRunDir(opts, brief);
+  const writeResult = makeResultWriter(opts, version, run);
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  dispatchToCursor(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  cursor-agent ${result.cursorAgentVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a cursor-agent error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated cursor-agent (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.readOnly) lines.push(`mode: read-only (plan)${result.readOnlyViolation ? " — VIOLATION: the tree changed during a read-only run" : ""}`);
+  if (result.resolvedModel) lines.push(`model: ${result.resolvedModel}${result.permissionMode ? `  ·  permission mode: ${result.permissionMode}` : ""}`);
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- cursor-agent final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -84,10 +84,10 @@ for (const skill of SKILLS) {
 // ---- one fake CLI, planted on PATH under every relay's binary name ----
 const FAKE = `const fs = require("node:fs");
 const args = process.argv.slice(2);
-if ((args.includes("--version") && ["qoder-version-hang", "vibe-version-hang"].includes(process.env.SMOKE_MODE))
+if ((args.includes("--version") && ["qoder-version-hang", "vibe-version-hang", "cursor-version-hang"].includes(process.env.SMOKE_MODE))
     || (args[0] === "changelog" && process.env.SMOKE_MODE === "agy-version-hang")) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
-} else if (args.includes("--version") && ["qoder-version-fail", "vibe-version-fail"].includes(process.env.SMOKE_MODE)) {
+} else if (args.includes("--version") && ["qoder-version-fail", "vibe-version-fail", "cursor-version-fail"].includes(process.env.SMOKE_MODE)) {
   console.error("fake version failure");
   process.exit(7);
 } else if (args.includes("--version") || args[0] === "version" || args[0] === "changelog") {
@@ -128,12 +128,31 @@ if (process.env.SMOKE_MODE === "vibe-success") {
   console.log(JSON.stringify({ role: "assistant", content: "fake vibe completed" }));
   process.exit(0);
 }
-if (["claude-success", "claude-read-only-write", "claude-read-only-clean", "claude-chunked"].includes(process.env.SMOKE_MODE)) {
+if (["cursor-success", "claude-success", "claude-read-only-write", "claude-read-only-clean", "claude-chunked"].includes(process.env.SMOKE_MODE)) {
   let brief = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (chunk) => { brief += chunk; });
   process.stdin.on("end", async () => {
     const mode = process.env.SMOKE_MODE;
+    if (mode === "cursor-success") {
+      fs.writeFileSync(process.env.SMOKE_CAPTURE_FILE, JSON.stringify({ args, brief }));
+      console.log(JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "cursor-session-1",
+        model: "claude-opus-4-8[context=1m,effort=high,fast=false]",
+        permissionMode: args.includes("plan") ? "plan" : "default",
+      }));
+      console.log(JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        session_id: "cursor-session-1",
+        result: "fake cursor completed",
+        usage: { input_tokens: 11, output_tokens: 4 },
+      }));
+      return;
+    }
     if (mode === "claude-read-only-write") {
       fs.writeFileSync("read-only-violation.txt", "written by fake claude\\n");
     }
@@ -362,6 +381,164 @@ check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
 
 // opencode refuses a fresh run without an explicit model
 const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [], vibe: [], cursor: [] };
+
+// ---- Cursor's session/model controls and structured result ----
+{
+  const outDir = join(scratch, "out-success-cursor");
+  const workDir = freshRepo("work success cursor");
+  const addDir = freshRepo("extra success cursor");
+  const captureFile = join(scratch, "capture-success-cursor.json");
+  const run = spawnSync(process.execPath, [
+    relayPath("cursor"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--session", "cursor-session-0",
+    "--model", "claude-opus-4-8[context=1m,effort=high,fast=false]",
+    "--add-dir", addDir,
+    "--no-force",
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "cursor-success", SMOKE_CAPTURE_FILE: captureFile },
+    encoding: "utf8",
+  });
+  const capture = existsSync(captureFile)
+    ? JSON.parse(readFileSync(captureFile, "utf8"))
+    : { args: [], brief: "" };
+  check("cursor success: relay exits zero", run.status === 0);
+  check("cursor success: session, model, add-dir, and no-force argv are exact",
+    JSON.stringify(capture.args) === JSON.stringify([
+      "--print", "--output-format", "stream-json", "--trust",
+      "--model", "claude-opus-4-8[context=1m,effort=high,fast=false]",
+      "--resume", "cursor-session-0",
+      "--add-dir", addDir,
+    ]));
+  check("cursor success: brief travels on stdin", capture.brief === "smoke brief: run until killed.");
+  check("cursor success: result preserves session, model, permission, usage, and final report",
+    existsSync(join(outDir, "result.json")) &&
+    result(outDir).status === "completed" &&
+    result(outDir).force === false &&
+    result(outDir).sessionId === "cursor-session-1" &&
+    result(outDir).resolvedModel === "claude-opus-4-8[context=1m,effort=high,fast=false]" &&
+    result(outDir).permissionMode === "default" &&
+    result(outDir).usage?.input_tokens === 11 &&
+    result(outDir).usage?.output_tokens === 4 &&
+    result(outDir).finalMessage === "fake cursor completed");
+}
+{
+  const outDir = join(scratch, "out-read-only-cursor");
+  const workDir = freshRepo("work-read-only-cursor");
+  const captureFile = join(scratch, "capture-read-only-cursor.json");
+  const run = spawnSync(process.execPath, [
+    relayPath("cursor"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--read-only",
+    "--resume-last",
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "cursor-success", SMOKE_CAPTURE_FILE: captureFile },
+    encoding: "utf8",
+  });
+  const capture = existsSync(captureFile)
+    ? JSON.parse(readFileSync(captureFile, "utf8"))
+    : { args: [] };
+  const value = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+  check("cursor read-only: plan mode resumes latest without force",
+    run.status === 0 &&
+    JSON.stringify(capture.args) === JSON.stringify([
+      "--print", "--output-format", "stream-json", "--trust",
+      "--mode", "plan",
+      "--continue",
+    ]) &&
+    value.readOnly === true &&
+    value.force === false &&
+    value.permissionMode === "plan");
+  check("cursor read-only: no unreliable porcelain tripwire is published",
+    !Object.prototype.hasOwnProperty.call(value, "readOnlyViolation"));
+}
+for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "600h"]) {
+  const rejected = spawnSync(process.execPath, [
+    relayPath("cursor"),
+    "--brief", briefPath,
+    "--timeout", bad,
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: join(scratch, "args-invalid-timeout-cursor") },
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  check(`cursor timeout: "${bad}" is rejected`, rejected.status === 2);
+}
+for (const [flag, bad] of [
+  ["--session", ""],
+  ["--session", "--continue"],
+  ["--session", "session & whoami"],
+  ["--model", ""],
+  ["--model", "--help"],
+  ["--model", "model & whoami"],
+]) {
+  const rejected = spawnSync(process.execPath, [
+    relayPath("cursor"),
+    "--brief", briefPath,
+    flag, bad,
+  ], { env: baseEnv, encoding: "utf8", timeout: 5000 });
+  check(`cursor validation: unsafe ${flag} value is rejected`, rejected.status === 2);
+}
+for (const [mode, expectedStatus, expectedExit] of [
+  ["cursor-version-hang", "timeout", 124],
+  ["cursor-version-fail", "failed", 7],
+]) {
+  const outDir = join(scratch, `out-${mode}`);
+  const preflight = spawnSync(process.execPath, [
+    relayPath("cursor"),
+    "--brief", briefPath,
+    "--out-dir", outDir,
+    "--timeout", "1s",
+  ], { env: { ...baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
+  const value = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+  check(`cursor preflight: ${mode} is explicit and prevents dispatch`,
+    preflight.status === expectedExit &&
+    value.status === expectedStatus &&
+    value.error?.includes("version preflight") &&
+    value.error?.includes("was not dispatched"));
+}
+if (!WIN) {
+  const outDir = join(scratch, "out-abort-preflight-cursor");
+  const preflight = runRelay("cursor", freshRepo("work-abort-preflight-cursor"), outDir, ["--timeout", "1s"], {
+    SMOKE_MODE: "cursor-version-hang",
+  });
+  check("cursor preflight abort: run artifacts are prepared",
+    await until(() => existsSync(join(outDir, "events.jsonl")), 2000));
+  preflight.kill("SIGTERM");
+  const exited = await new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), 5000);
+    preflight.on("close", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+  const value = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+  check("cursor preflight abort: result is aborted and dispatch never starts",
+    exited &&
+    value.status === "aborted" &&
+    value.signal === "SIGTERM" &&
+    value.error?.includes("version preflight") &&
+    value.error?.includes("was not dispatched"));
+}
+{
+  const outDir = join(scratch, "out-unavailable-cursor");
+  mkdirSync(outDir);
+  writeFileSync(join(outDir, "result.json"), "{\"status\":\"stale\"}\n");
+  writeFileSync(join(outDir, "final.txt"), "stale final\n");
+  const missing = spawnSync(process.execPath, [
+    relayPath("cursor"),
+    "--brief", briefPath,
+    "--out-dir", outDir,
+  ], { env: { ...process.env, PATH: "" }, encoding: "utf8" });
+  check("cursor unavailable: structured result replaces stale artifacts",
+    missing.status === 127 &&
+    result(outDir).status === "cursor_agent_unavailable" &&
+    !existsSync(join(outDir, "final.txt")));
+}
 
 // ---- Vibe's documented streaming argv and safer permission default ----
 for (const scenario of [

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -28,7 +28,7 @@
  *                 driven there (the skill docs carry the same caveat).
  *
  * Every fake answers each relay's version preflight (--version, `version`,
- * `changelog`). Quick Claude, Qoder, and Vibe success cases verify brief
+ * `changelog`). Quick Claude, Cursor, Qoder, and Vibe success cases verify brief
  * delivery, launch arguments, environment handling, and result-event parsing. The
  * timeout/abort cases otherwise run until killed and spawn a subprocess of
  * their own; both assert that this grandchild dies with the implementer.
@@ -456,10 +456,12 @@ const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"],
   check("cursor read-only: no unreliable porcelain tripwire is published",
     !Object.prototype.hasOwnProperty.call(value, "readOnlyViolation"));
 }
+const cursorNegativeWorkDir = freshRepo("work-negative-cursor");
 for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "600h"]) {
   const rejected = spawnSync(process.execPath, [
     relayPath("cursor"),
     "--brief", briefPath,
+    "--cd", cursorNegativeWorkDir,
     "--timeout", bad,
   ], {
     env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: join(scratch, "args-invalid-timeout-cursor") },
@@ -479,6 +481,7 @@ for (const [flag, bad] of [
   const rejected = spawnSync(process.execPath, [
     relayPath("cursor"),
     "--brief", briefPath,
+    "--cd", cursorNegativeWorkDir,
     flag, bad,
   ], { env: baseEnv, encoding: "utf8", timeout: 5000 });
   check(`cursor validation: unsafe ${flag} value is rejected`, rejected.status === 2);
@@ -491,6 +494,7 @@ for (const [mode, expectedStatus, expectedExit] of [
   const preflight = spawnSync(process.execPath, [
     relayPath("cursor"),
     "--brief", briefPath,
+    "--cd", cursorNegativeWorkDir,
     "--out-dir", outDir,
     "--timeout", "1s",
   ], { env: { ...baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
@@ -532,6 +536,7 @@ if (!WIN) {
   const missing = spawnSync(process.execPath, [
     relayPath("cursor"),
     "--brief", briefPath,
+    "--cd", cursorNegativeWorkDir,
     "--out-dir", outDir,
   ], { env: { ...process.env, PATH: "" }, encoding: "utf8" });
   check("cursor unavailable: structured result replaces stale artifacts",

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -7,10 +7,10 @@
  * not complete:
  *
  *   1. timeout  — the watchdog kills the implementer's WHOLE process tree and
- *                 result.json reports status "timeout". Driven for all seven
- *                 relays on both platforms. On Windows, claude launches a .cmd
- *                 shim through a serialized cmd.exe invocation, while
- *                 codex/opencode/grok use shell:true. These are exactly the
+ *                 result.json reports status "timeout". Driven for all eight
+ *                 relays on both platforms. On Windows, claude and cursor
+ *                 launch a .cmd shim through a serialized cmd.exe invocation,
+ *                 while codex/opencode/grok use shell:true. These are exactly the
  *                 cases a plain child.kill would miss; agy, kimi, and qoder spawn a
  *                 native binary directly — a .cmd stand-in cannot represent them,
  *                 so the smoke compiles a real fake .exe with the C# compiler
@@ -25,7 +25,7 @@
  *   2. aborted  — killing the relay itself still produces result.json with
  *                 status "aborted", and files the implementer flushes during
  *                 the shutdown grace window appear in the refreshed
- *                 touchedFiles. Driven for all seven relays on POSIX; Windows
+ *                 touchedFiles. Driven for all eight relays on POSIX; Windows
  *                 delivers no catchable SIGTERM, so the scenario cannot be
  *                 driven there (the skill docs carry the same caveat).
  *
@@ -43,8 +43,8 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder"];
-const binaryName = (skill) => skill === "qoder" ? "qodercli" : skill;
+const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder", "cursor"];
+const binaryName = (skill) => skill === "qoder" ? "qodercli" : skill === "cursor" ? "cursor-agent" : skill;
 const relayPath = (skill) => join(here, "..", "skills", `${skill}-delegate`, "scripts", "relay.mjs");
 const WIN = process.platform === "win32";
 let failed = 0;
@@ -233,8 +233,8 @@ const shimDir = join(scratch, "shim");
 mkdirSync(shimDir);
 writeFileSync(join(shimDir, "fake-cli.cjs"), FAKE);
 if (WIN) {
-  for (const skill of ["claude", "codex", "opencode", "grok"]) {
-    writeFileSync(join(shimDir, `${skill}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
+  for (const skill of ["claude", "codex", "opencode", "grok", "cursor"]) {
+    writeFileSync(join(shimDir, `${binaryName(skill)}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
   }
   const windir = process.env.WINDIR || "C:\\Windows";
   const csc = [
@@ -297,7 +297,7 @@ const emptyEffortRun = spawnSync(process.execPath,
 check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
 
 // opencode refuses a fresh run without an explicit model
-const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [] };
+const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [], cursor: [] };
 
 // ---- Qoder's documented print-mode argv and structured result ----
 {
@@ -626,6 +626,7 @@ const TIMEOUT_CASES = [
   { skill: "grok", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "kimi", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "qoder", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "cursor", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "agy", flags: ["--print-timeout", "1s"], exitDeadline: 120_000 },
 ];
 async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag) {


### PR DESCRIPTION
Adds `cursor-delegate` to the existing delegation-skill family, driving the Cursor Agent CLI (`cursor-agent`) through the same **brief → dispatch → review → land** loop. The branch is merged with current `master`, so the package now exposes nine skills without replacing newer sibling work.

## Relay contract

- Sends the brief on stdin and captures Cursor's streaming JSON into inspectable artifacts.
- Records `sessionId`, requested and resolved model, `permissionMode`, `force`, token `usage`, final report, and touched files in `result.json`.
- Supports model selection, `--resume-last`, `--session <id>`, and repeatable `--add-dir` on Cursor 2026.07.23 or newer.
- Defaults fresh write-capable runs to `--force`; `--no-force` withholds automatic command approval; `--read-only` selects Cursor's native plan mode.
- Always passes `--trust`, so the documented boundary is explicit: point `--cd` only at trusted repositories.
- Uses bounded version preflight, strict duration and shell-boundary validation, stale-artifact cleanup, atomic `result.json` publication, and whole-process-tree timeout/abort handling.
- Never commits; review and landing stay with the orchestrator.

## Verification

- Full shared `node test/relay-smoke.mjs` suite passed on macOS from head `e9e5d10`, including Cursor model/session/add-directory forwarding, `--no-force`, usage capture, read-only plan mode, validation, missing/failed/hung version preflight, preflight abort, atomic artifacts, timeout-yield, and process-tree cleanup.
- Native macOS plan-mode smoke passed against `cursor-agent` 2026.07.23-e383d2b with session/model/usage capture and no touched files.
- Contributor verified native Windows write, plan-mode, and session-resume runs against the same Cursor version.
- `npx skills add . --list` validates the package and lists all nine skills.
- The shared relay-smoke workflow is configured for Linux and Windows; results are reported in this PR's Checks tab after GitHub's fork-run approval.

## Documentation

README, package inventory, skill instructions, dispatch/reference guidance, trust boundaries, compatibility floor, and verification status are aligned with the implemented relay.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `cursor-delegate` skill to delegate bounded coding with write vs `--read-only` planning, model selection, session resumption, and enforced trust behavior.
  - Introduced a Cursor relay workflow that dispatches briefs, streams/parses Cursor output, detects read-only changes, and produces per-run artifacts with structured `result.json` reporting.
- **Documentation**
  - Updated `AGENTS.md` and README with `cursor-agent` setup plus end-to-end guidance: brief writing, dispatch/polling, review/landing, and multi-task queues, including Windows launch notes.
- **Tests**
  - Expanded relay smoke coverage for Cursor Agent, including new Windows shim behavior and additional success/read-only/timeout/unavailable-agent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->