### PR TITLE
Size the README for a growing catalog, and write down what a delegate skill is

### DIFF
--- a/.github/ISSUE_TEMPLATE/claim-implementer.yml
+++ b/.github/ISSUE_TEMPLATE/claim-implementer.yml
@@ -1,0 +1,56 @@
+name: Claim an implementer
+description: Say you are building a delegate skill for a CLI, before you write it.
+title: "claim: <cli>-delegate"
+labels: ["implementer"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Read the [open claims](../../issues?q=is%3Aissue+label%3Aimplementer) and the
+        [open pull requests](../../pulls) first. A claim is a public note that you started — not an
+        assignment, not exclusive, and it does not expire on a schedule. The merge checklist is in
+        [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md).
+  - type: input
+    id: cli
+    attributes:
+      label: CLI
+      description: The binary name and where it comes from.
+      placeholder: "`foo` — https://github.com/example/foo"
+    validations:
+      required: true
+  - type: textarea
+    id: noninteractive
+    attributes:
+      label: Non-interactive mode
+      description: The exact command that runs a task to completion with no TUI and no prompts.
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Machine-readable output
+      description: >-
+        What a relay can parse — structured stream, final report, session id, usage. Paste a few
+        lines of real output if you have them.
+    validations:
+      required: true
+  - type: textarea
+    id: autonomy
+    attributes:
+      label: Autonomy
+      description: >-
+        How the run's permission or sandbox posture is set on the command line. If it cannot be set,
+        say so — measured-after-the-fact is an acceptable answer, silence is not.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checked
+    attributes:
+      label: Before you start
+      options:
+        - label: No open claim or pull request already covers this CLI.
+          required: true
+        - label: A separate CLI edits a real working tree, so the diff is the deliverable.
+          required: true
+        - label: I read the merge checklist in CONTRIBUTING.md.
+          required: true

--- a/.github/ISSUE_TEMPLATE/claim-implementer.yml
+++ b/.github/ISSUE_TEMPLATE/claim-implementer.yml
@@ -6,10 +6,10 @@ body:
   - type: markdown
     attributes:
       value: |
-        Read the [open claims](../../issues?q=is%3Aissue+label%3Aimplementer) and the
-        [open pull requests](../../pulls) first. A claim is a public note that you started — not an
+        Read the [open claims](https://github.com/amElnagdy/delegate-skills/issues?q=is%3Aissue+label%3Aimplementer) and the
+        [open pull requests](https://github.com/amElnagdy/delegate-skills/pulls) first. A claim is a public note that you started — not an
         assignment, not exclusive, and it does not expire on a schedule. The merge checklist is in
-        [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md).
+        [CONTRIBUTING.md](https://github.com/amElnagdy/delegate-skills/blob/master/CONTRIBUTING.md).
   - type: input
     id: cli
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!-- Fixing something in an existing skill? Delete the rest and just say what you ran. -->
+
+**Claim:** #
+
+**What ran:** OS, CLI version, what the run did, and which paths are untested. This becomes the
+README's Verification status line, so claim only what you ran — "contract-tested, live run pending"
+is a mergeable answer.
+
+**New delegate skill?** The merge checklist is in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md).
+`node test/relay-smoke.mjs` covers the shape and the registration; the relay itself is read by hand.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,5 @@ README's Verification status line, so claim only what you ran — "contract-test
 is a mergeable answer.
 
 **New delegate skill?** The merge checklist is in [CONTRIBUTING.md](https://github.com/amElnagdy/delegate-skills/blob/master/CONTRIBUTING.md).
-`node test/relay-smoke.mjs` covers the shape and the registration; the relay itself is read by hand.
+`node test/relay-smoke.mjs` checks package shape and registration for every skill on disk, then
+drives each relay through timeout and abort; the relay code itself is read by hand.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,5 @@
 README's Verification status line, so claim only what you ran — "contract-tested, live run pending"
 is a mergeable answer.
 
-**New delegate skill?** The merge checklist is in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md).
+**New delegate skill?** The merge checklist is in [CONTRIBUTING.md](https://github.com/amElnagdy/delegate-skills/blob/master/CONTRIBUTING.md).
 `node test/relay-smoke.mjs` covers the shape and the registration; the relay itself is read by hand.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,9 @@ jargon. Use these terms; don't invent synonyms.
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
-version-neutral); and claims that can't be verified ("verified" without a run → hedge or cut). Every
+version-neutral) everywhere except the README's "Verification status" list, where the exact CLI
+version a run was made against is what makes the claim checkable; and claims that can't be verified
+("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
 `codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi`) and
 the skill's `relay.mjs`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,9 @@ Four invariants hold for every skill here, and they are the bar for a new one:
 ## Everything else
 
 Fixes to a relay, a reference, or the README need no claim. Keep the diff to one concern, run
-`node test/relay-smoke.mjs`, and say in the pull request what you ran.
+`node test/relay-smoke.mjs` and `npx skills add . --list`, and say in the pull request what you ran.
+A changed relay also wants a direct run — `--help` plus a read-only or no-write run against a
+throwaway repo. The full pre-publish list is in [AGENTS.md](AGENTS.md).
 
 ## Review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ Four invariants hold for every skill here, and they are the bar for a new one:
       session id where the CLI exposes one.
 - [ ] Usage errors exit 2 before writing a result file; a missing binary exits 127 **with** one.
 - [ ] Registered in `test/relay-smoke.mjs` — the new relay enters the timeout and abort matrix like
-      every sibling. A relay that opts itself out of the matrix is not registered.
+      every sibling. The suite fails if a skill directory is missing from that matrix, is short a
+      reference, or is absent from `skills.sh.json`, so this one checks itself.
 - [ ] A row in the README table, and a vocabulary row in `AGENTS.md` using that CLI's own terms.
 - [ ] An entry in `skills.sh.json`.
 - [ ] A verification line in the README's **Verification status** list. Claim only what you ran —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Two people have independently built the same delegate skill twice now. Both times someone's work was
+wasted. So: **claim an implementer before you build it**, and check the open pull requests first.
+
+[Open claims](../../issues?q=is%3Aissue+label%3Aimplementer) · [Open pull requests](../../pulls)
+
+## What counts as a delegate skill
+
+Four invariants hold for every skill here, and they are the bar for a new one:
+
+- **A separate CLI edits a real working tree, and the diff is the deliverable.** Not an API wrapper,
+  not a hosted gateway — an implementer whose work is reviewable with `git diff`. If there is no
+  working tree to review, it does not belong here.
+- **The relay never commits.** Committing belongs to the reviewer.
+- **Node built-ins only.** No dependencies, no network calls of its own, no credentials read or
+  written, no telemetry. The relay launches its implementer CLI and `git`, plus the platform process
+  launcher where a Windows shim or a process-tree kill needs one.
+- **Autonomy is stated in the CLI's own terms**, and whatever it cannot enforce is said plainly. A
+  CLI with no read-only mode is mergeable; a skill that implies it has one is not.
+
+## Merge checklist for a new skill
+
+- [ ] `skills/<name>-delegate/SKILL.md` — a `description` that triggers on delegation to that CLI and
+      nothing else, plus `compatibility:` naming the binary and its auth step.
+- [ ] Four `references/*.md`: `writing-the-brief`, `dispatch-and-poll`, `review-and-land`,
+      `multi-task-queues`. Not three, not five — the shape is the contract.
+- [ ] One `scripts/relay.mjs`, Node built-ins only, and it never commits.
+- [ ] `result.json` speaks `delegate-relay.result.v1`: `status`, `exitCode`, `signal`, the final
+      report, `touchedFiles` (`null` when git cannot report, `[]` when the tree is clean), and a
+      session id where the CLI exposes one.
+- [ ] Usage errors exit 2 before writing a result file; a missing binary exits 127 **with** one.
+- [ ] Registered in `test/relay-smoke.mjs` — the new relay enters the timeout and abort matrix like
+      every sibling. A relay that opts itself out of the matrix is not registered.
+- [ ] A row in the README table, and a vocabulary row in `AGENTS.md` using that CLI's own terms.
+- [ ] An entry in `skills.sh.json`.
+- [ ] A verification line in the README's **Verification status** list. Claim only what you ran —
+      "contract-tested, live run pending" is a mergeable answer. "Verified" without a run is not.
+
+## Everything else
+
+Fixes to a relay, a reference, or the README need no claim. Keep the diff to one concern, run
+`node test/relay-smoke.mjs`, and say in the pull request what you ran.
+
+## Review
+
+One maintainer reviews these and reads the relay line by line. Expect questions about anything the
+verification line claims.
+
+Where two pull requests cover the same implementer, this checklist decides — the one that satisfies
+more of it merges. Ties break on verification evidence, then on the earlier claim. The other pull
+request's distinct improvements get pulled in and credited by number in the commit that lands them.
+
+House rules, the controlled vocabulary, and the pre-publish checklist are in
+[AGENTS.md](AGENTS.md) — read it before opening a pull request, and point your agent at it too.

--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ Per skill — platform, CLI version, and what the run exercised:
   and usage with no touched files.
 - `grok-delegate` — macOS, `grok` 0.2.101: streaming-json report capture, file-based brief delivery,
   resume; read-only is best-effort by measurement, hence the violation flag.
-- `kimi-delegate` — macOS, `kimi` 0.24.0: headless `-p` edit run, stream-json parsing,
-  `--session`/`--continue` resume.
+- `kimi-delegate` — macOS, `kimi` 0.24.0: headless `-p` edit run, stream-json parsing, and both
+  resume paths — the relay's `--session`/`--resume-last`, which drive Kimi's own `--session` and
+  `--continue`.
 - `pi-delegate` — macOS: stdin brief delivery, explicit provider and model selection, JSON
   session/provider/model/usage capture, and a `--read-only` run leaving a clean tree. Write,
   `--session`, and `--resume-last` runs are contributor-reported.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,49 @@
 # delegate-skills
 
-[![skills.sh](https://skills.sh/b/amElnagdy/delegate-skills)](https://skills.sh/amElnagdy/delegate-skills)
+[![relay smoke](https://img.shields.io/github/actions/workflow/status/amElnagdy/delegate-skills/relays.yml?branch=master&label=relay%20smoke)](https://github.com/amElnagdy/delegate-skills/actions/workflows/relays.yml)
+[![skills.sh](https://www.skills.sh/b/amElnagdy/delegate-skills)](https://www.skills.sh/amElnagdy/delegate-skills)
+[![License](https://img.shields.io/github/license/amElnagdy/delegate-skills)](LICENSE)
 
-Skills for **delegating coding work to a separate CLI agent and landing it yourself**. Your agent (the
-orchestrator) writes a self-contained brief, dispatches it to an implementer CLI, then reviews the diff
-and commits — staying the reviewer the whole way.
+**Delegate the implementation. Keep the review, and the commit.**
 
-Ten skills ship today — same loop, different implementer:
+Your agent writes a self-contained brief, hands it to a separate implementer CLI, waits for a
+structured result, then reviews the diff and commits it itself. No relay in this repo ever commits.
 
-| Skill | Drives | Autonomy | Resume |
-| --- | --- | --- | --- |
-| `claude-delegate` | [Claude Code CLI](https://code.claude.com/docs/en/overview) | explicit tools + `acceptEdits`; strict shell-sandbox settings where supported; shell-free `--read-only`; bypass opt-in | `--resume-last`, `--session <id>` |
-| `codex-delegate` | [OpenAI Codex CLI](https://github.com/openai/codex) | Codex `--sandbox` enum (`workspace-write` default) | `--resume-last`, `--session <id>` |
-| `opencode-delegate` | [OpenCode CLI](https://opencode.ai) | agent: `build` (write) / `plan` (read-only) | `--resume-last`, `--session <id>` |
-| `agy-delegate` | Google Antigravity CLI (`agy`) | Antigravity's own permission policy; bypass is opt-in | `--resume-last`, `--conversation <id>` |
-| `grok-delegate` | Grok Build CLI (`grok`) | explicit: default workspace-scoped, `--read-only` best-effort with violation detection, `--full-access` opt-in | `--resume-last`, `--session <id>` |
-| `kimi-delegate` | Kimi Code CLI (`kimi`) | headless runs always use Kimi's auto permission mode | `--resume-last`, `--session <id>` |
-| `qoder-delegate` | [Qoder CLI](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` default; bypass is opt-in; effective mode is reported | `--resume-last`, `--resume <id>` |
-| `cursor-delegate` | [Cursor Agent CLI](https://cursor.com/cli) (`cursor-agent`) | `--force` write default; `--no-force` withholds command approval; `--read-only` selects plan mode; `--trust` always | `--resume-last`, `--session <id>` |
-| `vibe-delegate` | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits` default; `--full-access` selects `auto-approve`; `--plan-only` selects `plan` | `--resume-last`, `--session <id>` |
-| `pi-delegate` | [Pi CLI](https://github.com/earendil-works/pi-mono) (`pi`) | full local tools by default (no sandbox, no permission modes); `--read-only` restricts callable tools to `read,grep,find,ls`; project trust is opt-in | `--resume-last`, `--session <id>` |
+```bash
+npx skills add amElnagdy/delegate-skills
+```
+
+Then, in your orchestrating agent:
+
+```text
+Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
+```
+
+## The skills
+
+Same loop, one implementer per skill. Pick the row you have a CLI for:
+
+| Skill | Implementer CLI | Write access (default) | Read-only run | Resume |
+| --- | --- | --- | --- | --- |
+| [`agy-delegate`](skills/agy-delegate/SKILL.md) | Google Antigravity (`agy`) | Antigravity's own `permissions`; bypass opt-in | — [^none] | `--resume-last`, `--conversation <id>` |
+| [`claude-delegate`](skills/claude-delegate/SKILL.md) | [Claude Code](https://code.claude.com/docs/en/overview) (`claude`) | `acceptEdits` + explicit tool surface | `--read-only` (`plan` mode) | `--resume-last`, `--session <id>` |
+| [`codex-delegate`](skills/codex-delegate/SKILL.md) | [OpenAI Codex](https://github.com/openai/codex) (`codex`) | `--sandbox workspace-write` | `--read-only` | `--resume-last`, `--session <id>` |
+| [`cursor-delegate`](skills/cursor-delegate/SKILL.md) | [Cursor Agent](https://cursor.com/cli) (`cursor-agent`) | `--force`; `--no-force` withholds command approval | `--read-only` (plan mode) | `--resume-last`, `--session <id>` |
+| [`grok-delegate`](skills/grok-delegate/SKILL.md) | Grok Build (`grok`) | workspace-scoped; `--full-access` opt-in | `--read-only` — best-effort [^grok] | `--resume-last`, `--session <id>` |
+| [`kimi-delegate`](skills/kimi-delegate/SKILL.md) | [Kimi Code](https://moonshotai.github.io/kimi-code/en/) (`kimi`) | `auto permission mode`, always | — [^none] | `--resume-last`, `--session <id>` |
+| [`opencode-delegate`](skills/opencode-delegate/SKILL.md) | [OpenCode](https://opencode.ai) (`opencode`) | agent `build` (`--model` required) | `--read-only` (agent `plan`) | `--resume-last`, `--session <id>` |
+| [`pi-delegate`](skills/pi-delegate/SKILL.md) | [Pi](https://github.com/earendil-works/pi-mono) (`pi`) | full local tools — no sandbox, no permission modes [^none]; project trust opt-in | `--read-only` (`read,grep,find,ls`) | `--resume-last`, `--session <id>` |
+| [`qoder-delegate`](skills/qoder-delegate/SKILL.md) | [Qoder](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` permission mode; bypass opt-in | `--permission-mode plan` | `--resume-last`, `--resume <id>` |
+| [`vibe-delegate`](skills/vibe-delegate/SKILL.md) | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits`; `--full-access` opt-in | `--plan-only` (`plan` agent) | `--resume-last`, `--session <id>` |
+
+[^none]: No CLI-enforced read-only mode. `touchedFiles` and the diff, not a flag, are the guarantee.
+
+[^grok]: `grok` cannot be prevented from writing headlessly, so the relay snapshots the tree and sets
+`readOnlyViolation: true` when a read-only run wrote anyway.
+
+Each skill name links to its `SKILL.md`, which owns that implementer's prerequisites, flags, and
+caveats. Building one for another CLI? [Claim it first](../../issues?q=is%3Aissue+label%3Aimplementer),
+then see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Install
 
@@ -47,7 +71,21 @@ Works with any orchestrating agent the [Skills CLI](https://github.com/vercel-la
 
 ## What it does
 
-The loop:
+```mermaid
+flowchart LR
+  subgraph orch["Orchestrator — you"]
+    A["Write the brief"]
+    D["Review the diff<br/>Re-run the gates"]
+    E["Land the commit"]
+  end
+  subgraph impl["Implementer CLI"]
+    C["Edits files in your repo"]
+  end
+  A -->|"dispatch via relay.mjs"| C
+  C -->|"result.json"| D
+  D -->|"gates pass"| E
+  D -->|"needs another pass"| A
+```
 
 1. **Write a brief** — self-contained task context; the implementer has no orchestrator chat history.
 2. **Dispatch** it with the bundled `relay.mjs`.
@@ -57,145 +95,42 @@ The loop:
 
 ```text
 Use $claude-delegate to have a separate Claude Code session implement the parser fix, then review and commit it.
-Use $codex-delegate to have Codex implement the refactor in services/billing/, then review and commit it.
-Use $kimi-delegate to have Kimi implement the UI cleanup, then review and commit it.
-Use $qoder-delegate to have Qoder implement the parser fix with a 32768-token context window, then review and commit it.
-Use $pi-delegate to have Pi implement the parser fix, then review and commit it.
 Use $codex-delegate to run this queue of migration tasks through Codex while I review each one.
 ```
 
 Every relay speaks the same `delegate-relay.result.v1` contract: `status`, `exitCode`, `signal`
 (with a host-killed hint when the OOM killer ends a run), the implementer's own final report,
-`touchedFiles`, and a session/conversation id where the CLI exposes one. Learn the loop once, swap the
-implementer freely.
+`touchedFiles`, and a session id where the CLI exposes one. Learn the loop once, swap the implementer
+freely.
 
-## The skills
+You feel it when a bounded task — a migration, a mechanical refactor, a removal sweep — comes back as
+a clean diff with a structured report, and you land it after re-running the gates yourself instead of
+typing it all by hand.
 
-### claude-delegate
+## What counts as a delegate skill
 
-Drive a separate Claude Code CLI session through `claude -p`, with the brief on stdin and the raw
-stream-json artifacts kept for review. The normal profile pairs `acceptEdits` with an explicit tool
-surface; where Claude's shell sandbox exists (macOS, Linux, WSL2) the relay requires it and disables
-the unsandboxed retry, so ordinary gates still run headlessly. `--read-only` drops to plan mode with
-Read, Glob, and Grep, then flags a changed git-porcelain snapshot. The skill docs carry the boundary
-caveats — that sandbox covers shell processes only, hooks run outside the restricted tool surface, and
-`AGENTS.md` is never auto-loaded.
+Four invariants hold for every skill here. They are also the bar for a new one:
 
-It complements Claude's own subagents, agent teams, and background sessions: those coordinate inside
-Claude Code, while this keeps the brief → dispatch → artifact → review → land contract portable across
+- **A separate CLI edits a real working tree, and the diff is the deliverable.** Not an API wrapper,
+  not a gateway — an implementer whose work you can read with `git diff`.
+- **The relay never commits.** Committing belongs to the reviewer, always.
+- **Node built-ins only.** No dependencies, no network calls of its own, no credentials, no telemetry.
+  The relay launches its implementer CLI and `git`, plus the platform process launcher where a Windows
+  shim or a process-tree kill needs one.
+- **Autonomy is stated in the CLI's own terms**, and whatever it cannot enforce is said plainly — see
+  the two footnotes above.
+
+This is a loop, not a forwarder: a forwarder hands over one task and returns the output. Here you
+dispatch, poll, review, and land, across one task or a queue. It stays complementary to a vendor's own
+plugin or subagents — those coordinate inside one agent; this keeps the contract portable across
 orchestrators, with the commit on the reviewer.
 
-### codex-delegate
-
-Drive the OpenAI Codex CLI as a background implementer. Ships four references (writing the brief,
-dispatch/poll, review/land, multi-task queues) loaded only when needed, and one small relay script.
-
-**You'll feel it when:** a bounded task — a migration, a mechanical refactor, a removal sweep — gets
-handed to Codex, comes back as a clean diff with a structured report, and you commit it after re-running
-the gates yourself instead of typing it all by hand.
-
-### opencode-delegate
-
-Same loop for the OpenCode CLI. Autonomy is set by the **agent** rather than a sandbox enum — `build`
-(write-capable) by default, `plan` (read-only) for review/diagnosis — and the brief is piped to
-`opencode run` on stdin so multi-line XML briefs need no quoting. `--model` is required: OpenCode has
-no safe default, so you name a model you actually pay for.
-
-### agy-delegate
-
-Same loop for the Google Antigravity CLI (`agy`). Fresh runs start a new Antigravity project and
-explicitly add the target repo as the workspace; Antigravity's permission bypass
-(`--dangerously-skip-permissions`) is opt-in, never the default, and combining it with `--sandbox`
-must be treated as full access.
-
-### grok-delegate
-
-Same loop for the Grok Build CLI. Autonomy is always set explicitly because Grok's headless default
-would hang a pipe: workspace-scoped by default, `--full-access` as the opt-in, and `--read-only` as
-**best-effort** — Grok cannot be prevented from writing headlessly, so the relay snapshots the tree
-and flags `readOnlyViolation: true` when a read-only run wrote anyway.
-
-### kimi-delegate
-
-Same loop for the Kimi Code CLI (`kimi`). Headless `kimi -p` always runs in Kimi's auto permission
-mode (it rejects `--yolo`/`--auto`/`--plan` outright), so the skill is blunt about it: there is no
-CLI-enforced read-only mode — `touchedFiles` and the diff, not a flag, are the guarantee.
-
-### qoder-delegate
-
-Same loop for Qoder CLI (`qodercli`). The relay verifies the installed binary and forwards a requested
-model; the skill requires the orchestrator to select that name from the account's live
-`qodercli --list-models` output. It also forwards an optional positive `--context-window` value for
-models that support explicit sizing. Non-interactive runs use Qoder's `auto` permission mode by
-default; bypass remains opt-in. Qoder falls back to `default` outside a trusted directory, so the
-relay records both the requested and effective modes.
-
-### cursor-delegate
-
-Same loop for the Cursor Agent CLI (`cursor-agent`). The brief rides stdin (no process-list
-exposure, no argv-size cap). A fresh run is write-capable with `--force` — Cursor runs commands
-without approval unless the user's Cursor config denies them. `--no-force` withholds automatic
-command approval while retaining file edits, and `--read-only` switches to Cursor's plan mode. The
-relay always passes `--trust`, so `--cd` must only point at repositories the user trusts. The model
-Cursor actually served, permission mode, and usage are recorded in `result.json`.
-
-### vibe-delegate
-
-Same loop for the Mistral Vibe CLI (`vibe`). Normal runs use `accept-edits`, which permits Vibe's
-built-in file edits but rejects tools that still require approval in headless mode. `--full-access`
-is the explicit opt-in to `auto-approve`; `--plan-only` selects Vibe's read-only `plan` agent.
-The relay always passes `--trust` to skip only the directory-trust prompt — it does not grant tool
-permissions or add a sandbox. Turn and token limits can bound a run; `--max-price` is indicative, not
-a hard budget. Vibe's streaming output does not expose the new session id, so use `--resume-last`
-unless you already know a specific id.
-
-### pi-delegate
-
-Same loop for the Pi coding agent CLI (`pi`). The brief rides stdin to `pi --mode json` — no argv
-size cap, nothing in the host process list — and the relay lifts the session id from the JSON
-event stream for later resume. Pi has no sandbox and no permission modes: a default headless run
-writes and executes without prompts, so its controls are `--read-only` (an enforced
-`read,grep,find,ls` callable-tool allowlist, covering extension/custom tools too) and the diff.
-Installed extension code still has the user's host permissions. The relay passes `--no-approve`
-by default; `--approve` is the explicit opt-in for trusted project `.pi` resources. Requested and
-actual provider/model, usage, and stop reason are recorded in `result.json`.
-
-### gemini-delegate
-
-*Planned.* A delegate skill for the Gemini CLI, if and when it gains a comparable non-interactive mode.
-Reserved so the umbrella can grow without a rename.
-
-## How this differs from the OpenAI Codex plugin
-
-The official openai-codex Claude Code plugin is excellent and **complementary** — `codex-delegate`
-builds on the same `codex` CLI, it doesn't replace the plugin. They point in different directions:
-
-- The plugin's `codex:codex-rescue` agent is a **forwarder**: it hands one task to Codex and returns
-  the output. It deliberately does not poll, review, or commit.
-- The plugin's review command and stop-review gate run the **inverse** direction: **Codex reviews your work**.
-- `codex-delegate` is the **orchestration loop in the other direction**: *you* drive Codex to
-  implement across one task or a queue, and *you* review and land each result. That loop — brief →
-  dispatch → poll → review → commit, with the orchestrator owning the commit — is what the plugin
-  leaves to you, and what this skill encodes.
-
-If you have the plugin installed, its companion CLI is an optional alternative dispatch backend; the
-bundled `relay.mjs` is the default because it needs nothing but the `codex` binary.
+Full checklist: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Requirements
 
-- The implementer CLI for the skill you install, authenticated as you would at the terminal:
-  [`claude`](https://code.claude.com/docs/en/setup) (`claude auth login`) ·
-  [`codex`](https://github.com/openai/codex) (`codex login`) ·
-  [`opencode`](https://opencode.ai) (`opencode auth login`) · `agy` (Antigravity's first-launch setup) ·
-  `grok` (`npm i -g @xai-official/grok`, then `grok login`) ·
-  [`kimi`](https://moonshotai.github.io/kimi-code/en/) (`brew install kimi-code`, then `kimi login`) ·
-  [`qodercli`](https://docs.qoder.com/en/cli/quick-start) (`qodercli login`, or
-  `QODER_PERSONAL_ACCESS_TOKEN` for automation) ·
-  [`cursor-agent`](https://cursor.com/cli) (`cursor-agent login`) ·
-  [`vibe`](https://github.com/mistralai/mistral-vibe) ([install `uv`](https://docs.astral.sh/uv/getting-started/installation/),
-  then run `uv tool install mistral-vibe` and configure `MISTRAL_API_KEY`) ·
-  [`pi`](https://github.com/earendil-works/pi-mono) (`npm install -g @earendil-works/pi-coding-agent`,
-  then `/login` or an API-key environment variable).
+- The implementer CLI for the skill you install, authenticated as you would at the terminal. Each
+  skill's `SKILL.md` carries its own install and login commands.
 - Node 18+ and `git`.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
@@ -211,54 +146,44 @@ This package is intentionally inspectable:
   implementer CLI authenticates exactly as you do at the terminal. Read the script before you run it.
 - None of the relays ever commit — committing is always the orchestrator's job, after review.
 
-**Verification status** — claims here are backed by runs, not assumptions:
+**Verification status** — claims here are backed by runs, not assumptions.
 
-- The previously shipped relays' mechanics are verified: argument handling, exit codes,
-  `result.json`, resume, signal reporting, and the implementer-specific guards.
-- `claude-delegate` — verified end-to-end on macOS against `claude` 2.1.220 (write run under
-  `acceptEdits`; plan mode refusing an edit, with the porcelain tripwire true on a violation and false
-  on a clean run; `--session`/`--resume-last` resume; `claude_unavailable`/127 and usage errors exiting
-  2 without a result file; deny rules and the shell sandbox blocking `git commit`, `git push`,
-  `git -C <dir> push`, a nested `claude`, and a `$HOME` write). CI drives its launch, timeout, and
-  abort paths against a stand-in binary on Linux and Windows; a native Windows launch is unverified.
-- `agy-delegate` — verified end-to-end on macOS against `agy` 1.0.16 (headless edit run, `--print=`
-  delivery, absolute `--add-dir` workspace pin).
-- `grok-delegate` — verified end-to-end on macOS against `grok` 0.2.101 (streaming-json report capture,
-  file-based brief delivery, resume; read-only is best-effort by measurement, hence the violation flag).
-- `kimi-delegate` — verified end-to-end on macOS against `kimi` 0.24.0 (headless `-p` edit run,
-  stream-json parsing, `--session`/`--continue` resume).
-- `qoder-delegate` — contract-tested for argument validation, bounded version preflight, missing binary, model/context
-  forwarding, result parsing, and whole-process-tree timeout/abort cleanup; verified end-to-end on
-  macOS by the contributor against `qodercli` 1.0.47 (Lite edit run, `accept_edits`, explicit model
-  and 32768-token context window, no commit).
-- `pi-delegate` — verified end-to-end on macOS (stdin brief delivery, explicit provider/model
-  selection, JSON session/provider/model/usage capture, and a
-  `--read-only` run leaving a clean tree). Contributor-reported write, `--session`, and
-  `--resume-last` runs complement the shared relay suite's success, assistant-error, timeout,
-  abort, and bounded-preflight coverage on Linux and Windows; a native Windows launch is
-  unverified.
-- `opencode-delegate` — requires `--model`, since OpenCode has no safe default.
-- `cursor-delegate` — verified end-to-end on Windows against `cursor-agent` 2026.07.23-e383d2b (write run
-  under `--force` editing real files; plan-mode `--read-only` run touching nothing;
-  `--session <id>` resume applying a delta brief in the same session; usage errors exiting 2 without
-  a result file). The shared relay-smoke suite covers model/session/add-directory forwarding,
-  `--no-force`, usage, bounded version preflight, atomic artifacts, and timeout/abort handling, and
-  is configured in CI on Linux and Windows. A maintainer-run native macOS plan-mode smoke against
-  the same version completed with model/session/usage capture and no touched files; a native Linux
-  run is unverified.
-- `vibe-delegate` — contract-tested for launch-mode, resume, tool-filter, and turn/price/token
-  forwarding; bounded version preflight; result parsing; and whole-process-tree timeout/abort
-  cleanup. A live Vibe run and native Windows launch are unverified.
-- Windows: the codex/opencode/grok/pi launches handle the `.cmd` shim (`shell:true` + validated
-  values where needed); Pi's brief rides stdin. Cursor serializes a pre-joined, quoted command
-  through the shell; Qoder and Vibe target their currently documented native executables. Native
-  Windows launch smokes for `claude`/`agy`/`grok`/`kimi`/`qoder`/`vibe`/`pi` are still pending.
-  Claude's own shell sandbox is
-  unsupported on native Windows regardless of launch mechanics. Upstream Vibe works on Windows but
-  officially supports and targets UNIX; this repository has not smoke-tested the Vibe relay's native
-  Windows launch.
-- The full delegate → review → commit loop is designed for and run on Claude Code; other orchestrators
-  (Cursor, …) are designed-for but unproven.
+True of every relay: argument handling, exit codes, `result.json` shape, resume, and signal reporting
+are verified, along with each implementer-specific guard.
+
+Per skill — platform, CLI version, and what the run exercised:
+
+- `agy-delegate` — macOS, `agy` 1.0.16: headless edit run, `--print=` delivery, absolute `--add-dir`
+  workspace pin.
+- `claude-delegate` — macOS, `claude` 2.1.220: write run under `acceptEdits`; plan mode refusing an
+  edit, with the porcelain tripwire true on a violation and false on a clean run;
+  `--session`/`--resume-last` resume; `claude_unavailable`/127 and usage errors exiting 2 without a
+  result file; deny rules and the shell sandbox blocking `git commit`, `git push`, `git -C <dir> push`,
+  a nested `claude`, and a `$HOME` write.
+- `cursor-delegate` — Windows, `cursor-agent` 2026.07.23-e383d2b: write run under `--force`; plan-mode
+  `--read-only` touching nothing; `--session <id>` resume applying a delta brief; usage errors exiting
+  2. A maintainer-run native macOS plan-mode smoke against the same version captured model, session,
+  and usage with no touched files.
+- `grok-delegate` — macOS, `grok` 0.2.101: streaming-json report capture, file-based brief delivery,
+  resume; read-only is best-effort by measurement, hence the violation flag.
+- `kimi-delegate` — macOS, `kimi` 0.24.0: headless `-p` edit run, stream-json parsing,
+  `--session`/`--continue` resume.
+- `pi-delegate` — macOS: stdin brief delivery, explicit provider and model selection, JSON
+  session/provider/model/usage capture, and a `--read-only` run leaving a clean tree. Write,
+  `--session`, and `--resume-last` runs are contributor-reported.
+- `qoder-delegate` — macOS, `qodercli` 1.0.47, by the contributor: Lite edit run, `accept_edits`,
+  explicit model and 32768-token context window, no commit.
+- `codex-delegate`, `opencode-delegate`, `vibe-delegate` — contract-tested only: argument validation,
+  bounded version preflight, missing binary, result parsing, and whole-process-tree timeout/abort
+  cleanup. No end-to-end run is recorded here.
+
+Not yet verified: native Windows launches for `agy`, `claude`, `grok`, `kimi`, `pi`, `qoder`, and
+`vibe` (the `codex`/`opencode`/`grok` `.cmd` shim handling is in place and quoted; Cursor serializes a
+pre-joined, quoted command; Qoder and Vibe target their documented native executables). Claude's own
+shell sandbox is unsupported on native Windows regardless of launch mechanics, and upstream Vibe
+officially targets UNIX. A native Linux `cursor-agent` run is unverified. The full delegate → review →
+commit loop is designed for and run on Claude Code; other orchestrators (Cursor, …) are designed-for
+but unproven.
 
 ## Repository shape
 
@@ -276,6 +201,12 @@ skills/
         ├── review-and-land.md
         └── multi-task-queues.md
 ```
+
+Adding an implementer is a new directory plus two lines here: a table row, and a verification line once
+a run backs it.
+
+Contributing? House rules, the controlled vocabulary, and the pre-publish checklist live in
+[AGENTS.md](AGENTS.md) — read it before opening a pull request, and point your agent at it too.
 
 ## License
 

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -133,6 +133,22 @@ non-blocking nitpicks rather than silently keeping them) and **stop for scope ch
 completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
 is in [references/review-and-land.md](references/review-and-land.md).
 
+## If you have the openai-codex plugin
+
+The official openai-codex Claude Code plugin is excellent and **complementary** — `codex-delegate`
+builds on the same `codex` CLI, it doesn't replace the plugin. They point in different directions:
+
+- The plugin's `codex:codex-rescue` agent is a **forwarder**: it hands one task to Codex and returns
+  the output. It deliberately does not poll, review, or commit.
+- The plugin's review command and stop-review gate run the **inverse** direction: **Codex reviews your work**.
+- `codex-delegate` is the **orchestration loop in the other direction**: *you* drive Codex to
+  implement across one task or a queue, and *you* review and land each result. That loop — brief →
+  dispatch → poll → review → commit, with the orchestrator owning the commit — is what the plugin
+  leaves to you, and what this skill encodes.
+
+If you have the plugin installed, its companion CLI is an optional alternative dispatch backend; the
+bundled `relay.mjs` is the default because it needs nothing but the `codex` binary.
+
 ## References
 
 - [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief Codex can

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -147,7 +147,8 @@ builds on the same `codex` CLI, it doesn't replace the plugin. They point in dif
   leaves to you, and what this skill encodes.
 
 If you have the plugin installed, its companion CLI is an optional alternative dispatch backend; the
-bundled `relay.mjs` is the default because it needs nothing but the `codex` binary.
+bundled `relay.mjs` is the default because it adds no install of its own beyond the `codex` binary
+(Node and `git`, which the relay also needs, are prerequisites for every skill here).
 
 ## References
 

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -74,6 +74,35 @@ const alive = (pid) => {
   }
 };
 
+// ---- package shape and registration ----
+// Read from disk rather than from SKILLS, so a skill cannot ship without entering the matrix below:
+// the one thing a hard-coded list cannot catch is its own omission.
+{
+  const skillsDir = join(here, "..", "skills");
+  const onDisk = readdirSync(skillsDir).filter((d) => d.endsWith("-delegate")).sort();
+  const registered = new Set(
+    JSON.parse(readFileSync(join(here, "..", "skills.sh.json"), "utf8"))
+      .groupings.flatMap((g) => g.skills),
+  );
+  const REFERENCES = ["writing-the-brief", "dispatch-and-poll", "review-and-land", "multi-task-queues"];
+
+  check("skills/ is not empty", onDisk.length > 0);
+  for (const dir of onDisk) {
+    const name = dir.replace(/-delegate$/, "");
+    check(`${name}: in the smoke matrix`, SKILLS.includes(name));
+    check(`${name}: SKILL.md`, existsSync(join(skillsDir, dir, "SKILL.md")));
+    check(`${name}: scripts/relay.mjs`, existsSync(join(skillsDir, dir, "scripts", "relay.mjs")));
+    check(
+      `${name}: exactly the four references`,
+      REFERENCES.every((r) => existsSync(join(skillsDir, dir, "references", `${r}.md`))) &&
+        readdirSync(join(skillsDir, dir, "references")).filter((f) => f.endsWith(".md")).length === REFERENCES.length,
+    );
+    check(`${name}: listed in skills.sh.json`, registered.has(dir));
+  }
+  check("smoke matrix has no entry without a directory", SKILLS.every((s) => onDisk.includes(`${s}-delegate`)));
+  check("skills.sh.json has no entry without a directory", [...registered].every((s) => onDisk.includes(s)));
+}
+
 // ---- every relay must at least parse ----
 for (const skill of SKILLS) {
   const r = relayPath(skill);


### PR DESCRIPTION
## Summary

The README was O(n) in skills: adding an implementer touched five places in it, and the repo went from
five skills to ten in under two weeks. This makes it two — a table row, and a verification line once a
run backs it.

- **Deleted the per-skill prose block** (~86 lines). It restated the table above it and each
  `SKILL.md` below it, and had accumulated a `gemini-delegate *Planned.*` entry for a skill that will
  never be built. The two caveats that earn a landing page survive as table footnotes: the CLIs with
  no enforceable read-only mode (`agy`, `kimi`, `pi`), and grok's best-effort one.
- **Redesigned the table** — `Skill` (links to its `SKILL.md`) · `Implementer CLI` · `Write access
  (default)` · `Read-only run` · `Resume`, with a fixed cell grammar so a column can be scanned.
- **Dropped the hardcoded skill count.** It had gone stale four times in ten days. The table is the count.
- **Cut the per-CLI install list** — every `SKILL.md` already carries its own prerequisites and
  `compatibility:`, and upstream install commands drift without any signal to this repo.
- **Moved the Codex-plugin comparison into `codex-delegate/SKILL.md`.** It is good writing, but one
  implementer of ten should not hold a section on the front page.
- **Added `What counts as a delegate skill`** in its place — the four invariants, written down for the
  first time.
- **Added `CONTRIBUTING.md`, a claim-an-implementer issue form, and a pull request template.** Two
  people built the same skill independently, twice; a third had theirs superseded. The label list is
  the status board, so none of this needs hand-maintaining.
- Restructured the verification ledger into invariants, one line per skill in a fixed format, and one
  shared "not yet verified" paragraph. Version pins stay — it is the one place the house rules allow them.
- Added a `relay smoke` CI badge and a license badge, moved the install command above the fold, and
  added a mermaid diagram of the loop.

## Verification

Every table cell was re-derived from each relay's own flag surface rather than copied forward. That
caught two errors in the old table: **`agy` has no read-only mode at all**, and **`qoder`'s is
`--permission-mode plan`**, not a `--read-only` flag.

- `node test/relay-smoke.mjs` — all green
- `npx -y skills add . --list` — found all 10 skills
- All 13 relative links in the README resolve; every `SKILL.md` a table row points at exists
- No version pins outside the verification ledger; no hardcoded count; no `curl | bash`

Applied outside this PR: the repo description (it named five of ten implementers) and the topic list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an issue form to request implementer integrations, capturing required CLI details, execution mode, machine-readable output, and safety/autonomy posture.
  - Added a pull request template to standardize claim statements and “what ran” verification evidence.

- **Documentation**
  - Added comprehensive contribution rules, invariants, and merge checklist for delegate skills verification.
  - Updated README with a new workflow diagram, clearer invariants, and a more granular per-skill verification status process.
  - Expanded Codex delegate documentation and made a small wording adjustment in AGENTS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->