### PR TITLE
fix(relay): reject --timeout values the watchdog cannot honour

### DIFF
--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -71,6 +71,7 @@ import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
+const MAX_TIMER_MS = 2_147_483_647;
 const SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 
@@ -130,7 +131,7 @@ function parseArgs(argv) {
   // The watchdog is relay-only (codex has no timeout flag), so a malformed
   // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
   if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
-    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
   }
   if (opts.session !== null && opts.resumeLast) {
     fail("--session and --resume-last are mutually exclusive; pass only one");
@@ -147,7 +148,17 @@ function parseDuration(duration) {
   // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
-  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
 }
 
 function killChild(child, signal = "SIGTERM") {

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -82,6 +82,7 @@ import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
+const MAX_TIMER_MS = 2_147_483_647;
 const AUTONOMY_MODES = new Set(["workspace-write", "read-only", "full-access"]);
 
 function fail(message, code = 2) {
@@ -134,7 +135,7 @@ function parseArgs(argv) {
   // The watchdog is relay-only (the grok launch has no timeout flag), so a malformed
   // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
   if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
-    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
   }
   if (!AUTONOMY_MODES.has(opts.autonomy)) {
     fail(`invalid autonomy "${opts.autonomy}"`);
@@ -160,7 +161,17 @@ function parseDuration(duration) {
   // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
-  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
 }
 
 function killChild(child, signal = "SIGTERM") {

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -71,6 +71,7 @@ import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -124,7 +125,7 @@ function parseArgs(argv) {
   // The watchdog is relay-only (kimi has no timeout flag), so a malformed
   // --timeout must fail loudly here - a silent 30m fallback would be wrong.
   if (parseDuration(opts.timeout) === null) {
-    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
   }
   return opts;
 }
@@ -188,7 +189,17 @@ function parseDuration(duration) {
   // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
-  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
 }
 
 function gitTouchedFiles(cwd) {

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -72,6 +72,8 @@ import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
+const MAX_TIMER_MS = 2_147_483_647;
+
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
   process.exit(code);
@@ -125,7 +127,7 @@ function parseArgs(argv) {
   // The watchdog is relay-only (the opencode launch has no timeout flag), so a malformed
   // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
   if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
-    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
   }
   return opts;
 }
@@ -134,7 +136,17 @@ function parseDuration(duration) {
   // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
-  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
 }
 
 function killChild(child, signal = "SIGTERM") {

--- a/skills/qoder-delegate/scripts/relay.mjs
+++ b/skills/qoder-delegate/scripts/relay.mjs
@@ -54,6 +54,7 @@ import { basename, join, resolve } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
 const VERSION_TIMEOUT_MS = 10_000;
 const MAX_BRIEF_BYTES = (process.platform === "win32" ? 12 : 120) * 1024;
 const PERMISSION_MODES = new Set([
@@ -73,7 +74,17 @@ function fail(message, code = 2) {
 function parseDuration(duration) {
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
-  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
 }
 
 function parseArgs(argv) {
@@ -130,9 +141,8 @@ function parseArgs(argv) {
     fail(`unsupported --permission-mode: ${opts.permissionMode}`);
   }
   if (parseDuration(opts.timeout) === null) {
-    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
   }
-  if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
   if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
     fail(`working directory not found: ${opts.cd}`);
   }

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -28,7 +28,10 @@
  *                 driven there (the skill docs carry the same caveat).
  *
  * Every fake answers each relay's version preflight (--version, `version`,
- * `changelog`). Quick Claude, Cursor, Qoder, Vibe, and Pi success cases verify brief
+ * `changelog`). A shared matrix drives all ten through the --timeout values no
+ * watchdog can honour — malformed, zero, and past Node's timer ceiling — each of
+ * which would otherwise fire on the next tick as a silent instant "timeout".
+ * Quick Claude, Cursor, Qoder, Vibe, and Pi success cases verify brief
  * delivery, launch arguments, environment handling, and result-event parsing. The
  * timeout/abort cases otherwise run until killed and spawn a subprocess of
  * their own; both assert that this grandchild dies with the implementer.
@@ -510,19 +513,6 @@ const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"],
     !Object.prototype.hasOwnProperty.call(value, "readOnlyViolation"));
 }
 const cursorNegativeWorkDir = freshRepo("work-negative-cursor");
-for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "600h"]) {
-  const rejected = spawnSync(process.execPath, [
-    relayPath("cursor"),
-    "--brief", briefPath,
-    "--cd", cursorNegativeWorkDir,
-    "--timeout", bad,
-  ], {
-    env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: join(scratch, "args-invalid-timeout-cursor") },
-    encoding: "utf8",
-    timeout: 5000,
-  });
-  check(`cursor timeout: "${bad}" is rejected`, rejected.status === 2);
-}
 for (const [flag, bad] of [
   ["--session", ""],
   ["--session", "--continue"],
@@ -785,15 +775,42 @@ for (const skill of SKILLS) {
   if (timedOut) console.error(`${skill} atomic relay stderr:\n${stderr}`);
 }
 
-// ---- agy --timeout is validated before it can silently fire ----
-// parseDuration returns null for a malformed value, and setTimeout(fn, null) fires on the next
-// tick: an unvalidated flag would turn a typo into an instant, silent "timeout".
-for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "600h"]) {
-  const badRun = spawnSync(process.execPath,
-    [relayPath("agy"), "--brief", briefPath, "--timeout", bad],
-    { env: baseEnv, encoding: "utf8" });
-  check(`agy timeout: "${bad}" is rejected`, badRun.status === 2);
+// ---- no relay accepts a --timeout its watchdog cannot honour ----
+// Driven for all ten, because an unhonourable delay turns a typo into an instant, silent
+// "timeout" — the one failure mode a watchdog must never have. Two ways in: parseDuration
+// returns null for a malformed value and setTimeout(fn, null) fires on the next tick; and a
+// delay past 2^31-1 ms overflows and fires immediately too, so "600h" would fell the
+// implementer half a second in and report a 25-day budget as already spent. Both are usage
+// errors, so both must exit 2 before any artifact exists.
+const badTimeoutWorkDir = freshRepo("work-bad-timeout");
+for (const skill of SKILLS) {
+  for (const bad of ["NONSENSE", "", "10", "10s-junk", "1.5s", "1h30", "0s", "596h31m24s", "600h", "10000h"]) {
+    const outDir = join(scratch, `out-bad-timeout-${skill}`);
+    const rejected = spawnSync(process.execPath, [
+      relayPath(skill),
+      "--brief", briefPath,
+      "--cd", badTimeoutWorkDir,
+      "--out-dir", outDir,
+      "--timeout", bad,
+      ...EXTRA_ARGS[skill],
+    ], { env: baseEnv, encoding: "utf8", timeout: 10_000 });
+    check(`${skill} timeout: "${bad}" is rejected before artifacts`,
+      rejected.status === 2 && !existsSync(outDir));
+  }
+  // Positive control for the bound above: the largest duration the h/m/s grammar can express
+  // under the ceiling is still a legitimate budget, so validation must not over-reject the edge.
+  const accepted = spawnSync(process.execPath, [
+    relayPath(skill),
+    "--brief", briefPath,
+    "--cd", badTimeoutWorkDir,
+    "--out-dir", join(scratch, `out-max-timeout-${skill}`),
+    "--timeout", "596h31m23s",
+    ...EXTRA_ARGS[skill],
+  ], { env: { ...process.env, PATH: "" }, encoding: "utf8", timeout: 10_000 });
+  check(`${skill} timeout: the largest schedulable duration is accepted`, accepted.status !== 2);
 }
+// agy's own --print-timeout carries a 60s grace into the same watchdog, so its ceiling sits
+// one grace window lower and it needs its own row.
 for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h30m24s", "600h"]) {
   const badRun = spawnSync(process.execPath,
     [relayPath("agy"), "--brief", briefPath, "--print-timeout", bad],
@@ -874,17 +891,6 @@ for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h
   ], { env: baseEnv, encoding: "utf8" });
   check("qoder validation: non-positive context is rejected before artifacts",
     invalid.status === 2 && !existsSync(invalidOutDir));
-
-  const zeroTimeoutOutDir = join(scratch, "out-zero-timeout-qoder");
-  const zeroTimeout = spawnSync(process.execPath, [
-    relayPath("qoder"),
-    "--brief", briefPath,
-    "--cd", workDir,
-    "--out-dir", zeroTimeoutOutDir,
-    "--timeout", "0s",
-  ], { env: baseEnv, encoding: "utf8" });
-  check("qoder validation: zero timeout is rejected before preflight",
-    zeroTimeout.status === 2 && !existsSync(zeroTimeoutOutDir));
 
   const latestOutDir = join(scratch, "out-resume-last-qoder");
   const latestArgsFile = join(scratch, "args-resume-last-qoder");
@@ -1074,28 +1080,6 @@ for (const bad of ["NONSENSE", "0s", "", "10", "10s-junk", "1.5s", "1h30", "596h
     !resumeCapture.args.includes("--session") &&
     existsSync(join(resumeOutDir, "result.json")) &&
     result(resumeOutDir).resumed === true);
-
-  const zeroTimeoutOutDir = join(scratch, "out-zero-timeout-pi");
-  const zeroTimeout = spawnSync(process.execPath, [
-    relayPath("pi"),
-    "--brief", briefPath,
-    "--cd", workDir,
-    "--out-dir", zeroTimeoutOutDir,
-    "--timeout", "0s",
-  ], { env: baseEnv, encoding: "utf8" });
-  check("pi validation: zero timeout is rejected before artifacts",
-    zeroTimeout.status === 2 && !existsSync(zeroTimeoutOutDir));
-
-  const hugeTimeoutOutDir = join(scratch, "out-huge-timeout-pi");
-  const hugeTimeout = spawnSync(process.execPath, [
-    relayPath("pi"),
-    "--brief", briefPath,
-    "--cd", workDir,
-    "--out-dir", hugeTimeoutOutDir,
-    "--timeout", "10000h",
-  ], { env: baseEnv, encoding: "utf8" });
-  check("pi validation: a timeout beyond Node's timer range is rejected before artifacts",
-    hugeTimeout.status === 2 && !existsSync(hugeTimeoutOutDir));
 
   const missingOutDir = join(scratch, "out-unavailable-pi");
   const missing = spawnSync(process.execPath, [


### PR DESCRIPTION
Five relays accept a `--timeout` their watchdog cannot schedule, and the result is an instant, silent `status: "timeout"`.

`codex`, `opencode`, `grok`, `kimi`, and `qoder` check `--timeout` only for `parseDuration(...) === null`, so two classes of value get through:

- `0s` → `0`
- `600h` → `2_160_000_000` ms, past Node's `2^31-1` timer ceiling, which overflows to ~1 ms (Node prints a `TimeoutOverflowWarning`)

Either way `setTimeout` fires on the next tick. Reproduced against a hanging fake implementer planted on `PATH`, before the fix:

```
codex    --timeout 0s:   exit=1 status=timeout after 0.5s
codex    --timeout 600h: exit=1 status=timeout after 0.5s  [TimeoutOverflowWarning]
grok     --timeout 0s:   exit=1 status=timeout after 0.5s
grok     --timeout 600h: exit=1 status=timeout after 0.5s  [TimeoutOverflowWarning]
opencode --timeout 0s:   exit=1 status=timeout after 0.5s
opencode --timeout 600h: exit=1 status=timeout after 0.5s  [TimeoutOverflowWarning]
```

So asking for a 25-day budget fells the implementer half a second in and reports that budget as already spent. It is the failure mode `agy`'s own comment names, and the one `claude`, `cursor`, and `vibe` already closed by bounding `parseDuration` itself. `qoder` had the zero case covered but not the ceiling; the other four had neither.

## The fix

The same shape the four hardened relays already use, so the catalog converges instead of growing a sixth variant: `parseDuration` returns `null` unless the value is positive and `<= MAX_TIMER_MS`, and every call site inherits it — including the `?? parseDuration(DEFAULT_TIMEOUT)` fallbacks. `qoder`'s separate `=== 0` check becomes redundant and goes. Error text now matches the sibling wording. No behaviour change for any duration that was already schedulable.

## Tests

The scattered per-relay timeout loops become one matrix every relay enters — malformed, empty, unitless, fractional, `0s`, `596h31m24s` (one tick over the ceiling), `600h`, `10000h` — each asserting exit 2 **and** that no artifact directory was created, plus a positive control at `596h31m23s` so the bound cannot over-reject the edge.

Folded into that matrix because it strictly covers them: `agy`'s and `cursor`'s `--timeout` lists, `qoder`'s zero case, and `pi`'s zero and out-of-range cases. `agy`'s `--print-timeout` row stays — its 60s grace gives it a lower ceiling.

## What ran

Windows 10 (26200), native PowerShell, Node v26.3.0:

- `node test/relay-smoke.mjs` — 411 checks, 0 failures, `relay smoke: all green`. Green on the same machine before the change too. Covers the compiled-`.exe` fakes for `agy`/`kimi`/`qoder`/`vibe` and the `.cmd` shims for the rest; the POSIX-only abort scenarios were skipped by the suite as usual.
- `npx skills add . --list` — 10 skills found.
- `--help` on all five changed relays — exit 0.
- Direct runs against a fake implementer on `PATH`: the reproduction above, re-run after the fix (all ten relays now exit 2 with no `result.json`), and a no-write completion run for `codex`, `grok`, and `opencode` at `--timeout 30m` returning `status: completed` with `touchedFiles: []`.

**Untested:** no run against a real `codex` / `opencode` / `grok` / `kimi` / `qodercli` binary — none installed here — and no POSIX run. The change is in argument validation, which is platform-independent, but I have claimed only what I ran.

## One thing I left alone

Only `agy`'s `dispatch-and-poll.md` documents the bound ("the maximum is `596h31m23s`"). The other nine `--timeout` rows don't mention it. Nothing in them is now false, so I kept this to one concern — happy to add a matching clause across the catalog here or in a follow-up, whichever you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject invalid, non-positive, or excessively long relay timeout values.
  * Prevented oversized timeout values from causing immediate or silent timeouts.
  * Updated timeout validation messages to clarify the accepted range.

* **Tests**
  * Expanded timeout validation coverage across all relay integrations, including boundary and malformed values.
  * Verified that rejected timeouts do not produce artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->