### PR TITLE
fix(relay): bound the version preflight and stop mislabeling a broken…

### DIFF
--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -87,6 +87,10 @@ process has exited and `result.json` is written — not when a status line says 
 
 - **`status: codex_unavailable` (exit 127):** `codex` isn't on PATH or isn't found. Install
   (`npm i -g @openai/codex`) and `codex login`, then re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `codex --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
+  codex was never dispatched and the working tree is untouched. Check the install by running
+  `codex --version` yourself.
 - **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
   Common causes: an auth lapse, an invalid `--model` or unsupported `--effort`, or a sandbox that
   blocked something the task needed. Fix the cause and re-dispatch; don't paper over it by doing the

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -89,8 +89,8 @@ process has exited and `result.json` is written — not when a status line says 
   (`npm i -g @openai/codex`) and `codex login`, then re-dispatch.
 - **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
   `codex --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
-  codex was never dispatched and the working tree is untouched. Check the install by running
-  `codex --version` yourself.
+  codex was never dispatched; only the relay's own artifacts may already exist under `--out-dir`.
+  Check the install by running `codex --version` yourself.
 - **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
   Common causes: an auth lapse, an invalid `--model` or unsupported `--effort`, or a sandbox that
   blocked something the task needed. Fix the cause and re-dispatch; don't paper over it by doing the

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -71,6 +71,7 @@ import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
 const SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 
@@ -196,15 +197,39 @@ function readBrief(opts) {
   return stdin;
 }
 
-function codexVersion() {
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once codex is running, so the preflight needs a bound of
+  // its own: a `codex --version` that never returns would wedge the relay here, before
+  // any result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function codexVersion(probeTimeoutMs) {
   try {
     // On Windows, npm installs `codex` as a .cmd shim; Node's CreateProcess only
     // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
     // ENOENTs on a working install. POSIX is unaffected. (git installs a real
     // git.exe and must NOT get this flag — see gitTouchedFiles.)
-    return execFileSync("codex", ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
-  } catch {
-    return null;
+    const version = execFileSync("codex", ["--version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+    }).trim();
+    return { version: version || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+    // exit rather than ENOENT; that is still "not installed", not a broken install.
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    // Anything else — a hung probe we killed, or a real non-zero exit — means codex is
+    // installed but not usable. Reporting that as "unavailable" would send the caller
+    // off to reinstall a binary that is already there.
+    return { version: null, error };
   }
 }
 
@@ -323,6 +348,27 @@ function reportUnavailable(writeResult, resultPath) {
   printSummary(result, resultPath);
   process.stderr.write("relay: `codex` not found on PATH. Install it (npm i -g @openai/codex) and run `codex login`.\n");
   process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `codex --version preflight timed out after ${probeTimeoutMs}ms; Codex was not dispatched`
+    : `codex --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Codex was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    threadId: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
 }
 
 function dispatchToCodex(opts, brief, run, writeResult) {
@@ -471,12 +517,19 @@ function main() {
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
 
-  const version = codexVersion();
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
   const run = prepareRunDir(opts, brief);
-  const writeResult = makeResultWriter(opts, version, run);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = codexVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
 
-  if (!version) {
+  if (!probe.version && !probe.error) {
     reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
     return;
   }
 

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -374,7 +374,7 @@ function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
     threadId: null,
     finalMessage: "",
     touchedFiles: gitTouchedFiles(opts.cd),
-    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
     error: message,
   });
   printSummary(result, run.resultPath);

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -97,6 +97,10 @@ process has exited and `result.json` is written — not when a status line says 
 
 - **`status: grok_unavailable` (exit 127):** `grok` isn't on PATH or isn't found. Install with
   `npm i -g @xai-official/grok` and `grok login`, then re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `grok version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
+  grok was never dispatched and the working tree is untouched. Check the install by running
+  `grok version` yourself.
 - **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
   half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
   or a resume.

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -99,8 +99,8 @@ process has exited and `result.json` is written — not when a status line says 
   `npm i -g @xai-official/grok` and `grok login`, then re-dispatch.
 - **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
   `grok version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
-  grok was never dispatched and the working tree is untouched. Check the install by running
-  `grok version` yourself.
+  grok was never dispatched; only the relay's own artifacts may already exist under `--out-dir`.
+  Check the install by running `grok version` yourself.
 - **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
   half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
   or a resume.

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -470,7 +470,7 @@ function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
     finalMessage: "",
     usage: null,
     touchedFiles: gitTouchedFiles(opts.cd),
-    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
     error: message,
   });
   printSummary(result, run.resultPath);

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -234,12 +234,12 @@ function grokVersion(probeTimeoutMs) {
   // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
   // ENOENTs on a working install. POSIX is unaffected. (git installs a real
   // git.exe and must NOT get this flag — see gitTouchedFiles.)
-  const probe = (argv) => {
+  const probe = (argv, timeout = probeTimeoutMs) => {
     try {
       const version = execFileSync("grok", argv, {
         encoding: "utf8",
         shell: process.platform === "win32",
-        timeout: probeTimeoutMs,
+        timeout,
         killSignal: "SIGKILL",
       }).trim();
       return { version: version || "unknown", error: null };
@@ -260,9 +260,12 @@ function grokVersion(probeTimeoutMs) {
   // Prefer `grok version` (documented subcommand); fall back to `--version` for builds that
   // only answer the flag. A missing binary and a hung probe are both conclusive, though:
   // retrying either would only spend the bound a second time.
+  const startedAt = performance.now();
   const documented = probe(["version"]);
   if (documented.version || !documented.error || documented.error.code === "ETIMEDOUT") return documented;
-  return probe(["--version"]);
+  const remainingMs = Math.floor(probeTimeoutMs - (performance.now() - startedAt));
+  if (remainingMs <= 0) return { version: null, error: { code: "ETIMEDOUT" } };
+  return probe(["--version"], remainingMs);
 }
 
 function gitTouchedFiles(cwd) {

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -82,6 +82,7 @@ import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
 const AUTONOMY_MODES = new Set(["workspace-write", "read-only", "full-access"]);
 
 function fail(message, code = 2) {
@@ -209,21 +210,48 @@ function readBrief(opts) {
   return stdin;
 }
 
-function grokVersion() {
-  try {
-    // On Windows, npm installs `grok` as a .cmd shim; Node's CreateProcess only
-    // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
-    // ENOENTs on a working install. POSIX is unaffected. (git installs a real
-    // git.exe and must NOT get this flag — see gitTouchedFiles.)
-    // Prefer `grok version` (documented subcommand); fall back to `--version`.
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once grok is running, so the preflight needs a bound of its
+  // own: a version probe that never returns would wedge the relay here, before any
+  // result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function grokVersion(probeTimeoutMs) {
+  // On Windows, npm installs `grok` as a .cmd shim; Node's CreateProcess only
+  // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
+  // ENOENTs on a working install. POSIX is unaffected. (git installs a real
+  // git.exe and must NOT get this flag — see gitTouchedFiles.)
+  const probe = (argv) => {
     try {
-      return execFileSync("grok", ["version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
-    } catch {
-      return execFileSync("grok", ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
+      const version = execFileSync("grok", argv, {
+        encoding: "utf8",
+        shell: process.platform === "win32",
+        timeout: probeTimeoutMs,
+        killSignal: "SIGKILL",
+      }).trim();
+      return { version: version || "unknown", error: null };
+    } catch (error) {
+      if (error?.code === "ENOENT") return { version: null, error: null };
+      // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+      // exit rather than ENOENT; that is still "not installed", not a broken install.
+      if (process.platform === "win32" &&
+          /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+        return { version: null, error: null };
+      }
+      // Anything else — a hung probe we killed, or a real non-zero exit — means grok is
+      // installed but not usable. Reporting that as "unavailable" would send the caller
+      // off to reinstall a binary that is already there.
+      return { version: null, error };
     }
-  } catch {
-    return null;
-  }
+  };
+  // Prefer `grok version` (documented subcommand); fall back to `--version` for builds that
+  // only answer the flag. A missing binary and a hung probe are both conclusive, though:
+  // retrying either would only spend the bound a second time.
+  const documented = probe(["version"]);
+  if (documented.version || !documented.error || documented.error.code === "ETIMEDOUT") return documented;
+  return probe(["--version"]);
 }
 
 function gitTouchedFiles(cwd) {
@@ -414,6 +442,28 @@ function reportUnavailable(writeResult, resultPath) {
   process.exit(127);
 }
 
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `grok version preflight timed out after ${probeTimeoutMs}ms; Grok was not dispatched`
+    : `grok version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Grok was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    usage: null,
+    touchedFiles: gitTouchedFiles(opts.cd),
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
 function dispatchToGrok(opts, run, writeResult) {
   // grok cannot be prevented from writing headlessly (the read-only sandbox and
   // plan mode are advisory), so a --read-only run snapshots the tree up front
@@ -589,12 +639,19 @@ function main() {
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
 
-  const version = grokVersion();
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
   const run = prepareRunDir(opts, brief);
-  const writeResult = makeResultWriter(opts, version, run);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = grokVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
 
-  if (!version) {
+  if (!probe.version && !probe.error) {
     reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
     return;
   }
 

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -84,6 +84,10 @@ A pre-run usage error exits 2 and writes no result. A missing `kimi` exits 127 a
 
 - **`status: "kimi_unavailable"` (exit 127):** install the native Kimi Code CLI, authenticate with
   `kimi login`, and re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `kimi --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
+  kimi was never dispatched and the working tree is untouched. Check the install by running
+  `kimi --version` yourself.
 - **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. A common
   cause is an unconfigured model alias: `error: failed to run prompt: config.invalid: Model "<x>" is not configured in config.toml…`
 - **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -86,8 +86,8 @@ A pre-run usage error exits 2 and writes no result. A missing `kimi` exits 127 a
   `kimi login`, and re-dispatch.
 - **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
   `kimi --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
-  kimi was never dispatched and the working tree is untouched. Check the install by running
-  `kimi --version` yourself.
+  kimi was never dispatched; only the relay's own artifacts may already exist under `--out-dir`.
+  Check the install by running `kimi --version` yourself.
 - **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. A common
   cause is an unconfigured model alias: `error: failed to run prompt: config.invalid: Model "<x>" is not configured in config.toml…`
 - **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -357,7 +357,7 @@ function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
     sessionId: null,
     finalMessage: "",
     touchedFiles: gitTouchedFiles(opts.cd),
-    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
     error: message,
   });
   printSummary(result, run.resultPath);

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -71,6 +71,7 @@ import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -172,15 +173,28 @@ function killChild(child, signal = "SIGTERM") {
   }
 }
 
-function kimiVersion() {
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once kimi is running, so the preflight needs a bound of its
+  // own: a `kimi --version` that never returns would wedge the relay here, before any
+  // result.json exists, and --timeout could not reach it.
+  return Math.min(parseDuration(opts.timeout), VERSION_PROBE_TIMEOUT_MS);
+}
+
+function kimiVersion(probeTimeoutMs) {
   try {
-    const out = execFileSync("kimi", ["--version"], { encoding: "utf8" }).trim();
-    return out || "unknown";
+    const out = execFileSync("kimi", ["--version"], {
+      encoding: "utf8",
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+    }).trim();
+    return { version: out || "unknown", error: null };
   } catch (err) {
     // Only a missing binary means "unavailable"; any other version-probe
     // failure must not masquerade as exit 127.
-    if (err && err.code === "ENOENT") return null;
-    return "unknown";
+    if (err && err.code === "ENOENT") return { version: null, error: null };
+    // A hung probe we killed, or a real non-zero exit, means kimi is installed but not
+    // usable. Dispatching anyway would send the brief to a CLI already known to be broken.
+    return { version: null, error: err };
   }
 }
 
@@ -316,6 +330,28 @@ function reportUnavailable(writeResult, resultPath) {
   printSummary(result, resultPath);
   process.stderr.write("relay: `kimi` not found on PATH. Install Kimi Code and run `kimi login`.\n");
   process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `kimi --version preflight timed out after ${probeTimeoutMs}ms; Kimi was not dispatched`
+    : `kimi --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Kimi was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
 }
 
 function dispatchToKimi(opts, brief, run, writeResult) {
@@ -474,11 +510,18 @@ function main() {
     fail(`brief is ${Math.round(briefBytes / 1024)}KB; kimi passes the prompt as a CLI argument, which the OS caps (~128KB on Linux). Trim it, or have kimi read large context from the workspace instead of inlining it.`);
   }
 
-  const version = kimiVersion();
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
   const run = prepareRunDir(opts, brief);
-  const writeResult = makeResultWriter(opts, version, run);
-  if (!version) {
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = kimiVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
     reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
     return;
   }
   dispatchToKimi(opts, brief, run, writeResult);

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -95,8 +95,8 @@ process has exited and `result.json` is written — not when a status line says 
   (`npm i -g opencode-ai`) and `opencode auth login`, then re-dispatch.
 - **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
   `opencode --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter),
-  so opencode was never dispatched and the working tree is untouched. Check the install by running
-  `opencode --version` yourself.
+  so opencode was never dispatched; only the relay's own artifacts may already exist under
+  `--out-dir`. Check the install by running `opencode --version` yourself.
 - **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
   Common causes: an auth lapse, an unknown `--model` or `--agent`, or a permission the run needed but
   the agent didn't grant. Fix the cause and re-dispatch; don't paper over it by doing the work yourself

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -93,6 +93,10 @@ process has exited and `result.json` is written — not when a status line says 
 
 - **`status: opencode_unavailable` (exit 127):** `opencode` isn't on PATH or isn't found. Install
   (`npm i -g opencode-ai`) and `opencode auth login`, then re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `opencode --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter),
+  so opencode was never dispatched and the working tree is untouched. Check the install by running
+  `opencode --version` yourself.
 - **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
   Common causes: an auth lapse, an unknown `--model` or `--agent`, or a permission the run needed but
   the agent didn't grant. Fix the cause and re-dispatch; don't paper over it by doing the work yourself

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -403,7 +403,7 @@ function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
     finalMessage: "",
     touchedFiles: gitTouchedFiles(opts.cd),
     cost: null,
-    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
     error: message,
   });
   printSummary(result, run.resultPath);

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -72,6 +72,8 @@ import { join, resolve, basename } from "node:path";
 import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
   process.exit(code);
@@ -183,15 +185,39 @@ function readBrief(opts) {
   return stdin;
 }
 
-function opencodeVersion() {
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once opencode is running, so the preflight needs a bound of
+  // its own: an `opencode --version` that never returns would wedge the relay here, before
+  // any result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function opencodeVersion(probeTimeoutMs) {
   try {
     // On Windows, npm installs `opencode` as a .cmd shim; Node's CreateProcess only
     // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
     // ENOENTs on a working install. POSIX is unaffected. (git installs a real
     // git.exe and must NOT get this flag — see gitTouchedFiles.)
-    return execFileSync("opencode", ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
-  } catch {
-    return null;
+    const version = execFileSync("opencode", ["--version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+    }).trim();
+    return { version: version || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+    // exit rather than ENOENT; that is still "not installed", not a broken install.
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    // Anything else — a hung probe we killed, or a real non-zero exit — means opencode is
+    // installed but not usable. Reporting that as "unavailable" would send the caller
+    // off to reinstall a binary that is already there.
+    return { version: null, error };
   }
 }
 
@@ -350,6 +376,28 @@ function reportUnavailable(writeResult, resultPath) {
   printSummary(result, resultPath);
   process.stderr.write("relay: `opencode` not found on PATH. Install it (npm i -g opencode-ai) and run `opencode auth login`.\n");
   process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `opencode --version preflight timed out after ${probeTimeoutMs}ms; OpenCode was not dispatched`
+    : `opencode --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; OpenCode was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    cost: null,
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
 }
 
 function dispatchToOpenCode(opts, brief, run, writeResult) {
@@ -538,12 +586,19 @@ function main() {
     fail("no model given: pass --model provider/model — opencode has no safe default (e.g. a plan you're subscribed to, like opencode-go/kimi-k2.7-code)");
   }
 
-  const version = opencodeVersion();
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
   const run = prepareRunDir(opts, brief);
-  const writeResult = makeResultWriter(opts, version, run);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = opencodeVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
 
-  if (!version) {
+  if (!probe.version && !probe.error) {
     reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
     return;
   }
 

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -28,7 +28,10 @@
  *                 driven there (the skill docs carry the same caveat).
  *
  * Every fake answers each relay's version preflight (--version, `version`,
- * `changelog`). Quick Claude, Cursor, Qoder, Vibe, and Pi success cases verify brief
+ * `changelog`), and can be told to hang or fail that probe by mode name, so a
+ * relay whose preflight is unbounded — wedging before any result.json exists —
+ * or which reports a broken CLI as a missing one is caught here.
+ * Quick Claude, Cursor, Qoder, Vibe, and Pi success cases verify brief
  * delivery, launch arguments, environment handling, and result-event parsing. The
  * timeout/abort cases otherwise run until killed and spawn a subprocess of
  * their own; both assert that this grandchild dies with the implementer.
@@ -113,13 +116,15 @@ for (const skill of SKILLS) {
 // ---- one fake CLI, planted on PATH under every relay's binary name ----
 const FAKE = `const fs = require("node:fs");
 const args = process.argv.slice(2);
-if ((args.includes("--version") && /-version-hang$/.test(process.env.SMOKE_MODE || ""))
-    || (args[0] === "changelog" && process.env.SMOKE_MODE === "agy-version-hang")) {
+// Every probe form one relay or another uses: --version, grok's \`version\` subcommand, and
+// agy's \`changelog\`. Treating them alike lets any relay's hang/fail mode be driven by name.
+const versionProbe = args.includes("--version") || args[0] === "version" || args[0] === "changelog";
+if (versionProbe && /-version-hang$/.test(process.env.SMOKE_MODE || "")) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
-} else if (args.includes("--version") && /-version-fail$/.test(process.env.SMOKE_MODE || "")) {
+} else if (versionProbe && /-version-fail$/.test(process.env.SMOKE_MODE || "")) {
   console.error("fake version failure");
   process.exit(7);
-} else if (args.includes("--version") || args[0] === "version" || args[0] === "changelog") {
+} else if (versionProbe) {
   console.log("fake-cli 0.0.0-smoke");
   process.exit(0);
 }
@@ -273,16 +278,20 @@ using System.IO;
 using System.Threading;
 class FakeCli {
   static int Main(string[] args) {
-    if ((Array.IndexOf(args, "--version") >= 0 && (Environment.GetEnvironmentVariable("SMOKE_MODE") == "qoder-version-hang" || Environment.GetEnvironmentVariable("SMOKE_MODE") == "vibe-version-hang"))
-        || (args.Length > 0 && args[0] == "changelog" && Environment.GetEnvironmentVariable("SMOKE_MODE") == "agy-version-hang")) {
+    // Mirrors the .cjs fake: any probe form, and hang/fail selected by the mode's suffix,
+    // so a native-binary relay (agy, kimi, qoder, vibe) enters the same preflight matrix.
+    var mode = Environment.GetEnvironmentVariable("SMOKE_MODE") ?? "";
+    bool versionProbe = Array.IndexOf(args, "--version") >= 0
+      || (args.Length > 0 && (args[0] == "version" || args[0] == "changelog"));
+    if (versionProbe && mode.EndsWith("-version-hang")) {
       Thread.Sleep(Timeout.Infinite);
       return 1;
     }
-    if (Array.IndexOf(args, "--version") >= 0 && (Environment.GetEnvironmentVariable("SMOKE_MODE") == "qoder-version-fail" || Environment.GetEnvironmentVariable("SMOKE_MODE") == "vibe-version-fail")) {
+    if (versionProbe && mode.EndsWith("-version-fail")) {
       Console.Error.WriteLine("fake version failure");
       return 7;
     }
-    if (Array.IndexOf(args, "--version") >= 0 || (args.Length > 0 && (args[0] == "version" || args[0] == "changelog"))) {
+    if (versionProbe) {
       Console.WriteLine("fake-cli 0.0.0-smoke");
       return 0;
     }
@@ -783,6 +792,49 @@ for (const skill of SKILLS) {
   check(`${skill} atomic: result.json is never partially published`, !parseFailed && finalResultValid);
   check(`${skill} atomic: no temporary result file survives the run`, leftovers.length === 0);
   if (timedOut) console.error(`${skill} atomic relay stderr:\n${stderr}`);
+}
+
+// ---- the version preflight is bounded and classified, not open-ended ----
+// The probe runs before the watchdog is armed, so an implementer that never answers its
+// version query would wedge the relay with no result.json and no --timeout able to reach it.
+// A probe that *fails* is a distinct outcome from a missing binary: reporting exit 127
+// "not installed" for a CLI that is installed but broken sends the caller to reinstall it.
+for (const skill of ["codex", "opencode", "grok", "kimi"]) {
+  const workDir = freshRepo(`work-preflight-${skill}`);
+  for (const [suffix, expectedStatus, expectedExit] of [
+    ["version-hang", "timeout", 124],
+    ["version-fail", "failed", 7],
+  ]) {
+    const outDir = join(scratch, `out-${skill}-${suffix}`);
+    const preflight = spawnSync(process.execPath, [
+      relayPath(skill),
+      "--brief", briefPath,
+      "--cd", workDir,
+      "--out-dir", outDir,
+      "--timeout", "1s",
+      ...EXTRA_ARGS[skill],
+    ], { env: { ...baseEnv, SMOKE_MODE: `${skill}-${suffix}` }, encoding: "utf8", timeout: 15_000 });
+    const value = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+    check(`${skill} preflight: ${skill}-${suffix} is explicit and prevents dispatch`,
+      preflight.status === expectedExit &&
+      value.status === expectedStatus &&
+      value.error?.includes("version preflight") &&
+      value.error?.includes("was not dispatched"));
+  }
+  // A missing binary must stay distinguishable from a broken one, so the classification
+  // added above cannot quietly turn "not installed" into a generic failure.
+  const missingOutDir = join(scratch, `out-unavailable-${skill}`);
+  const missing = spawnSync(process.execPath, [
+    relayPath(skill),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", missingOutDir,
+    ...EXTRA_ARGS[skill],
+  ], { env: { ...process.env, PATH: "" }, encoding: "utf8", timeout: 15_000 });
+  check(`${skill} unavailable: missing binary still reports ${skill}_unavailable`,
+    missing.status === 127 &&
+    existsSync(join(missingOutDir, "result.json")) &&
+    result(missingOutDir).status === `${skill}_unavailable`);
 }
 
 // ---- agy --timeout is validated before it can silently fire ----

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -132,6 +132,8 @@ if (versionProbe && process.env.SMOKE_MODE === "grok-version-fallback-budget") {
   process.exit(0);
 } else if (versionProbe && /-version-hang$/.test(process.env.SMOKE_MODE || "")) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+} else if (versionProbe && /-version-fail-silent$/.test(process.env.SMOKE_MODE || "")) {
+  process.exit(7);
 } else if (versionProbe && /-version-fail$/.test(process.env.SMOKE_MODE || "")) {
   console.error("fake version failure");
   process.exit(7);
@@ -297,6 +299,9 @@ class FakeCli {
     if (versionProbe && mode.EndsWith("-version-hang")) {
       Thread.Sleep(Timeout.Infinite);
       return 1;
+    }
+    if (versionProbe && mode.EndsWith("-version-fail-silent")) {
+      return 7;
     }
     if (versionProbe && mode.EndsWith("-version-fail")) {
       Console.Error.WriteLine("fake version failure");
@@ -802,6 +807,7 @@ for (const skill of ["codex", "opencode", "grok", "kimi"]) {
   for (const [suffix, expectedStatus, expectedExit] of [
     ["version-hang", "timeout", 124],
     ["version-fail", "failed", 7],
+    ["version-fail-silent", "failed", 7],
   ]) {
     const outDir = join(scratch, `out-${skill}-${suffix}`);
     const preflight = spawnSync(process.execPath, [
@@ -816,6 +822,7 @@ for (const skill of ["codex", "opencode", "grok", "kimi"]) {
     check(`${skill} preflight: ${skill}-${suffix} is explicit and prevents dispatch`,
       preflight.status === expectedExit &&
       value.status === expectedStatus &&
+      Array.isArray(value.stderrTail) &&
       value.error?.includes("version preflight") &&
       value.error?.includes("was not dispatched"));
   }

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -122,7 +122,15 @@ const args = process.argv.slice(2);
 // Every probe form one relay or another uses: --version, grok's \`version\` subcommand, and
 // agy's \`changelog\`. Treating them alike lets any relay's hang/fail mode be driven by name.
 const versionProbe = args.includes("--version") || args[0] === "version" || args[0] === "changelog";
-if (versionProbe && /-version-hang$/.test(process.env.SMOKE_MODE || "")) {
+if (versionProbe && process.env.SMOKE_MODE === "grok-version-fallback-budget") {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 700);
+  if (args[0] === "version") {
+    console.error("fake documented version failure");
+    process.exit(7);
+  }
+  console.log("fake-cli 0.0.0-smoke");
+  process.exit(0);
+} else if (versionProbe && /-version-hang$/.test(process.env.SMOKE_MODE || "")) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
 } else if (versionProbe && /-version-fail$/.test(process.env.SMOKE_MODE || "")) {
   console.error("fake version failure");
@@ -825,6 +833,20 @@ for (const skill of ["codex", "opencode", "grok", "kimi"]) {
     missing.status === 127 &&
     existsSync(join(missingOutDir, "result.json")) &&
     result(missingOutDir).status === `${skill}_unavailable`);
+}
+
+if (!WIN) {
+  const workDir = freshRepo("work-preflight-grok-fallback-budget");
+  const outDir = join(scratch, "out-grok-version-fallback-budget");
+  const preflight = spawnSync(process.execPath, [
+    relayPath("grok"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--timeout", "1s",
+  ], { env: { ...baseEnv, SMOKE_MODE: "grok-version-fallback-budget" }, encoding: "utf8", timeout: 15_000 });
+  check("grok preflight: fallback shares one timeout budget",
+    preflight.status === 124 && result(outDir).status === "timeout");
 }
 
 // ---- no relay accepts a --timeout its watchdog cannot honour ----


### PR DESCRIPTION
**Claim:** the version preflight in `codex`, `opencode`, `grok`, and `kimi` is unbounded and
misclassifies a broken CLI as a missing one.

Four relays probe their implementer's version before arming the watchdog:

```js
function codexVersion() {
  try {
    return execFileSync("codex", ["--version"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
  } catch {
    return null;
  }
}
```

Two problems live in those six lines.

**The probe has no bound.** `--timeout` only arms once the implementer is spawned, which happens
after this call. A `codex --version` that never returns wedges the relay forever, with no
`result.json` written and nothing for the caller to poll — the one failure the relay contract exists
to prevent. `cursor`, `qoder`, `vibe`, and `pi` already cap this probe at 10s; these four did not.

**`catch { return null }` collapses two different outcomes.** A missing binary and an installed CLI
that exits non-zero both become `*_unavailable` at exit 127, whose remedy is "install it and
re-dispatch". For a CLI that is already installed but broken or unauthenticated, that sends the
caller to reinstall something already on disk.

I reproduced the hang against a fake CLI that never answers `--version`, with `cursor` as the
control:

```
codex     --timeout 5s -> still running when the probe gave up at 120s   result.json=false
grok      --timeout 5s -> still running when the probe gave up at 120s   result.json=false
opencode  --timeout 5s -> still running when the probe gave up at 120s   result.json=false
cursor    --timeout 5s -> exited                             after 0.1s  result.json=true
```

After the fix, all three honor the bound and publish a result:

```
codex     --timeout 5s -> exited code=124  after 5.1s  result.json=true
grok      --timeout 5s -> exited code=124  after 5.1s  result.json=true
opencode  --timeout 5s -> exited code=124  after 5.1s  result.json=true
```

**The fix** ports the shape `cursor` already uses to all four: the probe gets
`timeout: min(--timeout, 10s)` with `killSignal: "SIGKILL"`, and the version function returns
`{ version, error }` so the three outcomes stay distinct — missing binary is still
`*_unavailable`/127, a hung probe is `timeout`/124, and a non-zero exit is `failed` carrying the
probe's own exit code and `stderrTail`. The run directory is now prepared before the probe, so a
preflight that fails still has somewhere to publish `result.json`. On Windows the existing
`shell: true` shim handling is preserved, including the `cmd.exe` "not recognized" case that must
stay classified as *missing*, not *broken*.

`grok`'s probe tries the documented `grok version` subcommand first and falls back to `--version`;
a timeout short-circuits that fallback, since retrying would only spend the bound a second time.

No new statuses, exit codes, or flags — this only fills in outcomes that were previously
unreachable or mislabeled.

Worth noting: the README's Verification status already lists "bounded version preflight" among the
contract-tested claims for `codex-delegate` and `opencode-delegate`. That claim was true of the
suite's other relays but not of these; the patch makes it true rather than needing the line softened.

**What ran:** Windows 11 Pro (build 26200), Node 26.3.0, native PowerShell 5.1 (not Git Bash/WSL).
`node test/relay-smoke.mjs` — 332 checks, all green, 1 skip (the aborted-path scenarios, which
Windows cannot drive: no catchable `SIGTERM`). `npx skills add . --list` lists all ten skills.
The four relays were also run against a missing binary to confirm `*_unavailable`/127 still reports
separately from the new failure paths.

The suite now carries the four through the same preflight matrix the other relays use — a hung
probe and a failing probe per relay, plus a missing-binary case asserting the two stay
distinguishable. The two fake CLIs were generalized rather than extended case by case: both now
recognize every probe form in the repo (`--version`, `grok`'s `version`, `agy`'s `changelog`) and
take hang/fail from the mode name, so adding a relay to the matrix needs no new fake branch. That
generalization removed the existing per-CLI special cases instead of adding to them.

**A limitation this does not fix, found while verifying.** On Windows the shim relays run the probe
through a shell, so the timeout kills `cmd.exe` but not the implementer process underneath it: a
probe that hangs is reported correctly and promptly, but leaves one orphan behind. This is not new —
`cursor`'s probe already goes through `execSync` on win32 and leaks the same way, which is visible as
one stray process per suite run before this branch and four after. Fixing it means replacing
`execFileSync` with a spawn plus `taskkill /t /f`, and would have to be done to the four relays that
already ship this probe as well, so it belongs in its own change rather than here. The relays' *run*
paths are unaffected — they already fell the whole process tree, and the suite asserts it.

Not verified: POSIX. Every run above is native Windows. The `ETIMEDOUT` classification and
`killSignal` behavior are the same ones `cursor`, `qoder`, `vibe`, and `pi` already rely on, so
they are not new ground, but I have not run this branch on macOS or Linux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added bounded version checks for Codex, Grok, Kimi, and OpenCode to prevent hangs before execution starts.
  * Improved reporting for version-check failures and timeouts, including status, exit codes, and available error details.
  * Ensured result files are created even when a version check fails, while preventing dispatch and preserving the working tree.

* **Documentation**
  * Added troubleshooting guidance for version preflight failures and recommended verification commands.

* **Tests**
  * Added coverage for version-check hangs, failures, timeouts, and unavailable tools across supported relays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->