### PR TITLE
add task-specific model routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,13 +56,23 @@ the skill's `relay.mjs`.
   the skill otherwise.
 - **Progressive disclosure:** keep `SKILL.md` lean; push depth into `references/*.md` that load only
   when needed.
-- **Executables:** keep them minimal and inspectable. Today there is one per skill — a
+- **Executables:** keep them minimal and inspectable. Today there is one per delegation skill — a
   `scripts/relay.mjs` under each of `skills/claude-delegate/`, `skills/codex-delegate/`,
   `skills/opencode-delegate/`, `skills/agy-delegate/`, `skills/grok-delegate/`,
   `skills/kimi-delegate/`, `skills/qoder-delegate/`, `skills/vibe-delegate/`, and
   `skills/cursor-delegate/`, and `skills/pi-delegate/` — each Node built-ins only, no dependencies,
-  no network calls of its own, no credentials, no telemetry. New scripts must hold the same line,
-  and the README's trust section must stay accurate.
+  no network calls of its own, no credentials, no telemetry. The utility skill `delegate-config` has
+  a `scripts/discover.mjs` under the same rules. New scripts must hold the same line, and the
+  README's trust section must stay accurate.
+- **Utility skills** (like `delegate-config`) sit under `skills/<name>/` without the `-delegate`
+  suffix. They have a `SKILL.md` and optional `scripts/` but no `relay.mjs`, no `references/`
+  directory, and no `result.json` contract. They are listed in `skills.sh.json` under their own
+  grouping.
+- **Delegate config files:** relays read optional config from `.delegate/config.json` at the Git
+  repository root and `~/.config/delegate-skills/config.json` (user-global). Version 2 supports
+  implementer `defaults` plus named task `routes`; version 1 single-default files remain readable.
+  Explicit CLI flags win per field, followed by project route, project defaults, global route, and
+  global defaults. The `delegate-config` skill proposes changes and writes only after user approval.
 
 ## Before publishing a change
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,44 @@ Each skill name links to its `SKILL.md`, which owns that implementer's prerequis
 caveats. Building one for another CLI? [Claim it first](../../issues?q=is%3Aissue+label%3Aimplementer),
 then see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### Utilities
+
+| Skill | Purpose |
+| --- | --- |
+| [`delegate-config`](skills/delegate-config/SKILL.md) | Discover implementer CLIs and reported models, then propose defaults and task-specific routes for approval. |
+
+### Delegate config file
+
+Every relay reads optional config files that provide implementer defaults and named task routes such
+as `frontend`, `backend`, `fast`, `medium`, and `complex`. Run `delegate-config` to inspect installed
+CLIs and reported models, review the orchestrator's proposed configuration, and approve or adjust it
+before anything is written.
+
+```json
+{
+  "version": "delegate-config.v2",
+  "implementers": {
+    "codex": {
+      "defaults": {
+        "sandbox": "workspace-write",
+        "timeout": "30m"
+      },
+      "routes": {
+        "fast": { "model": "provider/fast-model", "effort": "low" },
+        "frontend": { "model": "provider/frontend-model", "effort": "medium" },
+        "backend": { "model": "provider/backend-model", "effort": "medium" },
+        "complex": { "model": "provider/complex-model", "effort": "high" }
+      }
+    }
+  }
+}
+```
+
+Select a route with `--route frontend`. Per field, explicit relay flags win, followed by the project
+route, project defaults, global route, global defaults, and finally the implementer's own default.
+Project config is read from `.delegate/config.json` at the Git repository root; global config remains
+at `~/.config/delegate-skills/config.json`. Version 1 single-default config files remain supported.
+
 ## Install
 
 Browse first:
@@ -139,11 +177,15 @@ Full checklist: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 This package is intentionally inspectable:
 
-- All skill content is Markdown, plus exactly **one** executable per skill — each a `scripts/relay.mjs`.
+- All skill content is Markdown, plus exactly **one** executable per skill — a `scripts/relay.mjs`
+  for delegation skills or `scripts/discover.mjs` for `delegate-config`.
 - Each `relay.mjs` makes no network calls, reads or writes no credentials, sends no telemetry, and has
   no dependencies (Node built-ins only). It launches its implementer CLI and `git`, plus the platform
   process launcher/termination utility where a Windows shim or process-tree kill requires one. The
   implementer CLI authenticates exactly as you do at the terminal. Read the script before you run it.
+- `discover.mjs` makes no direct network calls and does not read credentials. It runs bounded
+  version, authentication-status, and model-list commands; an implementer CLI may contact its own
+  service while answering those commands.
 - None of the relays ever commit — committing is always the orchestrator's job, after review.
 
 **Verification status** — claims here are backed by runs, not assumptions.
@@ -188,19 +230,22 @@ but unproven.
 
 ## Repository shape
 
-Every skill has the same shape — a lean `SKILL.md`, four references that load only when needed, and
-one inspectable script:
+Every delegation skill has the same shape — a lean `SKILL.md`, four references that load only when
+needed, and one inspectable script:
 
 ```text
 skills/
-└── <name>-delegate/
+├── <name>-delegate/
+│   ├── SKILL.md
+│   ├── scripts/relay.mjs
+│   └── references/
+│       ├── writing-the-brief.md
+│       ├── dispatch-and-poll.md
+│       ├── review-and-land.md
+│       └── multi-task-queues.md
+└── delegate-config/          ← utility skill (no relay, no references)
     ├── SKILL.md
-    ├── scripts/relay.mjs
-    └── references/
-        ├── writing-the-brief.md
-        ├── dispatch-and-poll.md
-        ├── review-and-land.md
-        └── multi-task-queues.md
+    └── scripts/discover.mjs
 ```
 
 Adding an implementer is a new directory plus two lines here: a table row, and a verification line once

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -2,6 +2,13 @@
   "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
   "groupings": [
     {
+      "title": "Configure delegation",
+      "description": "Set up implementer defaults and task-specific model routes for delegate skills.",
+      "skills": [
+        "delegate-config"
+      ]
+    },
+    {
       "title": "Delegate to CLI agents",
       "description": "Delegate a coding task to a CLI implementer agent, then review the diff and commit it yourself.",
       "skills": [

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -29,6 +29,7 @@ Options:
 | --- | --- |
 | `--brief <file>` | The brief. Omit it to read the brief from stdin before passing it to `agy --print`. |
 | `--cd <dir>` | Working root for Antigravity (default: current directory). |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--model <name>` | Antigravity model label. Optional; a fresh run can use Antigravity's configured default. |
 | `--project <id>` | Use an existing Antigravity project. |
 | `--new-project` | Force a fresh Antigravity project. This is the default for fresh dispatches. |
@@ -60,7 +61,7 @@ touched-files report shows only Antigravity's edits and nothing of the helper's 
   `null` (not `[]`) when git cannot report; `[]` means git ran and the tree is clean
 - `briefPath` / `finalPath` / `logPath` / `stderrPath` - the exact brief, final message, Antigravity
   log, and stderr capture
-- `workdir`, `model`, `project` (the `--project` you passed, vs `projectId` parsed from the log),
+- `workdir`, `route`, `timeout`, `model`, `modelSource`, `project` (the `--project` you passed, vs `projectId` parsed from the log),
   `sandbox`, `dangerouslySkipPermissions`, `resumed` (true for a `--resume-last` or `--conversation`
   run), `startedAt`, `finishedAt`
 - `stderrTail` - last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -34,6 +34,7 @@
  * Options:
  *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
  *   --cd <dir>              Working root for Antigravity (default: current directory).
+ *   --route <name>          Named delegate-config task route.
  *   --model <name>          Antigravity model label (default: agy's configured default).
  *   --project <id>          Use an existing Antigravity project.
  *   --new-project           Force a fresh Antigravity project (default for fresh runs).
@@ -71,14 +72,107 @@
 
 import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
-import { join, resolve, basename } from "node:path";
-import { constants, tmpdir } from "node:os";
+import { join, resolve, basename, dirname } from "node:path";
+import { constants, tmpdir, homedir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_PRINT_TIMEOUT = "30m";
 const MAX_TIMER_MS = 2_147_483_647;
 const MAX_TIMER_DURATION = "596h31m23s";
 const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const CONFIG_FIELDS = new Set(["model", "timeout"]);
+const BOOLEAN_CONFIG_FIELDS = new Set();
+
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.agy;
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.agy must be an object`);
+  }
+  if (document.version === "delegate-config.v1") return [{ values: entry, label: "defaults" }];
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported agy section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: agy.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    { scope: "global", path: join(homedir(), ".config", "delegate-skills", "config.json") },
+    { scope: "project", path: join(findProjectRoot(cwd), ".delegate", "config.json") },
+  ];
+  const resolved = {};
+  let modelSource = "default";
+  let routeFound = route === null;
+  for (const candidate of candidates) {
+    const document = readDelegateConfig(candidate.path);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, candidate.path)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${candidate.path}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${candidate.path}: unsupported agy field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${candidate.path}: agy field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+        if (field === "model") modelSource = `${candidate.scope}:${layer.label}`;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved, modelSource };
+}
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -89,6 +183,7 @@ function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     model: null,
     project: null,
     newProject: false,
@@ -117,6 +212,7 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--model": opts.model = next(); break;
       case "--project": opts.project = next(); break;
       case "--new-project": opts.newProject = true; break;
@@ -132,6 +228,12 @@ function parseArgs(argv) {
         fail(`unknown option: ${arg}`);
     }
   }
+  const modelFromFlag = opts.model !== null;
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.model === null && config.model !== undefined) opts.model = config.model;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  opts.modelSource = modelFromFlag ? "flag" : delegateConfig.modelSource;
   if (opts.resumeLast && opts.conversation) {
     fail("--resume-last and --conversation are mutually exclusive; pass only one");
   }
@@ -143,6 +245,9 @@ function parseArgs(argv) {
     if (milliseconds === null || milliseconds <= 0 || milliseconds > MAX_TIMER_MS) {
       fail(`--timeout "${opts.timeout}" must be an h/m/s duration from 1s through ${MAX_TIMER_DURATION}`);
     }
+  }
+  if (opts.model !== null && (typeof opts.model !== "string" || !opts.model.trim())) {
+    fail("--model must be a non-empty string");
   }
   const printTimeoutMs = parseDuration(opts.printTimeout);
   if (printTimeoutMs === null || printTimeoutMs <= 0 || printTimeoutMs + 60_000 > MAX_TIMER_MS) {
@@ -322,7 +427,7 @@ function parseIdsFromLog(logPath) {
   };
 }
 
-function makeResultWriter(opts, version, run) {
+function makeResultWriter(opts, modelSource, version, run) {
   return (extra) => {
     const ids = parseIdsFromLog(run.logPath);
     const result = {
@@ -330,6 +435,9 @@ function makeResultWriter(opts, version, run) {
       tool: "agy",
       workdir: opts.cd,
       model: opts.model,
+      modelSource,
+      route: opts.route,
+      timeout: opts.timeout,
       project: opts.project,
       sandbox: opts.sandbox,
       dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
@@ -536,11 +644,11 @@ function main() {
   try {
     version = agyVersion(watchdogMs);
   } catch (error) {
-    const writeResult = makeResultWriter(opts, "unknown", run);
+    const writeResult = makeResultWriter(opts, opts.modelSource, "unknown", run);
     reportVersionTimeout(writeResult, run, watchdogMs, error);
     return;
   }
-  const writeResult = makeResultWriter(opts, version, run);
+  const writeResult = makeResultWriter(opts, opts.modelSource, version, run);
 
   if (!version) {
     reportUnavailable(writeResult, run.resultPath);

--- a/skills/claude-delegate/references/dispatch-and-poll.md
+++ b/skills/claude-delegate/references/dispatch-and-poll.md
@@ -29,6 +29,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | --- | --- |
 | `--brief <file>` | Brief path. Omit it to read stdin. The exact text is then sent to Claude on stdin, never argv. |
 | `--cd <dir>` | Child process cwd and target working root (default: current directory). |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp directory). |
 | `--timeout <dur>` | Relay watchdog, such as `30m`, `90s`, or `2h` (default: off). |
 | `--model <name>` | Claude model alias or full name (default: Claude's configured choice). The relay does not pin a model version. |
@@ -162,7 +163,7 @@ Core fields:
   while `[]` means git reported a clean tree. This is the whole final tree, not attribution.
 - `readOnlyViolation` — present only on `--read-only`, with the three-state meaning above.
 
-Run metadata includes `workdir`, `model`, `effort`, `maxTurns`, `maxBudgetUsd`, `timeout`, `readOnly`,
+Run metadata includes `workdir`, `route`, `model`, `modelSource`, `effort`, `maxTurns`, `maxBudgetUsd`, `timeout`, `readOnly`,
 `resumed`, `resumeLast`, `toolSurface`, `shellSandbox`, `dangerouslySkipPermissions`, timestamps, and
 all artifact paths. Failed, timed-out, and aborted runs include `stderrTail` when available;
 launch/watchdog/signal failures include `error`.

--- a/skills/claude-delegate/scripts/relay.mjs
+++ b/skills/claude-delegate/scripts/relay.mjs
@@ -51,6 +51,7 @@
  * Options:
  *   --brief <file>                    Brief path. Omit to read the brief from stdin.
  *   --cd <dir>                        Child cwd (default: current directory).
+ *   --route <name>                    Named delegate-config task route.
  *   --out-dir <dir>                   Artifact directory (default: system temp).
  *   --timeout <dur>                   Relay watchdog; off by default. Use h/m/s,
  *                                     such as 30m, 90s, or 1h30m.
@@ -101,8 +102,8 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { basename, delimiter, join, resolve } from "node:path";
-import { constants as osConstants, tmpdir } from "node:os";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
+import { constants as osConstants, tmpdir, homedir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const SCHEMA = "delegate-relay.result.v1";
@@ -111,6 +112,99 @@ const MAX_TIMER_MS = 2_147_483_647;
 const EFFORT_LEVELS = new Set(["low", "medium", "high", "xhigh", "max", "ultracode"]);
 const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:@\/\[\]-]*$/;
 const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const CONFIG_FIELDS = new Set(["model", "effort", "timeout", "readOnly"]);
+const BOOLEAN_CONFIG_FIELDS = new Set(["readOnly"]);
+
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.claude;
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.claude must be an object`);
+  }
+  if (document.version === "delegate-config.v1") return [{ values: entry, label: "defaults" }];
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported claude section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: claude.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    { scope: "global", path: join(homedir(), ".config", "delegate-skills", "config.json") },
+    { scope: "project", path: join(findProjectRoot(cwd), ".delegate", "config.json") },
+  ];
+  const resolved = {};
+  let modelSource = "default";
+  let routeFound = route === null;
+  for (const candidate of candidates) {
+    const document = readDelegateConfig(candidate.path);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, candidate.path)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${candidate.path}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${candidate.path}: unsupported claude field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${candidate.path}: claude field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+        if (field === "model") modelSource = `${candidate.scope}:${layer.label}`;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved, modelSource };
+}
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -137,6 +231,7 @@ function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     outDir: null,
     timeout: null,
     model: null,
@@ -145,7 +240,7 @@ function parseArgs(argv) {
     maxBudgetUsd: null,
     resumeLast: false,
     session: null,
-    readOnly: false,
+    readOnly: null,
     dangerouslySkipPermissions: false,
   };
 
@@ -166,6 +261,7 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
       case "--timeout": opts.timeout = next(); break;
       case "--model": opts.model = next(); break;
@@ -181,6 +277,18 @@ function parseArgs(argv) {
     }
   }
 
+  const modelFromFlag = opts.model !== null;
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.model === null && config.model !== undefined) opts.model = config.model;
+  if (opts.effort === null && config.effort !== undefined) opts.effort = config.effort;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  if (opts.readOnly === null && config.readOnly !== undefined) opts.readOnly = config.readOnly;
+  if (opts.readOnly === null) opts.readOnly = false;
+  opts.modelSource = modelFromFlag ? "flag" : delegateConfig.modelSource;
+  if (typeof opts.readOnly !== "boolean") {
+    fail("delegate config claude.readOnly must be a boolean");
+  }
   if (opts.resumeLast && opts.session) {
     fail("--resume-last and --session are mutually exclusive; pass only one");
   }
@@ -190,13 +298,13 @@ function parseArgs(argv) {
   if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
     fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
   }
-  if (opts.model !== null && !SAFE_MODEL.test(opts.model)) {
+  if (opts.model !== null && (typeof opts.model !== "string" || !SAFE_MODEL.test(opts.model))) {
     fail("--model contains unsupported characters (allowed: letters, digits, . _ : @ / [ ] -)");
   }
   if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
     fail("--session contains unsupported characters (allowed: letters, digits, . _ : -)");
   }
-  if (opts.effort !== null && !EFFORT_LEVELS.has(opts.effort)) {
+  if (opts.effort !== null && (typeof opts.effort !== "string" || !EFFORT_LEVELS.has(opts.effort))) {
     fail(`invalid --effort "${opts.effort}" (expected: ${[...EFFORT_LEVELS].join(", ")})`);
   }
   if (opts.maxTurns !== null) {
@@ -611,13 +719,15 @@ function writeJsonAtomic(path, value) {
   renameSync(temporary, path);
 }
 
-function makeResultWriter(opts, version, run, state, beforeTree) {
+function makeResultWriter(opts, modelSource, version, run, state, beforeTree) {
   return (extra) => {
     const result = {
       schema: SCHEMA,
       tool: "claude",
       workdir: opts.cd,
       model: opts.model,
+      modelSource,
+      route: opts.route,
       effort: opts.effort,
       maxTurns: opts.maxTurns === null ? null : Number(opts.maxTurns),
       maxBudgetUsd: opts.maxBudgetUsd === null ? null : Number(opts.maxBudgetUsd),
@@ -934,7 +1044,7 @@ function main() {
     usage: null,
     totalCostUsd: null,
   };
-  const writeResult = makeResultWriter(opts, version, run, state, beforeTree);
+  const writeResult = makeResultWriter(opts, opts.modelSource, version, run, state, beforeTree);
 
   if (!launcher || version === null) {
     reportUnavailable(writeResult, opts, run);

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -34,6 +34,7 @@ Options:
 | --- | --- |
 | `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
 | `--cd <dir>` | Working root for Codex (default: current directory). |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--model <name>` | Codex model (default: Codex's own configured default). |
 | `--effort <level>` | Reasoning effort, passed to Codex as `-c model_reasoning_effort=<level>` (default: Codex's own configured default). The relay accepts a bare token; Codex and the model own the supported levels. Applies to fresh and resumed runs. |
 | `--sandbox <mode>` | `read-only` \| `workspace-write` \| `danger-full-access` (default: `workspace-write`). |
@@ -60,7 +61,7 @@ touched-files report shows only Codex's edits and nothing of the helper's own.
 - `finalMessage` — Codex's own final report (the `<structured_output_contract>` you asked for)
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report — `git` missing, or a non-repo run under `--skip-git-repo-check`; `[]` means git ran and the tree is clean
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSONL event stream, and the final-message file
-- `workdir`, `sandbox`, `model`, `effort`, `resumeLast`, `session`, `startedAt`, `finishedAt` — `session` is the explicit session id, or `null` for fresh and `--resume-last` runs
+- `workdir`, `route`, `timeout`, `sandbox`, `model`, `modelSource`, `effort`, `resumeLast`, `session`, `startedAt`, `finishedAt` — `session` is the explicit session id, or `null` for fresh and `--resume-last` runs
 - `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `codex_unavailable`, and launch failures
 - `error` — present on a launch failure, and on `timeout` and `aborted` runs
 

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -26,6 +26,7 @@
  * Options:
  *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
  *   --cd <dir>              Working root for Codex (default: current directory).
+ *   --route <name>          Named delegate-config task route.
  *   --model <name>          Codex model (default: Codex's own configured default).
  *   --effort <level>        Reasoning effort, passed to Codex as
  *                           `-c model_reasoning_effort=<level>` (default: Codex's
@@ -67,25 +68,120 @@
 
 import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
-import { join, resolve, basename } from "node:path";
-import { constants, tmpdir } from "node:os";
+import { join, resolve, basename, dirname } from "node:path";
+import { constants, tmpdir, homedir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const CONFIG_FIELDS = new Set(["model", "sandbox", "effort", "timeout", "readOnly"]);
+const BOOLEAN_CONFIG_FIELDS = new Set(["readOnly"]);
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
   process.exit(code);
 }
 
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.codex;
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.codex must be an object`);
+  }
+  if (document.version === "delegate-config.v1") return [{ values: entry, label: "defaults" }];
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported codex section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: codex.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    { scope: "global", path: join(homedir(), ".config", "delegate-skills", "config.json") },
+    { scope: "project", path: join(findProjectRoot(cwd), ".delegate", "config.json") },
+  ];
+  const resolved = {};
+  let modelSource = "default";
+  let routeFound = route === null;
+  for (const candidate of candidates) {
+    const document = readDelegateConfig(candidate.path);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, candidate.path)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${candidate.path}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${candidate.path}: unsupported codex field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${candidate.path}: codex field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+        if (field === "model") modelSource = `${candidate.scope}:${layer.label}`;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved, modelSource };
+}
+
 function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     model: null,
     effort: null,
-    sandbox: "workspace-write",
+    sandbox: null,
     resumeLast: false,
     session: null,
     skipGitRepoCheck: false,
@@ -108,6 +204,7 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--model": opts.model = next(); break;
       case "--effort": opts.effort = next(); break;
       case "--sandbox": opts.sandbox = next(); break;
@@ -121,10 +218,28 @@ function parseArgs(argv) {
         fail(`unknown option: ${arg}`);
     }
   }
-  if (!SANDBOX_MODES.has(opts.sandbox)) {
-    fail(`invalid --sandbox "${opts.sandbox}" (expected: ${[...SANDBOX_MODES].join(", ")})`);
+  const modelFromFlag = opts.model !== null;
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.model === null && config.model !== undefined) opts.model = config.model;
+  if (opts.effort === null && config.effort !== undefined) opts.effort = config.effort;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  if (opts.sandbox === null) {
+    if (config.readOnly === true) opts.sandbox = "read-only";
+    else if (config.sandbox !== undefined) opts.sandbox = config.sandbox;
+    else opts.sandbox = "workspace-write";
   }
-  if (opts.effort !== null && !/^[a-z][a-z0-9-]*$/i.test(opts.effort)) {
+  opts.modelSource = modelFromFlag ? "flag" : delegateConfig.modelSource;
+  if (config.readOnly !== undefined && typeof config.readOnly !== "boolean") {
+    fail("delegate config codex.readOnly must be a boolean");
+  }
+  if (!SANDBOX_MODES.has(opts.sandbox)) {
+    fail(`invalid sandbox "${opts.sandbox}" (expected: ${[...SANDBOX_MODES].join(", ")})`);
+  }
+  if (opts.model !== null && (typeof opts.model !== "string" || !SAFE_TOKEN.test(opts.model))) {
+    fail("invalid model (expected a shell-safe token using letters, digits, . _ : / -)");
+  }
+  if (opts.effort !== null && (typeof opts.effort !== "string" || !/^[a-z][a-z0-9-]*$/i.test(opts.effort))) {
     fail(`invalid --effort "${opts.effort}" (expected a non-empty bare token)`);
   }
   // The watchdog is relay-only (codex has no timeout flag), so a malformed
@@ -288,7 +403,7 @@ function prepareRunDir(opts, brief) {
   return run;
 }
 
-function makeResultWriter(opts, version, run) {
+function makeResultWriter(opts, modelSource, version, run) {
   // Returns writeResult(extra): merges the per-outcome fields onto the run's
   // standing metadata, persists result.json, and returns the object it just
   // wrote so the caller can hand it straight to printSummary.
@@ -298,6 +413,9 @@ function makeResultWriter(opts, version, run) {
       workdir: opts.cd,
       sandbox: opts.resumeLast || opts.session ? "(inherited from resumed session)" : opts.sandbox,
       model: opts.model,
+      modelSource,
+      route: opts.route,
+      timeout: opts.timeout,
       effort: opts.effort,
       resumeLast: opts.resumeLast,
       session: opts.session,
@@ -473,7 +591,7 @@ function main() {
 
   const version = codexVersion();
   const run = prepareRunDir(opts, brief);
-  const writeResult = makeResultWriter(opts, version, run);
+  const writeResult = makeResultWriter(opts, opts.modelSource, version, run);
 
   if (!version) {
     reportUnavailable(writeResult, run.resultPath);

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -27,8 +27,10 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | --- | --- |
 | `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
 | `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--model <name>` | Cursor model for this run (default: your Cursor default, usually `auto`). Names come from `cursor-agent models`. |
 | `--read-only` | Run in Cursor's plan mode: read-only analysis, no edits, no `--force`. |
+| `--sandbox <mode>` | Pass Cursor `--sandbox enabled` or `--sandbox disabled`. |
 | `--no-force` | Keep the run write-capable but withhold `--force`; commands requiring approval are refused. |
 | `--session <id>` | Resume a specific Cursor chat (`--resume <id>`); send only the delta brief. |
 | `--resume-last` | Resume the most recent Cursor chat (`--continue`); send only the delta brief. |
@@ -60,7 +62,7 @@ inside the worktree can make the artifacts appear there:
 
 - `schema`, `tool` (`"cursor-agent"`), `status` (`completed` | `failed` | `timeout` | `aborted` |
   `cursor_agent_unavailable`), `exitCode`, and `signal` (`null` unless the child died on a signal).
-- `workdir`, `model` (the requested name or `null`), `resolvedModel` (the model Cursor actually
+- `workdir`, `route`, `timeout`, `model` (the requested name or `null`), `modelSource`, `resolvedModel` (the model Cursor actually
   served, from its init event), `permissionMode` (the mode Cursor reported applying), `readOnly`,
   `force`, `resumed`, `cursorAgentVersion`, `sessionId`, `startedAt`, and `finishedAt`.
 - `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -34,10 +34,12 @@
  * Options:
  *   --brief <file>          Path to the brief. If omitted, read it from stdin.
  *   --cd <dir>              Working root for Cursor (default: current directory).
+ *   --route <name>          Named delegate-config task route.
  *   --model <name>          Cursor model (default: your Cursor default, usually
  *                           auto). List names with `cursor-agent models`.
  *   --read-only             Run in Cursor's plan mode: read-only analysis, no
  *                           edits, no --force.
+ *   --sandbox <mode>        Cursor sandbox: enabled | disabled.
  *   --no-force              Withhold --force on a write-capable run; commands
  *                           that require approval are refused instead of run.
  *   --session <id>          Resume a specific Cursor chat (`--resume <id>`);
@@ -71,8 +73,8 @@
 
 import { spawn, execSync, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, renameSync, rmSync, readFileSync, existsSync, appendFileSync } from "node:fs";
-import { join, resolve, basename } from "node:path";
-import { constants, tmpdir } from "node:os";
+import { join, resolve, basename, dirname } from "node:path";
+import { constants, tmpdir, homedir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
@@ -80,6 +82,10 @@ const MAX_TIMER_MS = 2_147_483_647;
 const VERSION_PROBE_TIMEOUT_MS = 10_000;
 const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:@/[\],=-]*$/;
 const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const SANDBOX_MODES = new Set(["enabled", "disabled"]);
+const CONFIG_FIELDS = new Set(["model", "sandbox", "force", "timeout", "readOnly"]);
+const BOOLEAN_CONFIG_FIELDS = new Set(["force", "readOnly"]);
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -90,13 +96,15 @@ function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     model: null,
-    readOnly: false,
-    force: true,
+    readOnly: null,
+    force: null,
+    sandbox: null,
     session: null,
     resumeLast: false,
     addDirs: [],
-    timeout: DEFAULT_TIMEOUT,
+    timeout: null,
     outDir: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -115,8 +123,10 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--model": opts.model = next(); break;
       case "--read-only": opts.readOnly = true; break;
+      case "--sandbox": opts.sandbox = next(); break;
       case "--no-force": opts.force = false; break;
       case "--session": opts.session = next(); break;
       case "--resume-last": opts.resumeLast = true; break;
@@ -127,10 +137,31 @@ function parseArgs(argv) {
         fail(`unknown option: ${arg}`);
     }
   }
+  const modelFromFlag = opts.model !== null;
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.model === null && config.model !== undefined) opts.model = config.model;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  if (opts.sandbox === null && config.sandbox !== undefined) opts.sandbox = config.sandbox;
+  if (opts.force === null && config.force !== undefined) opts.force = config.force;
+  if (opts.readOnly === null && config.readOnly !== undefined) opts.readOnly = config.readOnly;
+  if (opts.force === null) opts.force = true;
+  if (opts.readOnly === null) opts.readOnly = false;
+  if (opts.timeout === null) opts.timeout = DEFAULT_TIMEOUT;
+  opts.modelSource = modelFromFlag ? "flag" : delegateConfig.modelSource;
+  if (typeof opts.force !== "boolean") {
+    fail("delegate config cursor-agent.force must be a boolean");
+  }
+  if (typeof opts.readOnly !== "boolean") {
+    fail("delegate config cursor-agent.readOnly must be a boolean");
+  }
+  if (opts.sandbox !== null && !SANDBOX_MODES.has(opts.sandbox)) {
+    fail(`invalid sandbox "${opts.sandbox}" (expected: enabled, disabled)`);
+  }
   if (opts.resumeLast && opts.session) {
     fail("--resume-last and --session are mutually exclusive; pass only one");
   }
-  if (opts.model !== null && !SAFE_MODEL.test(opts.model)) {
+  if (opts.model !== null && (typeof opts.model !== "string" || !SAFE_MODEL.test(opts.model))) {
     fail("--model contains unsupported characters (allowed: letters, digits, . _ : @ / [ ] , = -)");
   }
   if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
@@ -146,7 +177,7 @@ function parseArgs(argv) {
   }
   // The watchdog is relay-only (cursor-agent has no timeout flag), so a
   // malformed --timeout must fail loudly here — a silent 30m fallback would be wrong.
-  if (parseDuration(opts.timeout) === null) {
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
     fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
   }
   return opts;
@@ -269,6 +300,7 @@ function buildArgv(opts) {
   const argv = ["--print", "--output-format", "stream-json", "--trust"];
   if (opts.readOnly) argv.push("--mode", "plan");
   else if (opts.force) argv.push("--force");
+  if (opts.sandbox) argv.push("--sandbox", opts.sandbox);
   if (opts.model) argv.push("--model", winq(opts.model));
   if (opts.session) argv.push("--resume", winq(opts.session));
   else if (opts.resumeLast) argv.push("--continue");
@@ -344,8 +376,12 @@ function makeResultWriter(opts, version, run) {
       tool: "cursor-agent",
       workdir: opts.cd,
       model: opts.model,
+      modelSource: opts.modelSource,
+      route: opts.route,
+      timeout: opts.timeout,
       readOnly: opts.readOnly,
       force: opts.force && !opts.readOnly,
+      sandbox: opts.sandbox,
       resumed: Boolean(opts.resumeLast || opts.session),
       cursorAgentVersion: version,
       startedAt: run.startedAt,
@@ -617,6 +653,96 @@ function dispatchToCursor(opts, brief, run, writeResult) {
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
   });
+}
+
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.["cursor-agent"];
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.cursor-agent must be an object`);
+  }
+  if (document.version === "delegate-config.v1") return [{ values: entry, label: "defaults" }];
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported cursor-agent section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: cursor-agent.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    { scope: "global", path: join(homedir(), ".config", "delegate-skills", "config.json") },
+    { scope: "project", path: join(findProjectRoot(cwd), ".delegate", "config.json") },
+  ];
+  const resolved = {};
+  let modelSource = "default";
+  let routeFound = route === null;
+  for (const candidate of candidates) {
+    const document = readDelegateConfig(candidate.path);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, candidate.path)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${candidate.path}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${candidate.path}: unsupported cursor-agent field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${candidate.path}: cursor-agent field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+        if (field === "model") modelSource = `${candidate.scope}:${layer.label}`;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved, modelSource };
 }
 
 async function main() {

--- a/skills/delegate-config/SKILL.md
+++ b/skills/delegate-config/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: delegate-config
+description: >-
+  Configure default settings and task-specific model routes for delegate skills.
+  Discovers installed implementer CLIs, authentication, and reported models, then
+  proposes a configuration for frontend, backend, fast, medium, complex, or other
+  task types for the user to approve or adjust before writing. Use when the user
+  asks to configure delegation models, routing, or preferences, or before the
+  first delegation when no config exists.
+license: MIT
+compatibility: Requires Node 18+. No implementer CLIs are required — the skill discovers what is available.
+metadata:
+  version: 0.2.0
+---
+
+# Delegate Config
+
+You are the **orchestrator**. Discover the available implementer CLIs, propose task-specific model
+routes, and write configuration only after the user approves or adjusts the proposal.
+
+This utility does not dispatch work to an implementer. It configures how later delegation runs select
+models and other defaults.
+
+## Trigger
+
+Use this skill when the user:
+
+- asks to configure delegation models, task routes, or preferences;
+- asks which implementer CLIs or models are available; or
+- is about to delegate for the first time and neither project nor global config exists.
+
+For the last case, suggest configuration without forcing it.
+
+Do not use this skill for a one-off model change. Pass `--model` directly to that relay instead.
+
+## Configuration flow
+
+### 1. Discover implementers
+
+Run:
+
+```bash
+node <skill-path>/scripts/discover.mjs
+```
+
+The report includes installed binaries, versions, paths, authentication when a bounded headless probe
+exists, supported config fields, and model reporting:
+
+- `reported` — the CLI returned model identifiers;
+- `unsupported` — the CLI has no bounded model-list command used by this skill;
+- `failed` — a supported model probe failed or timed out.
+
+Treat `authenticated: null` as unknown, not unauthenticated. A reported model catalog can include
+models for providers the user has not authenticated with.
+
+### 2. Load existing configuration
+
+Check:
+
+1. the Git repository root at `.delegate/config.json`;
+2. `~/.config/delegate-skills/config.json`.
+
+Relays also support the earlier `delegate-config.v1` single-default shape. New or updated
+configuration uses `delegate-config.v2`.
+
+### 3. Propose routes
+
+Use the discovered models and the user's stated work to propose a compact set of routes. Start with
+routes that are useful now, commonly:
+
+- `frontend`
+- `backend`
+- `fast`
+- `medium`
+- `complex`
+
+Add a combined route such as `frontend-complex` only when it needs settings different from both
+existing routes. Route names are user-owned and may describe other task types.
+
+For each route, show:
+
+- implementer and model;
+- effort or equivalent setting when supported;
+- why the route fits that task type;
+- any uncertainty, such as unknown authentication or a model catalog that may include unavailable
+  providers.
+
+Do not invent unavailable model identifiers. If the CLI cannot report models, use the CLI's current
+default or ask the user for a model identifier.
+
+### 4. Ask for approval
+
+Present the complete proposed JSON before writing. Ask the user to approve it or name adjustments.
+Do not create or overwrite a config file until approval is explicit.
+
+### 5. Choose scope
+
+Ask whether to save:
+
+- for the current repository at `.delegate/config.json`; or
+- globally at `~/.config/delegate-skills/config.json`.
+
+### 6. Write and confirm
+
+Create parent directories as needed, write JSON atomically, re-read it, and show:
+
+- the path written;
+- the diff when updating a file;
+- the routes and defaults now configured.
+
+## Version 2 schema
+
+Each implementer can have shared `defaults` plus named `routes`.
+
+```json
+{
+  "version": "delegate-config.v2",
+  "implementers": {
+    "codex": {
+      "defaults": {
+        "sandbox": "workspace-write",
+        "timeout": "30m"
+      },
+      "routes": {
+        "frontend": {
+          "model": "provider/frontend-model",
+          "effort": "medium"
+        },
+        "backend": {
+          "model": "provider/backend-model",
+          "effort": "medium"
+        },
+        "fast": {
+          "model": "provider/fast-model",
+          "effort": "low"
+        },
+        "complex": {
+          "model": "provider/complex-model",
+          "effort": "high"
+        }
+      }
+    }
+  }
+}
+```
+
+All settings are optional. Use duration strings such as `90s`, `30m`, or `2h`. For version 1
+compatibility, positive integer timeouts are interpreted as seconds. Qoder's version 1 `sandbox`
+field is read as `permissionMode`; new configuration uses `permissionMode`.
+
+Dispatch a configured route with:
+
+```bash
+node <delegate-skill-path>/scripts/relay.mjs --route frontend --brief <brief-file> --cd <repo>
+```
+
+An explicit `--model`, `--timeout`, or permission flag still wins over route configuration.
+
+## Per-field precedence
+
+Relays resolve each field independently:
+
+1. explicit relay flag;
+2. project route;
+3. project implementer defaults;
+4. global route;
+5. global implementer defaults;
+6. implementer CLI default.
+
+Project config is located from the Git repository root even when `--cd` names a subdirectory.
+Selecting a route that exists nowhere is an error rather than a silent fallback.
+
+## Supported fields
+
+| Implementer key | Skill | Supported config fields |
+| --- | --- | --- |
+| `claude` | claude-delegate | model, effort, timeout, readOnly |
+| `codex` | codex-delegate | model, sandbox, effort, timeout, readOnly |
+| `opencode` | opencode-delegate | model, timeout, readOnly |
+| `agy` | agy-delegate | model, timeout |
+| `grok` | grok-delegate | model, sandbox, effort, timeout, readOnly |
+| `kimi` | kimi-delegate | model, timeout |
+| `qodercli` | qoder-delegate | model, permissionMode, timeout, readOnly |
+| `vibe` | vibe-delegate | timeout, readOnly |
+| `cursor-agent` | cursor-delegate | model, sandbox, force, timeout, readOnly |
+| `pi` | pi-delegate | provider, model, timeout, readOnly |
+
+Fields unsupported by an implementer are configuration errors. Dangerous permission bypasses remain
+explicit relay flags and are not configurable defaults.

--- a/skills/delegate-config/scripts/discover.mjs
+++ b/skills/delegate-config/scripts/discover.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+/**
+ * discover.mjs — probes PATH for installed implementer CLIs.
+ *
+ * Outputs a JSON report listing every installed implementer CLI with its
+ * version, path, authentication status, and supported config fields.
+ *
+ * Usage:
+ *   node discover.mjs              JSON report to stdout
+ *   node discover.mjs --help       Show this help
+ *
+ * Exit codes:
+ *   0   Report written (even if nothing is installed)
+ *   2   Usage error
+ *
+ * Node built-ins only — no dependencies, direct network calls, credential
+ * access, or telemetry. Probed CLIs may contact their own services.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  accessSync,
+  constants as fsConstants,
+  statSync,
+} from "node:fs";
+import { delimiter, join, resolve } from "node:path";
+
+// ── CLI table ──────────────────────────────────────────────────────────────────
+//
+// Each entry maps a human-facing implementer name to the binary the relay
+// resolves on PATH, the version probe command, an optional auth probe, and the
+// config fields the relay can consume.
+
+const IMPLEMENTERS = [
+  {
+    name: "claude",
+    binary: "claude",
+    versionArgs: ["--version"],
+    authProbe: { args: ["auth", "status"], jsonField: "loggedIn" },
+    supports: ["model", "effort", "timeout", "readOnly"],
+    modelFlag: "--model",
+    modelProbe: null,
+    shell: false,  // native binary (launcher resolves .cmd on win32)
+  },
+  {
+    name: "codex",
+    binary: "codex",
+    versionArgs: ["--version"],
+    authProbe: null,  // no headless auth check
+    supports: ["model", "sandbox", "effort", "timeout", "readOnly"],
+    modelFlag: "-m",
+    modelProbe: null,
+    shell: true,  // needs shell:true on win32 for .cmd shim
+  },
+  {
+    name: "opencode",
+    binary: "opencode",
+    versionArgs: ["--version"],
+    authProbe: null,
+    supports: ["model", "timeout", "readOnly"],
+    modelFlag: "--model",
+    modelProbe: { args: ["models"], format: "lines" },
+    shell: true,
+  },
+  {
+    name: "agy",
+    binary: "agy",
+    versionArgs: ["changelog"],
+    authProbe: null,
+    supports: ["model", "timeout"],
+    modelFlag: "--model",
+    modelProbe: { args: ["models"], format: "lines" },
+    shell: false,
+  },
+  {
+    name: "grok",
+    binary: "grok",
+    versionArgs: ["version"],
+    versionFallbackArgs: ["--version"],
+    authProbe: null,
+    supports: ["model", "sandbox", "effort", "timeout", "readOnly"],
+    modelFlag: "--model",
+    modelProbe: null,
+    shell: true,
+  },
+  {
+    name: "kimi",
+    binary: "kimi",
+    versionArgs: ["--version"],
+    authProbe: null,
+    supports: ["model", "timeout"],
+    modelFlag: "-m",
+    modelProbe: null,
+    shell: false,
+  },
+  {
+    name: "qodercli",
+    binary: "qodercli",
+    versionArgs: ["--version"],
+    authProbe: null,
+    supports: ["model", "permissionMode", "timeout", "readOnly"],
+    modelFlag: "--model",
+    modelProbe: null,
+    shell: false,
+  },
+  {
+    name: "vibe",
+    binary: "vibe",
+    versionArgs: ["--version"],
+    authProbe: null,
+    supports: ["timeout", "readOnly"],  // vibe relay does not pass --model
+    modelFlag: null,
+    modelProbe: null,
+    shell: false,
+  },
+  {
+    name: "cursor-agent",
+    binary: "cursor-agent",
+    versionArgs: ["--version"],
+    authProbe: null,
+    supports: ["model", "sandbox", "force", "timeout", "readOnly"],
+    modelFlag: "--model",
+    modelProbe: { args: ["--list-models"], format: "cursor" },
+    shell: true,  // win32 uses shell:true + execSync
+  },
+  {
+    name: "pi",
+    binary: "pi",
+    versionArgs: ["--version"],
+    authProbe: null,
+    supports: ["provider", "model", "timeout", "readOnly"],
+    modelFlag: "--model",
+    modelProbe: null,
+    shell: true,
+  },
+];
+
+// ── Help ───────────────────────────────────────────────────────────────────────
+
+const HELP = `\
+discover.mjs — probe PATH for installed implementer CLIs
+
+Usage:
+  node discover.mjs              JSON report to stdout
+  node discover.mjs --help       Show this help
+
+Output shape (JSON):
+  {
+    "discovered": [
+      {
+        "name":          "<implementer name>",
+        "binary":        "<CLI binary name>",
+        "version":       "<version string or null>",
+        "path":          "<resolved binary path or null>",
+        "authenticated": <true | false | null>,
+        "supports":      ["model", "sandbox", ...],
+        "modelFlag":     "<flag the relay uses, or null>",
+        "models":        {"status":"reported|unsupported|failed","values":[],"truncated":false}
+      }
+    ],
+    "missing": ["<binary>", ...]
+  }
+`;
+
+// ── Argument parsing ───────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+if (args.includes("--help") || args.includes("-h")) {
+  process.stdout.write(HELP);
+  process.exit(0);
+}
+if (args.length > 0) {
+  process.stderr.write("discover.mjs: unexpected arguments. Use --help for usage.\n");
+  process.exit(2);
+}
+
+// ── Binary resolution ──────────────────────────────────────────────────────────
+
+/**
+ * Resolve a binary name to its absolute path on PATH. Mirrors the approach
+ * used by the relay scripts: walk PATH entries, check file existence and
+ * executability. On win32, also check PATHEXT extensions (.cmd, .bat, .exe).
+ *
+ * @param {string} binary  The binary name to search for.
+ * @returns {string|null}  Absolute path to the binary, or null if not found.
+ */
+function resolveBinary(binary) {
+  const pathValue = process.env.PATH || process.env.Path || "";
+  if (!pathValue) return null;
+
+  const pathEntries = pathValue
+    .split(delimiter)
+    .map((entry) => entry.replace(/^"(.*)"$/, "$1"));
+
+  if (process.platform === "win32") {
+    const pathExt = (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+      .split(";")
+      .map((ext) => ext.trim().toLowerCase())
+      .filter(Boolean);
+
+    for (const entry of pathEntries) {
+      const dir = resolve(entry || ".");
+      for (const ext of pathExt) {
+        const candidate = join(dir, `${binary}${ext}`);
+        try {
+          if (statSync(candidate).isFile()) return candidate;
+        } catch {
+          // Not here — keep looking.
+        }
+      }
+    }
+    return null;
+  }
+
+  // POSIX
+  for (const entry of pathEntries) {
+    const candidate = join(resolve(entry || "."), binary);
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // Not here — keep looking.
+    }
+  }
+  return null;
+}
+
+// ── Version probing ────────────────────────────────────────────────────────────
+
+const PROBE_TIMEOUT = 10_000; // 10 seconds
+
+/**
+ * Run the version command for an implementer and return the version string.
+ *
+ * @param {object} impl  An entry from IMPLEMENTERS.
+ * @returns {string|null}  Version string, or null if the probe failed.
+ */
+function needsWindowsShell(impl, binaryPath) {
+  return process.platform === "win32" &&
+    (impl.shell || /\.(?:cmd|bat)$/i.test(binaryPath));
+}
+
+function probeVersion(impl, binaryPath) {
+  const useShell = needsWindowsShell(impl, binaryPath);
+
+  const tryArgs = (versionArgs) => {
+    try {
+      const raw = execFileSync(binaryPath, versionArgs, {
+        encoding: "utf8",
+        timeout: PROBE_TIMEOUT,
+        stdio: ["pipe", "pipe", "pipe"],
+        shell: useShell,
+      });
+      return raw.trim().split("\n")[0].trim() || null;
+    } catch {
+      return null;
+    }
+  };
+
+  let version = tryArgs(impl.versionArgs);
+  if (version === null && impl.versionFallbackArgs) {
+    version = tryArgs(impl.versionFallbackArgs);
+  }
+  return version;
+}
+
+// ── Auth probing ───────────────────────────────────────────────────────────────
+
+/**
+ * Check authentication status for an implementer CLI.
+ *
+ * @param {object} impl  An entry from IMPLEMENTERS.
+ * @returns {boolean|null}  true if authenticated, false if not, null if
+ *                          the CLI has no auth probe or the check failed.
+ */
+function probeAuth(impl, binaryPath) {
+  if (!impl.authProbe) return null;
+
+  const useShell = needsWindowsShell(impl, binaryPath);
+  try {
+    const raw = execFileSync(binaryPath, impl.authProbe.args, {
+      encoding: "utf8",
+      timeout: PROBE_TIMEOUT,
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: useShell,
+    });
+    if (impl.authProbe.jsonField) {
+      return JSON.parse(raw)[impl.authProbe.jsonField] === true;
+    }
+    return impl.authProbe.successPattern.test(raw);
+  } catch (err) {
+    // Some CLIs exit non-zero when not authenticated but still print a
+    // message. Check stderr and stdout from the error.
+    const combined = `${err.stdout || ""}${err.stderr || ""}`;
+    if (combined && impl.authProbe.successPattern?.test(combined)) return true;
+    return false;
+  }
+}
+
+function parseModelLines(raw, format) {
+  const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const identifiers = format === "cursor"
+    ? lines
+        .filter((line) => line !== "Available models" && !line.startsWith("Tip:"))
+        .map((line) => line.split(/\s+-\s+/, 1)[0])
+    : lines;
+  const unique = [...new Set(identifiers)].filter(Boolean);
+  return {
+    status: "reported",
+    values: unique.slice(0, 200),
+    truncated: unique.length > 200,
+  };
+}
+
+function probeModels(impl, binaryPath) {
+  if (!impl.modelProbe) return { status: "unsupported", values: [], truncated: false };
+  try {
+    const raw = execFileSync(binaryPath, impl.modelProbe.args, {
+      encoding: "utf8",
+      timeout: PROBE_TIMEOUT,
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: needsWindowsShell(impl, binaryPath),
+    });
+    return parseModelLines(raw, impl.modelProbe.format);
+  } catch {
+    return { status: "failed", values: [], truncated: false };
+  }
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+const discovered = [];
+const missing = [];
+
+for (const impl of IMPLEMENTERS) {
+  const binaryPath = resolveBinary(impl.binary);
+
+  if (!binaryPath) {
+    missing.push(impl.binary);
+    continue;
+  }
+
+  const version = probeVersion(impl, binaryPath);
+  const authenticated = probeAuth(impl, binaryPath);
+  const models = probeModels(impl, binaryPath);
+
+  discovered.push({
+    name: impl.name,
+    binary: impl.binary,
+    version,
+    path: binaryPath,
+    authenticated,
+    supports: impl.supports,
+    modelFlag: impl.modelFlag,
+    models,
+  });
+}
+
+const report = { discovered, missing };
+process.stdout.write(JSON.stringify(report, null, 2) + "\n");

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -34,6 +34,7 @@ Options:
 | --- | --- |
 | `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
 | `--cd <dir>` | Working root for Grok (default: current directory); passed as `--cwd`. |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--model <name>` | Grok model (default: Grok's own configured default). |
 | `--effort <level>` | Reasoning effort for this run (`--effort`). |
 | `--max-turns <n>` | Maximum number of agent turns for this run (`--max-turns`). |
@@ -66,7 +67,7 @@ touched-files report shows only Grok's edits and nothing of the helper's own.
 - `usage` — token counts from the run's end event (`input_tokens` / `output_tokens` / `total_tokens`); `null` if none were reported
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report; `[]` means git ran and the tree is clean
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw streaming-json event stream, and the final-message file
-- `workdir`, `autonomy`, `model`, `effort`, `resumeLast`, `startedAt`, `finishedAt`
+- `workdir`, `route`, `timeout`, `autonomy`, `model`, `modelSource`, `effort`, `resumeLast`, `startedAt`, `finishedAt`
 - `readOnlyViolation` — present on `--read-only` runs only: `true` when the working tree changed
   between dispatch and completion, i.e. the best-effort read-only was not honored. A porcelain-level
   tripwire: it catches new dirt, but an edit inside an already-dirty file can evade it — the diff

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -42,6 +42,7 @@
  * Options:
  *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
  *   --cd <dir>              Working root for Grok (default: current directory).
+ *   --route <name>          Named delegate-config task route.
  *   --model <name>          Grok model (default: Grok's own configured default).
  *   --effort <level>        Reasoning effort for this run (passed as `--effort`).
  *   --max-turns <n>         Maximum number of agent turns for this run.
@@ -78,25 +79,119 @@
 
 import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
-import { join, resolve, basename } from "node:path";
-import { constants, tmpdir } from "node:os";
+import { join, resolve, basename, dirname } from "node:path";
+import { constants, tmpdir, homedir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const AUTONOMY_MODES = new Set(["workspace-write", "read-only", "full-access"]);
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const CONFIG_FIELDS = new Set(["model", "sandbox", "effort", "timeout", "readOnly"]);
+const BOOLEAN_CONFIG_FIELDS = new Set(["readOnly"]);
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
   process.exit(code);
 }
 
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.grok;
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.grok must be an object`);
+  }
+  if (document.version === "delegate-config.v1") return [{ values: entry, label: "defaults" }];
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported grok section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: grok.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    { scope: "global", path: join(homedir(), ".config", "delegate-skills", "config.json") },
+    { scope: "project", path: join(findProjectRoot(cwd), ".delegate", "config.json") },
+  ];
+  const resolved = {};
+  let modelSource = "default";
+  let routeFound = route === null;
+  for (const candidate of candidates) {
+    const document = readDelegateConfig(candidate.path);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, candidate.path)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${candidate.path}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${candidate.path}: unsupported grok field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${candidate.path}: grok field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+        if (field === "model") modelSource = `${candidate.scope}:${layer.label}`;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved, modelSource };
+}
+
 function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     model: null,
     effort: null,
     maxTurns: null,
-    autonomy: "workspace-write",
+    autonomy: null,
     resumeLast: false,
     session: null,
     timeout: null,
@@ -118,6 +213,7 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--model": opts.model = next(); break;
       case "--effort": opts.effort = next(); break;
       case "--max-turns": opts.maxTurns = next(); break;
@@ -130,6 +226,21 @@ function parseArgs(argv) {
       default:
         fail(`unknown option: ${arg}`);
     }
+  }
+  const modelFromFlag = opts.model !== null;
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.model === null && config.model !== undefined) opts.model = config.model;
+  if (opts.effort === null && config.effort !== undefined) opts.effort = config.effort;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  if (opts.autonomy === null) {
+    if (config.readOnly === true) opts.autonomy = "read-only";
+    else if (config.sandbox !== undefined) opts.autonomy = config.sandbox;
+    else opts.autonomy = "workspace-write";
+  }
+  opts.modelSource = modelFromFlag ? "flag" : delegateConfig.modelSource;
+  if (config.readOnly !== undefined && typeof config.readOnly !== "boolean") {
+    fail("delegate config grok.readOnly must be a boolean");
   }
   // The watchdog is relay-only (the grok launch has no timeout flag), so a malformed
   // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
@@ -145,7 +256,7 @@ function parseArgs(argv) {
   // These values reach a shell on win32 (shell:true for the .cmd shim), so restrict them to safe tokens.
   const safeToken = /^[A-Za-z0-9][A-Za-z0-9._:\/-]*$/;
   for (const flag of ["model", "effort", "session"]) {
-    if (opts[flag] !== null && !safeToken.test(opts[flag])) {
+    if (opts[flag] !== null && (typeof opts[flag] !== "string" || !safeToken.test(opts[flag]))) {
       fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
     }
   }
@@ -377,7 +488,7 @@ function prepareRunDir(opts, brief) {
   return run;
 }
 
-function makeResultWriter(opts, version, run) {
+function makeResultWriter(opts, modelSource, version, run) {
   // Returns writeResult(extra): merges the per-outcome fields onto the run's
   // standing metadata, persists result.json, and returns the object it just
   // wrote so the caller can hand it straight to printSummary.
@@ -388,6 +499,9 @@ function makeResultWriter(opts, version, run) {
       workdir: opts.cd,
       autonomy: opts.autonomy,
       model: opts.model,
+      modelSource,
+      route: opts.route,
+      timeout: opts.timeout,
       effort: opts.effort,
       resumeLast: opts.resumeLast,
       grokVersion: version,
@@ -591,7 +705,7 @@ function main() {
 
   const version = grokVersion();
   const run = prepareRunDir(opts, brief);
-  const writeResult = makeResultWriter(opts, version, run);
+  const writeResult = makeResultWriter(opts, opts.modelSource, version, run);
 
   if (!version) {
     reportUnavailable(writeResult, run.resultPath);

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -27,6 +27,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | --- | --- |
 | `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
 | `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--model <alias>` | Kimi model alias for this run (default: Kimi's own `default_model`). |
 | `--session <id>` | Resume a specific Kimi session; send only the delta brief. |
 | `--resume-last` | Resume the most recent Kimi session for this cwd (`kimi --continue`); send only the delta brief. |
@@ -57,7 +58,7 @@ inside the worktree can make the artifacts appear there:
 
 - `schema`, `tool` (`"kimi"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `kimi_unavailable`), `exitCode`, and
   `signal` (`null` unless the child died on a signal).
-- `workdir`, `model` (the model alias or `null`), `resumed`, `kimiVersion`, `sessionId`, `startedAt`,
+- `workdir`, `route`, `timeout`, `model` (the model alias or `null`), `modelSource`, `resumed`, `kimiVersion`, `sessionId`, `startedAt`,
   and `finishedAt`.
 - `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
 - `finalMessage` - assistant `content` strings joined with `"\n\n"`; tool calls and tool results are

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -38,6 +38,7 @@
  * Options:
  *   --brief <file>          Path to the brief. If omitted, read it from stdin.
  *   --cd <dir>              Working root for Kimi (default: current directory).
+ *   --route <name>          Named delegate-config task route.
  *   --model <alias>         Kimi model alias (default: Kimi's own default_model).
  *   --session <id>          Resume a specific Kimi session; send only the delta brief.
  *   --resume-last           Resume the most recent Kimi session for this cwd;
@@ -66,11 +67,14 @@
 
 import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
-import { join, resolve, basename } from "node:path";
-import { constants, tmpdir } from "node:os";
+import { join, resolve, basename, dirname } from "node:path";
+import { constants, tmpdir, homedir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const CONFIG_FIELDS = new Set(["model", "timeout"]);
+const BOOLEAN_CONFIG_FIELDS = new Set();
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -81,11 +85,12 @@ function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     model: null,
     session: null,
     resumeLast: false,
     addDirs: [],
-    timeout: DEFAULT_TIMEOUT,
+    timeout: null,
     outDir: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -104,6 +109,7 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--model": opts.model = next(); break;
       case "--session": opts.session = next(); break;
       case "--resume-last": opts.resumeLast = true; break;
@@ -120,11 +126,21 @@ function parseArgs(argv) {
   // kimi resolves a relative --add-dir against ITS cwd, so resolve against --cd
   // (not the relay's own cwd) - and only after the loop, since --add-dir may
   // appear before --cd on the command line. resolve() passes absolutes through.
+  const modelFromFlag = opts.model !== null;
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.model === null && config.model !== undefined) opts.model = config.model;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  if (opts.timeout === null) opts.timeout = DEFAULT_TIMEOUT;
+  opts.modelSource = modelFromFlag ? "flag" : delegateConfig.modelSource;
   opts.addDirs = opts.addDirs.map((dir) => resolve(opts.cd, dir));
   // The watchdog is relay-only (kimi has no timeout flag), so a malformed
   // --timeout must fail loudly here - a silent 30m fallback would be wrong.
-  if (parseDuration(opts.timeout) === null) {
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
     fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  if (opts.model !== null && (typeof opts.model !== "string" || !opts.model.trim())) {
+    fail("--model must be a non-empty string");
   }
   return opts;
 }
@@ -285,6 +301,9 @@ function makeResultWriter(opts, version, run) {
       tool: "kimi",
       workdir: opts.cd,
       model: opts.model,
+      modelSource: opts.modelSource,
+      route: opts.route,
+      timeout: opts.timeout,
       resumed: Boolean(opts.resumeLast || opts.session),
       kimiVersion: version,
       startedAt: run.startedAt,
@@ -458,6 +477,96 @@ function dispatchToKimi(opts, brief, run, writeResult) {
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
   });
+}
+
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.kimi;
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.kimi must be an object`);
+  }
+  if (document.version === "delegate-config.v1") return [{ values: entry, label: "defaults" }];
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported kimi section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: kimi.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    { scope: "global", path: join(homedir(), ".config", "delegate-skills", "config.json") },
+    { scope: "project", path: join(findProjectRoot(cwd), ".delegate", "config.json") },
+  ];
+  const resolved = {};
+  let modelSource = "default";
+  let routeFound = route === null;
+  for (const candidate of candidates) {
+    const document = readDelegateConfig(candidate.path);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, candidate.path)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${candidate.path}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${candidate.path}: unsupported kimi field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${candidate.path}: kimi field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+        if (field === "model") modelSource = `${candidate.scope}:${layer.label}`;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved, modelSource };
 }
 
 function main() {

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -31,6 +31,7 @@ Options:
 | --- | --- |
 | `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
 | `--cd <dir>` | Working root for OpenCode (default: current directory). |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--model <name>` | Model as `provider/model`. **Required on a fresh run** — OpenCode has no safe default (a bare `opencode run` errors); a resumed run inherits its session's model. |
 | `--agent <name>` | OpenCode agent (default: `build`, write-capable). |
 | `--read-only` | Shortcut for `--agent plan` — review/diagnosis with no edits. |
@@ -65,7 +66,7 @@ touched-files report shows only OpenCode's edits and nothing of the helper's own
 - `cost` — total run cost in USD, summed from the step events (`null` if none were reported)
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSON event stream, and
   the final-message file
-- `workdir`, `model`, `auto`, `resumeLast`, `startedAt`, `finishedAt`
+- `workdir`, `route`, `timeout`, `model`, `modelSource`, `auto`, `resumeLast`, `startedAt`, `finishedAt`
 - `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`,
   `opencode_unavailable`, and launch failures
 - `error` — present on a launch failure, and on `timeout` and `aborted` runs

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -32,6 +32,7 @@
  * Options:
  *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
  *   --cd <dir>              Working root for OpenCode (default: current directory).
+ *   --route <name>          Named delegate-config task route.
  *   --model <name>          Model as provider/model. REQUIRED for a fresh run — OpenCode has no
  *                           safe default; a resumed run inherits its session's model.
  *   --agent <name>          OpenCode agent (default: build). Use plan for read-only review.
@@ -68,21 +69,117 @@
 
 import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
-import { join, resolve, basename } from "node:path";
-import { constants, tmpdir } from "node:os";
+import { join, resolve, basename, dirname } from "node:path";
+import { constants, tmpdir, homedir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
+
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const CONFIG_FIELDS = new Set(["model", "timeout", "readOnly"]);
+const BOOLEAN_CONFIG_FIELDS = new Set(["readOnly"]);
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
   process.exit(code);
 }
 
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.opencode;
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.opencode must be an object`);
+  }
+  if (document.version === "delegate-config.v1") return [{ values: entry, label: "defaults" }];
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported opencode section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: opencode.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    { scope: "global", path: join(homedir(), ".config", "delegate-skills", "config.json") },
+    { scope: "project", path: join(findProjectRoot(cwd), ".delegate", "config.json") },
+  ];
+  const resolved = {};
+  let modelSource = "default";
+  let routeFound = route === null;
+  for (const candidate of candidates) {
+    const document = readDelegateConfig(candidate.path);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, candidate.path)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${candidate.path}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${candidate.path}: unsupported opencode field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${candidate.path}: opencode field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+        if (field === "model") modelSource = `${candidate.scope}:${layer.label}`;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved, modelSource };
+}
+
 function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     model: null,
-    agent: "build",
+    agent: null,
     variant: null,
     auto: true,
     resumeLast: false,
@@ -107,6 +204,7 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--model": opts.model = next(); break;
       case "--agent": opts.agent = next(); break;
       case "--read-only": opts.agent = "plan"; break;
@@ -121,6 +219,20 @@ function parseArgs(argv) {
       default:
         fail(`unknown option: ${arg}`);
     }
+  }
+  const modelFromFlag = opts.model !== null;
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.model === null && config.model !== undefined) opts.model = config.model;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  if (opts.agent === null && config.readOnly === true) opts.agent = "plan";
+  if (opts.agent === null) opts.agent = "build";
+  opts.modelSource = modelFromFlag ? "flag" : delegateConfig.modelSource;
+  if (config.readOnly !== undefined && typeof config.readOnly !== "boolean") {
+    fail("delegate config opencode.readOnly must be a boolean");
+  }
+  if (opts.model !== null && (typeof opts.model !== "string" || !SAFE_TOKEN.test(opts.model))) {
+    fail("invalid model (expected a shell-safe token using letters, digits, . _ : / -)");
   }
   // The watchdog is relay-only (the opencode launch has no timeout flag), so a malformed
   // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
@@ -314,7 +426,7 @@ function prepareRunDir(opts, brief) {
   return run;
 }
 
-function makeResultWriter(opts, version, run) {
+function makeResultWriter(opts, modelSource, version, run) {
   // Returns writeResult(extra): merges the per-outcome fields onto the run's
   // standing metadata, persists result.json, and returns the object it just
   // wrote so the caller can hand it straight to printSummary.
@@ -326,6 +438,9 @@ function makeResultWriter(opts, version, run) {
       workdir: opts.cd,
       agent: resuming ? "(inherited from resumed session)" : opts.agent,
       model: opts.model,
+      modelSource,
+      route: opts.route,
+      timeout: opts.timeout,
       auto: opts.auto,
       resumeLast: opts.resumeLast,
       opencodeVersion: version,
@@ -532,6 +647,7 @@ function main() {
   if (opts.session && opts.resumeLast) {
     fail("--session and --resume-last are mutually exclusive; pass only one");
   }
+
   // OpenCode has no safe default model (a bare `opencode run` errors), so a fresh run must name one.
   // A resumed run inherits its session's model, so --model is optional there.
   if (!opts.model && !opts.resumeLast && !opts.session) {
@@ -540,7 +656,7 @@ function main() {
 
   const version = opencodeVersion();
   const run = prepareRunDir(opts, brief);
-  const writeResult = makeResultWriter(opts, version, run);
+  const writeResult = makeResultWriter(opts, opts.modelSource, version, run);
 
   if (!version) {
     reportUnavailable(writeResult, run.resultPath);

--- a/skills/pi-delegate/references/dispatch-and-poll.md
+++ b/skills/pi-delegate/references/dispatch-and-poll.md
@@ -27,6 +27,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | --- | --- |
 | `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
 | `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--provider <name>` | pi provider name (default: pi's own default). Token-validated. |
 | `--model <pattern>` | pi model id or pattern (default: pi's own default). Token-validated: letters, digits, `. _ : / -`. |
 | `--session <id>` | Resume a specific pi session; send only the delta brief. |
@@ -59,7 +60,7 @@ Artifacts live outside the repo by default, so they do not appear in `touchedFil
 
 - `schema`, `tool` (`"pi"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `pi_unavailable`), `exitCode`, and
   `signal` (`null` unless the child died on a signal).
-- `workdir`, requested `provider`/`model`, `projectTrusted`, `readOnly`, `resumed`, `piVersion`,
+- `workdir`, `route`, `timeout`, requested `provider`/`model`, `modelSource`, `projectTrusted`, `readOnly`, `resumed`, `piVersion`,
   `sessionId`, `startedAt`, and `finishedAt`.
 - `actualProvider`, `actualModel`, `usage`, and `stopReason` from Pi's final assistant event.
 - `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -41,6 +41,7 @@
  * Options:
  *   --brief <file>          Path to the brief. If omitted, read it from stdin.
  *   --cd <dir>              Working root for pi (default: current directory).
+ *   --route <name>          Named delegate-config task route.
  *   --provider <name>       pi provider name (default: pi's own default).
  *   --model <pattern>       pi model id or pattern (default: pi's own default).
  *                           Letters, digits, and . _ : / - only.
@@ -84,8 +85,8 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { join, resolve, basename } from "node:path";
-import { constants, tmpdir } from "node:os";
+import { join, resolve, basename, dirname } from "node:path";
+import { constants, tmpdir, homedir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
@@ -94,6 +95,9 @@ const READ_ONLY_TOOLS = "read,grep,find,ls";
 // --model, --provider, and --session values reach a shell on win32 (shell:true for the
 // .cmd shim), so they are restricted to safe tokens.
 const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const CONFIG_FIELDS = new Set(["provider", "model", "timeout", "readOnly"]);
+const BOOLEAN_CONFIG_FIELDS = new Set(["readOnly"]);
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -111,13 +115,14 @@ function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     provider: null,
     model: null,
     session: null,
     resumeLast: false,
-    readOnly: false,
+    readOnly: null,
     approve: false,
-    timeout: DEFAULT_TIMEOUT,
+    timeout: null,
     outDir: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -136,6 +141,7 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--provider": opts.provider = next(); break;
       case "--model": opts.model = next(); break;
       case "--session": opts.session = next(); break;
@@ -148,21 +154,34 @@ function parseArgs(argv) {
         fail(`unknown option: ${arg}`);
     }
   }
+  const modelFromFlag = opts.model !== null;
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.provider === null && config.provider !== undefined) opts.provider = config.provider;
+  if (opts.model === null && config.model !== undefined) opts.model = config.model;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  if (opts.readOnly === null && config.readOnly !== undefined) opts.readOnly = config.readOnly;
+  if (opts.readOnly === null) opts.readOnly = false;
+  if (opts.timeout === null) opts.timeout = DEFAULT_TIMEOUT;
+  opts.modelSource = modelFromFlag ? "flag" : delegateConfig.modelSource;
+  if (typeof opts.readOnly !== "boolean") {
+    fail("delegate config pi.readOnly must be a boolean");
+  }
   if (opts.resumeLast && opts.session) {
     fail("--resume-last and --session are mutually exclusive; pass only one");
   }
   for (const flag of ["model", "provider", "session"]) {
-    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+    if (opts[flag] !== null && (typeof opts[flag] !== "string" || !SAFE_TOKEN.test(opts[flag]))) {
       fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
     }
   }
-  if (parseDuration(opts.timeout) === null) {
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
     fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
   }
-  if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
+  if (opts.timeout !== null && parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
   // setTimeout overflows past 2^31 - 1 ms (~24.8 days) and fires immediately,
   // which would read as an instant spurious timeout — reject it up front.
-  if (parseDuration(opts.timeout) > 2_147_483_647) {
+  if (opts.timeout !== null && parseDuration(opts.timeout) > 2_147_483_647) {
     fail(`--timeout "${opts.timeout}" exceeds the maximum schedulable watchdog (~24.8 days)`);
   }
   if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
@@ -372,6 +391,9 @@ function makeResultWriter(opts, version, run) {
       workdir: opts.cd,
       provider: opts.provider,
       model: opts.model,
+      modelSource: opts.modelSource,
+      route: opts.route,
+      timeout: opts.timeout,
       readOnly: opts.readOnly,
       projectTrusted: opts.approve,
       resumed: Boolean(opts.resumeLast || opts.session),
@@ -651,6 +673,96 @@ function dispatchToPi(opts, brief, run, writeResult) {
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
   });
+}
+
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.pi;
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.pi must be an object`);
+  }
+  if (document.version === "delegate-config.v1") return [{ values: entry, label: "defaults" }];
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported pi section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: pi.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    { scope: "global", path: join(homedir(), ".config", "delegate-skills", "config.json") },
+    { scope: "project", path: join(findProjectRoot(cwd), ".delegate", "config.json") },
+  ];
+  const resolved = {};
+  let modelSource = "default";
+  let routeFound = route === null;
+  for (const candidate of candidates) {
+    const document = readDelegateConfig(candidate.path);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, candidate.path)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${candidate.path}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${candidate.path}: unsupported pi field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${candidate.path}: pi field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+        if (field === "model") modelSource = `${candidate.scope}:${layer.label}`;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved, modelSource };
 }
 
 async function main() {

--- a/skills/qoder-delegate/references/dispatch-and-poll.md
+++ b/skills/qoder-delegate/references/dispatch-and-poll.md
@@ -25,6 +25,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | --- | --- |
 | `--brief <file>` | Brief path; omit to read stdin. |
 | `--cd <dir>` | Primary working root and child cwd; defaults to current directory. |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--model <name>` | Exact live model value from `qodercli --list-models`; omit for Qoder's default. |
 | `--context-window <n>` | Positive integer requested for models that support explicit sizing. |
 | `--resume <id>` | Resume one Qoder session with a delta brief. |
@@ -72,7 +73,7 @@ Important `result.json` fields:
 
 - `tool` (`"qoder"`), `status` (`completed`, `failed`, `timeout`, `aborted`, or
   `qoder_unavailable`), `exitCode`, `signal`.
-- Requested `model`, `contextWindow`, and `permissionMode`; observed `actualModel` and
+- Requested `route`, `timeout`, `model`, `modelSource`, `contextWindow`, and `permissionMode`; observed `actualModel` and
   `actualPermissionMode` from Qoder's init event.
 - `qoderVersion`, `sessionId`, `resumed`, `startedAt`, and `finishedAt`.
 - `usage`, `resultSubtype`, `qoderErrors`, and `permissionDenials` from Qoder's result event.

--- a/skills/qoder-delegate/scripts/relay.mjs
+++ b/skills/qoder-delegate/scripts/relay.mjs
@@ -19,6 +19,7 @@
  * Options:
  *   --brief <file>          Brief path. If omitted, read stdin.
  *   --cd <dir>              Qoder working root (default: current directory).
+ *   --route <name>          Named delegate-config task route.
  *   --model <name>          Model from `qodercli --list-models`.
  *   --context-window <n>    Positive integer; supported models only.
  *   --resume <id>           Resume one Qoder session; send a delta brief.
@@ -49,8 +50,8 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { constants, tmpdir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { constants, tmpdir, homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
@@ -64,6 +65,9 @@ const PERMISSION_MODES = new Set([
   "auto",
   "plan",
 ]);
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const CONFIG_FIELDS = new Set(["model", "timeout", "readOnly", "permissionMode"]);
+const BOOLEAN_CONFIG_FIELDS = new Set(["readOnly"]);
 
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
@@ -80,13 +84,14 @@ function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     model: null,
     contextWindow: null,
     resume: null,
     resumeLast: false,
     addDirs: [],
-    permissionMode: "auto",
-    timeout: DEFAULT_TIMEOUT,
+    permissionMode: null,
+    timeout: null,
     outDir: null,
   };
 
@@ -106,6 +111,7 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--model": opts.model = next(); break;
       case "--context-window": opts.contextWindow = next(); break;
       case "--resume": opts.resume = next(); break;
@@ -122,17 +128,35 @@ function parseArgs(argv) {
     fail("--resume-last and --resume are mutually exclusive; pass only one");
   }
   if (opts.resume !== null && !opts.resume.trim()) fail("--resume must not be empty");
-  if (opts.model !== null && !opts.model.trim()) fail("--model must not be empty");
+  if (opts.model !== null && (typeof opts.model !== "string" || !opts.model.trim())) {
+    fail("--model must be a non-empty string");
+  }
+  const modelFromFlag = opts.model !== null;
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.model === null && config.model !== undefined) opts.model = config.model;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  if (opts.permissionMode === null) {
+    if (config.readOnly === true) opts.permissionMode = "plan";
+    else if (config.permissionMode !== undefined) opts.permissionMode = config.permissionMode;
+    else if (config.sandbox !== undefined) opts.permissionMode = config.sandbox;
+    else opts.permissionMode = "auto";
+  }
+  if (opts.timeout === null) opts.timeout = DEFAULT_TIMEOUT;
+  opts.modelSource = modelFromFlag ? "flag" : delegateConfig.modelSource;
+  if (config.readOnly !== undefined && typeof config.readOnly !== "boolean") {
+    fail("delegate config qodercli.readOnly must be a boolean");
+  }
   if (opts.contextWindow !== null && !/^[1-9]\d*$/.test(opts.contextWindow)) {
     fail("--context-window must be a positive integer");
   }
-  if (!PERMISSION_MODES.has(opts.permissionMode)) {
+  if (opts.permissionMode !== null && !PERMISSION_MODES.has(opts.permissionMode)) {
     fail(`unsupported --permission-mode: ${opts.permissionMode}`);
   }
-  if (parseDuration(opts.timeout) === null) {
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
     fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
   }
-  if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
+  if (opts.timeout !== null && parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
   if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
     fail(`working directory not found: ${opts.cd}`);
   }
@@ -301,6 +325,9 @@ function makeResultWriter(opts, version, run) {
       tool: "qoder",
       workdir: opts.cd,
       model: opts.model,
+      modelSource: opts.modelSource,
+      route: opts.route,
+      timeout: opts.timeout,
       contextWindow: opts.contextWindow,
       permissionMode: opts.permissionMode,
       resumed: Boolean(opts.resumeLast || opts.resume),
@@ -577,6 +604,103 @@ function printSummary(result, resultPath) {
   lines.push(`result: ${resultPath}`);
   lines.push("relay does not commit. Review the diff, rerun the project gates yourself, then commit from the orchestrator.");
   process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.qodercli;
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.qodercli must be an object`);
+  }
+  if (document.version === "delegate-config.v1") {
+    const values = { ...entry };
+    if (values.sandbox !== undefined && values.permissionMode === undefined) {
+      values.permissionMode = values.sandbox;
+    }
+    delete values.sandbox;
+    return [{ values, label: "defaults" }];
+  }
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported qodercli section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: qodercli.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    { scope: "global", path: join(homedir(), ".config", "delegate-skills", "config.json") },
+    { scope: "project", path: join(findProjectRoot(cwd), ".delegate", "config.json") },
+  ];
+  const resolved = {};
+  let modelSource = "default";
+  let routeFound = route === null;
+  for (const candidate of candidates) {
+    const document = readDelegateConfig(candidate.path);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, candidate.path)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${candidate.path}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${candidate.path}: unsupported qodercli field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${candidate.path}: qodercli field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+        if (field === "model") modelSource = `${candidate.scope}:${layer.label}`;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved, modelSource };
 }
 
 function main() {

--- a/skills/vibe-delegate/references/dispatch-and-poll.md
+++ b/skills/vibe-delegate/references/dispatch-and-poll.md
@@ -34,6 +34,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | --- | --- |
 | `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
 | `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--route <name>` | Apply a named `delegate-config.v2` task route. |
 | `--max-turns <n>` | Maximum number of Vibe agent turns (`--max-turns`). Useful for cost control. |
 | `--max-price <usd>` | Positive, indicative cost threshold in USD; not a hard budget (`--max-price`). |
 | `--max-tokens <n>` | Positive maximum cumulative session tokens (`--max-tokens`). |
@@ -71,7 +72,7 @@ inside the worktree can make the artifacts appear there:
 
 - `schema`, `tool` (`"vibe"`), `status` (`completed` | `failed` | `timeout` | `aborted` |
   `vibe_unavailable`), `exitCode`, and `signal` (`null` unless the child died on a signal).
-- `workdir`, `agent` (`"accept-edits"`, `"plan"`, or `"auto-approve"`), `maxTurns`, `maxPrice`,
+- `workdir`, `route`, `timeout`, `agent` (`"accept-edits"`, `"plan"`, or `"auto-approve"`), `maxTurns`, `maxPrice`,
   `maxTokens`, `resumed`, `vibeVersion`, `sessionId`, `startedAt`, and `finishedAt`.
 - `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
 - `finalMessage` — the last non-empty assistant content string; tool calls and tool results are excluded.

--- a/skills/vibe-delegate/scripts/relay.mjs
+++ b/skills/vibe-delegate/scripts/relay.mjs
@@ -37,6 +37,7 @@
  * Options:
  *   --brief <file>           Path to the brief. If omitted, read it from stdin.
  *   --cd <dir>               Working root for Vibe (default: current directory).
+ *   --route <name>           Named delegate-config task route.
  *   --max-turns <n>          Maximum number of Vibe agent turns (--max-turns).
  *   --max-price <usd>        Indicative cost threshold in USD (--max-price);
  *                            not a hard budget.
@@ -81,11 +82,14 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { join, resolve, basename } from "node:path";
-import { constants, tmpdir } from "node:os";
+import { join, resolve, basename, dirname } from "node:path";
+import { constants, tmpdir, homedir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
+const SAFE_ROUTE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const CONFIG_FIELDS = new Set(["timeout", "readOnly"]);
+const BOOLEAN_CONFIG_FIELDS = new Set(["readOnly"]);
 const MAX_TIMER_MS = 2_147_483_647;
 const MAX_BRIEF_BYTES = (process.platform === "win32" ? 12 : 120) * 1024;
 const PROBE_TIMEOUT_MS = 10_000;
@@ -99,6 +103,7 @@ function parseArgs(argv) {
   const opts = {
     brief: null,
     cd: process.cwd(),
+    route: null,
     maxTurns: null,
     maxPrice: null,
     maxTokens: null,
@@ -108,7 +113,7 @@ function parseArgs(argv) {
     fullAccess: false,
     enabledTools: [],
     disabledTools: [],
-    timeout: DEFAULT_TIMEOUT,
+    timeout: null,
     outDir: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -127,6 +132,7 @@ function parseArgs(argv) {
         break;
       case "--brief": opts.brief = next(); break;
       case "--cd": opts.cd = resolve(next()); break;
+      case "--route": opts.route = next(); break;
       case "--max-turns": {
         const v = next();
         const n = Number(v);
@@ -166,6 +172,14 @@ function parseArgs(argv) {
         fail(`unknown option: ${arg}`);
     }
   }
+  const delegateConfig = loadDelegateConfig(opts.cd, opts.route);
+  const config = delegateConfig.values;
+  if (opts.timeout === null && config.timeout !== undefined) opts.timeout = config.timeout;
+  if (!opts.planOnly && !opts.fullAccess && config.readOnly === true) opts.planOnly = true;
+  if (opts.timeout === null) opts.timeout = DEFAULT_TIMEOUT;
+  if (config.readOnly !== undefined && typeof config.readOnly !== "boolean") {
+    fail("delegate config vibe.readOnly must be a boolean");
+  }
   if (opts.resumeLast && opts.session) {
     fail("--resume-last and --session are mutually exclusive; pass only one");
   }
@@ -177,7 +191,7 @@ function parseArgs(argv) {
   if (opts.disabledTools.some((tool) => !tool.trim())) fail("--disabled-tools must not be empty");
   // The watchdog is relay-only (vibe has no timeout flag), so a malformed
   // --timeout must fail loudly here — a silent 30m fallback would be wrong.
-  if (parseDuration(opts.timeout) === null) {
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
     fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
   }
   try {
@@ -381,6 +395,8 @@ function makeResultWriter(opts, version, run) {
       schema: "delegate-relay.result.v1",
       tool: "vibe",
       workdir: opts.cd,
+      route: opts.route,
+      timeout: opts.timeout,
       agent: agentName(opts),
       maxTurns: opts.maxTurns,
       maxPrice: opts.maxPrice,
@@ -601,6 +617,94 @@ function dispatchToVibe(opts, brief, run, writeResult, onReady) {
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
   });
+}
+
+/** Find the nearest Git repository root, or retain cwd outside a repository. */
+function findProjectRoot(cwd) {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(cwd);
+    current = parent;
+  }
+}
+
+function readDelegateConfig(configPath) {
+  if (!existsSync(configPath)) return null;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    fail(`invalid delegate config ${configPath}: ${error.message}`);
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    fail(`invalid delegate config ${configPath}: expected a JSON object`);
+  }
+  if (!["delegate-config.v1", "delegate-config.v2"].includes(document.version)) {
+    fail(`invalid delegate config ${configPath}: unsupported version "${document.version}"`);
+  }
+  return document;
+}
+
+function configLayers(document, route, configPath) {
+  const entry = document?.implementers?.vibe;
+  if (entry === undefined) return [];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    fail(`invalid delegate config ${configPath}: implementers.vibe must be an object`);
+  }
+  if (document.version === "delegate-config.v1") return [{ values: entry, label: "defaults" }];
+  for (const field of Object.keys(entry)) {
+    if (!["defaults", "routes"].includes(field)) {
+      fail(`invalid delegate config ${configPath}: unsupported vibe section "${field}"`);
+    }
+  }
+  if (entry.routes !== undefined && (!entry.routes || typeof entry.routes !== "object" || Array.isArray(entry.routes))) {
+    fail(`invalid delegate config ${configPath}: vibe.routes must be an object`);
+  }
+  const layers = [];
+  if (entry.defaults !== undefined) layers.push({ values: entry.defaults, label: "defaults" });
+  if (route && entry.routes?.[route] !== undefined) {
+    layers.push({ values: entry.routes[route], label: `route:${route}` });
+  }
+  return layers;
+}
+
+function loadDelegateConfig(cwd, route) {
+  if (route !== null && !SAFE_ROUTE.test(route)) {
+    fail("--route contains unsupported characters (allowed: letters, digits, . _ -)");
+  }
+  const candidates = [
+    join(homedir(), ".config", "delegate-skills", "config.json"),
+    join(findProjectRoot(cwd), ".delegate", "config.json"),
+  ];
+  const resolved = {};
+  let routeFound = route === null;
+  for (const configPath of candidates) {
+    const document = readDelegateConfig(configPath);
+    if (!document) continue;
+    for (const layer of configLayers(document, route, configPath)) {
+      if (!layer.values || typeof layer.values !== "object" || Array.isArray(layer.values)) {
+        fail(`invalid delegate config ${configPath}: ${layer.label} must be an object`);
+      }
+      if (layer.label.startsWith("route:")) routeFound = true;
+      for (const [field, rawValue] of Object.entries(layer.values)) {
+        if (!CONFIG_FIELDS.has(field)) {
+          fail(`invalid delegate config ${configPath}: unsupported vibe field "${field}"`);
+        }
+        const fieldValue = field === "timeout" && Number.isSafeInteger(rawValue) && rawValue > 0
+          ? `${rawValue}s`
+          : rawValue;
+        const expectedType = BOOLEAN_CONFIG_FIELDS.has(field) ? "boolean" : "string";
+        if (typeof fieldValue !== expectedType) {
+          fail(`invalid delegate config ${configPath}: vibe field "${field}" must be a ${expectedType}`);
+        }
+        resolved[field] = fieldValue;
+      }
+    }
+  }
+  if (!routeFound) fail(`delegate config route not found: ${route}`);
+  return { values: resolved };
 }
 
 async function main() {

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -35,7 +35,7 @@
  * Node built-ins only.
  */
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, readdirSync, existsSync, rmSync, chmodSync, mkdirSync, copyFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync, existsSync, rmSync, chmodSync, mkdirSync, copyFileSync, statSync } from "node:fs";
 import { join, delimiter, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -79,7 +79,12 @@ const alive = (pid) => {
 // the one thing a hard-coded list cannot catch is its own omission.
 {
   const skillsDir = join(here, "..", "skills");
-  const onDisk = readdirSync(skillsDir).filter((d) => d.endsWith("-delegate")).sort();
+  const allOnDisk = readdirSync(skillsDir).sort();
+  const onDisk = allOnDisk.filter((d) => d.endsWith("-delegate"));
+  // Utility skills (like delegate-config) don't end in -delegate.
+  const utilityOnDisk = allOnDisk.filter(
+    (d) => !d.endsWith("-delegate") && statSync(join(skillsDir, d)).isDirectory(),
+  );
   const registered = new Set(
     JSON.parse(readFileSync(join(here, "..", "skills.sh.json"), "utf8"))
       .groupings.flatMap((g) => g.skills),
@@ -99,8 +104,14 @@ const alive = (pid) => {
     );
     check(`${name}: listed in skills.sh.json`, registered.has(dir));
   }
+  // Utility skills: must have SKILL.md and be listed in skills.sh.json, but no relay or references.
+  for (const dir of utilityOnDisk) {
+    check(`${dir}: SKILL.md`, existsSync(join(skillsDir, dir, "SKILL.md")));
+    check(`${dir}: listed in skills.sh.json`, registered.has(dir));
+  }
   check("smoke matrix has no entry without a directory", SKILLS.every((s) => onDisk.includes(`${s}-delegate`)));
-  check("skills.sh.json has no entry without a directory", [...registered].every((s) => onDisk.includes(s)));
+  const allDiskSkills = new Set([...onDisk, ...utilityOnDisk]);
+  check("skills.sh.json has no entry without a directory", [...registered].every((s) => allDiskSkills.has(s)));
 }
 
 // ---- every relay must at least parse ----
@@ -113,7 +124,14 @@ for (const skill of SKILLS) {
 // ---- one fake CLI, planted on PATH under every relay's binary name ----
 const FAKE = `const fs = require("node:fs");
 const args = process.argv.slice(2);
-if ((args.includes("--version") && /-version-hang$/.test(process.env.SMOKE_MODE || ""))
+if (args[0] === "auth" && args[1] === "status") {
+  console.log(JSON.stringify({ loggedIn: true }));
+  process.exit(0);
+} else if (args[0] === "models" || args.includes("--list-models")) {
+  console.log("fake-fast-model");
+  console.log("fake-complex-model - Fake Complex");
+  process.exit(0);
+} else if ((args.includes("--version") && /-version-hang$/.test(process.env.SMOKE_MODE || ""))
     || (args[0] === "changelog" && process.env.SMOKE_MODE === "agy-version-hang")) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
 } else if (args.includes("--version") && /-version-fail$/.test(process.env.SMOKE_MODE || "")) {
@@ -273,6 +291,15 @@ using System.IO;
 using System.Threading;
 class FakeCli {
   static int Main(string[] args) {
+    if (args.Length > 1 && args[0] == "auth" && args[1] == "status") {
+      Console.WriteLine("{\\"loggedIn\\":true}");
+      return 0;
+    }
+    if ((args.Length > 0 && args[0] == "models") || Array.IndexOf(args, "--list-models") >= 0) {
+      Console.WriteLine("fake-fast-model");
+      Console.WriteLine("fake-complex-model - Fake Complex");
+      return 0;
+    }
     if ((Array.IndexOf(args, "--version") >= 0 && (Environment.GetEnvironmentVariable("SMOKE_MODE") == "qoder-version-hang" || Environment.GetEnvironmentVariable("SMOKE_MODE") == "vibe-version-hang"))
         || (args.Length > 0 && args[0] == "changelog" && Environment.GetEnvironmentVariable("SMOKE_MODE") == "agy-version-hang")) {
       Thread.Sleep(Timeout.Infinite);
@@ -351,7 +378,15 @@ if (WIN) {
 }
 const briefPath = join(scratch, "brief.txt");
 writeFileSync(briefPath, "smoke brief: run until killed.");
-const baseEnv = { ...process.env, PATH: shimDir + delimiter + process.env.PATH, SMOKE_NODE: process.execPath };
+const smokeHome = join(scratch, "home");
+mkdirSync(smokeHome);
+const baseEnv = {
+  ...process.env,
+  PATH: shimDir + delimiter + process.env.PATH,
+  HOME: smokeHome,
+  USERPROFILE: smokeHome,
+  SMOKE_NODE: process.execPath,
+};
 const slowWriteHook = join(scratch, "slow-result-write.cjs");
 writeFileSync(slowWriteHook, `const fs = require("node:fs");
 const { syncBuiltinESMExports } = require("node:module");
@@ -385,6 +420,23 @@ const runRelay = (skill, workDir, outDir, extraArgs, extraEnv) =>
   });
 
 const result = (outDir) => JSON.parse(readFileSync(join(outDir, "result.json"), "utf8"));
+
+// ---- delegate-config discovery parses auth and bounded model reports ----
+{
+  const discovery = spawnSync(process.execPath,
+    [join(here, "..", "skills", "delegate-config", "scripts", "discover.mjs")],
+    { env: baseEnv, encoding: "utf8", timeout: 30_000 });
+  const report = discovery.status === 0 ? JSON.parse(discovery.stdout) : { discovered: [] };
+  const claude = report.discovered.find((implementer) => implementer.name === "claude");
+  const opencode = report.discovered.find((implementer) => implementer.name === "opencode");
+  const cursor = report.discovered.find((implementer) => implementer.name === "cursor-agent");
+  check("delegate-config discovery: Claude JSON auth is parsed",
+    claude?.authenticated === true);
+  check("delegate-config discovery: OpenCode models are reported",
+    opencode?.models?.status === "reported" && opencode.models.values.includes("fake-fast-model"));
+  check("delegate-config discovery: Cursor labels are normalized to model ids",
+    cursor?.models?.status === "reported" && cursor.models.values.includes("fake-complex-model"));
+}
 
 
 // ---- codex effort is validated, forwarded, and recorded ----
@@ -431,6 +483,238 @@ const emptyEffortRun = spawnSync(process.execPath,
   [relayPath("codex"), "--brief", briefPath, "--effort", ""],
   { env: baseEnv, encoding: "utf8" });
 check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
+
+// ---- delegate config routes resolve before validation and preserve explicit flags ----
+const CONFIG_KEYS = {
+  agy: "agy",
+  claude: "claude",
+  codex: "codex",
+  cursor: "cursor-agent",
+  grok: "grok",
+  kimi: "kimi",
+  opencode: "opencode",
+  pi: "pi",
+  qoder: "qodercli",
+  vibe: "vibe",
+};
+
+const writeProjectConfig = (workDir, implementer, entry) => {
+  const configDir = join(workDir, ".delegate");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "config.json"), `${JSON.stringify({
+    version: "delegate-config.v2",
+    implementers: { [implementer]: entry },
+  }, null, 2)}\n`);
+};
+
+for (const skill of SKILLS) {
+  const workDir = freshRepo(`work-config-${skill}`);
+  const nestedDir = join(workDir, "nested");
+  mkdirSync(nestedDir);
+  const outDir = join(scratch, `out-config-${skill}`);
+  const argsFile = join(scratch, `args-config-${skill}`);
+  const routeValues = skill === "vibe"
+    ? { timeout: 5, readOnly: true }
+    : { model: "config-fast-model", timeout: 5 };
+  writeProjectConfig(workDir, CONFIG_KEYS[skill], {
+    defaults: { timeout: "30m" },
+    routes: { fast: routeValues },
+  });
+  const configuredRun = spawnSync(process.execPath, [
+    relayPath(skill),
+    "--brief", briefPath,
+    "--cd", nestedDir,
+    "--out-dir", outDir,
+    "--route", "fast",
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  const configuredResult = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+  // The capture fake emits no result event. Claude correctly treats that as a
+  // failed implementer run, while the other relays accept its zero exit. The
+  // route metadata is the cross-relay assertion here.
+  check(`${skill} config: route resolves from the repository root`,
+    configuredResult.route === "fast");
+  if (skill !== "vibe") {
+    check(`${skill} config: route selects the model and records its source`,
+      configuredResult.model === "config-fast-model" &&
+      configuredResult.modelSource === "project:route:fast");
+  }
+}
+
+for (const skill of SKILLS) {
+  const workDir = freshRepo(`work-config-type-${skill}`);
+  writeProjectConfig(workDir, CONFIG_KEYS[skill], {
+    routes: {
+      invalid: skill === "vibe" ? { readOnly: "yes" } : { model: 42 },
+    },
+  });
+  const invalidTypeRun = spawnSync(process.execPath, [
+    relayPath(skill),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--route", "invalid",
+  ], { env: baseEnv, encoding: "utf8" });
+  check(`${skill} config: invalid field types fail before dispatch`, invalidTypeRun.status === 2);
+}
+
+{
+  const workDir = freshRepo("work-config-explicit-codex");
+  const outDir = join(scratch, "out-config-explicit-codex");
+  const argsFile = join(scratch, "args-config-explicit-codex");
+  writeProjectConfig(workDir, "codex", {
+    defaults: { sandbox: "danger-full-access", model: "config-default-model" },
+    routes: { complex: { model: "config-route-model", timeout: 1 } },
+  });
+  const explicitRun = spawnSync(process.execPath, [
+    relayPath("codex"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--route", "complex",
+    "--model", "flag-model",
+    "--sandbox", "workspace-write",
+    "--timeout", "5s",
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  const explicitArgs = existsSync(argsFile) ? JSON.parse(readFileSync(argsFile, "utf8")) : [];
+  const explicitResult = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+  check("codex config: explicit model and sandbox override project config",
+    explicitRun.status === 0 &&
+    explicitArgs[explicitArgs.indexOf("-m") + 1] === "flag-model" &&
+    explicitArgs[explicitArgs.indexOf("-s") + 1] === "workspace-write");
+  check("codex config: explicit model source is recorded",
+    explicitResult.modelSource === "flag");
+}
+
+{
+  const workDir = freshRepo("work-config-precedence-codex");
+  const outDir = join(scratch, "out-config-precedence-codex");
+  const argsFile = join(scratch, "args-config-precedence-codex");
+  const isolatedHome = join(scratch, "home-config-precedence");
+  const globalConfigDir = join(isolatedHome, ".config", "delegate-skills");
+  mkdirSync(globalConfigDir, { recursive: true });
+  writeFileSync(join(globalConfigDir, "config.json"), `${JSON.stringify({
+    version: "delegate-config.v2",
+    implementers: {
+      codex: {
+        defaults: { model: "global-default", sandbox: "read-only", timeout: "30m" },
+        routes: { complex: { model: "global-route", effort: "low" } },
+      },
+    },
+  }, null, 2)}\n`);
+  writeProjectConfig(workDir, "codex", {
+    defaults: { model: "project-default", timeout: "20m" },
+    routes: { complex: { model: "project-route", effort: "high" } },
+  });
+  const precedenceRun = spawnSync(process.execPath, [
+    relayPath("codex"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--route", "complex",
+  ], {
+    env: {
+      ...baseEnv,
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+      SMOKE_MODE: "capture",
+      SMOKE_ARGS_FILE: argsFile,
+    },
+    encoding: "utf8",
+  });
+  const precedenceResult = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+  check("codex config: project and route layers resolve per field",
+    precedenceRun.status === 0 &&
+    precedenceResult.model === "project-route" &&
+    precedenceResult.modelSource === "project:route:complex" &&
+    precedenceResult.effort === "high" &&
+    precedenceResult.timeout === "20m" &&
+    precedenceResult.sandbox === "read-only");
+}
+
+{
+  const workDir = freshRepo("work-config-v1-codex");
+  const outDir = join(scratch, "out-config-v1-codex");
+  const argsFile = join(scratch, "args-config-v1-codex");
+  const configDir = join(workDir, ".delegate");
+  mkdirSync(configDir);
+  writeFileSync(join(configDir, "config.json"), `${JSON.stringify({
+    version: "delegate-config.v1",
+    implementers: {
+      codex: { model: "legacy-model", sandbox: "read-only", effort: "low", timeout: 5 },
+    },
+  }, null, 2)}\n`);
+  const legacyRun = spawnSync(process.execPath, [
+    relayPath("codex"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  const legacyResult = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+  check("codex config: version 1 defaults and integer timeout remain compatible",
+    legacyRun.status === 0 &&
+    legacyResult.model === "legacy-model" &&
+    legacyResult.modelSource === "project:defaults" &&
+    legacyResult.sandbox === "read-only" &&
+    legacyResult.timeout === "5s");
+}
+
+{
+  const workDir = freshRepo("work-config-v1-qoder");
+  const outDir = join(scratch, "out-config-v1-qoder");
+  const argsFile = join(scratch, "args-config-v1-qoder");
+  const configDir = join(workDir, ".delegate");
+  mkdirSync(configDir);
+  writeFileSync(join(configDir, "config.json"), `${JSON.stringify({
+    version: "delegate-config.v1",
+    implementers: {
+      qodercli: { model: "legacy-model", sandbox: "plan", timeout: 5 },
+    },
+  }, null, 2)}\n`);
+  const legacyRun = spawnSync(process.execPath, [
+    relayPath("qoder"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+  ], {
+    env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  const legacyResult = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+  check("qoder config: version 1 sandbox alias remains compatible",
+    legacyRun.status === 0 &&
+    legacyResult.permissionMode === "plan" &&
+    legacyResult.timeout === "5s");
+}
+
+{
+  const workDir = freshRepo("work-config-invalid-codex");
+  writeProjectConfig(workDir, "codex", {
+    routes: { unsafe: { model: "bad & whoami" } },
+  });
+  const invalidConfigRun = spawnSync(process.execPath, [
+    relayPath("codex"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--route", "unsafe",
+  ], { env: baseEnv, encoding: "utf8" });
+  check("codex config: unsafe model is rejected before dispatch", invalidConfigRun.status === 2);
+
+  const missingRouteRun = spawnSync(process.execPath, [
+    relayPath("codex"),
+    "--brief", briefPath,
+    "--cd", workDir,
+    "--route", "missing",
+  ], { env: baseEnv, encoding: "utf8" });
+  check("codex config: an unknown route fails instead of falling back", missingRouteRun.status === 2);
+}
 
 // opencode refuses a fresh run without an explicit model
 const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [], vibe: [], cursor: [], pi: [] };


### PR DESCRIPTION
## What changed

- add the `delegate-config` utility skill for discovering installed implementers, authentication state, supported settings, and reported models
- add version 2 config with per-implementer defaults and named task routes such as `frontend`, `backend`, `fast`, `medium`, and `complex`
- add `--route` support, strict config validation, layered precedence, and route metadata across all ten relays
- preserve version 1 config compatibility and correct existing timeout, explicit-flag precedence, and Cursor sandbox behavior
- expand relay smoke coverage for discovery, nested repository lookup, route selection, precedence, malformed values, and compatibility

## Why

The previous single-model configuration could not select different models or effort levels for different task types. Configuration was also merged after some relay defaults were applied, which allowed defaults to override explicit intent, and malformed config values could fail later as child-process errors.

This change lets the orchestrator propose a task-specific configuration for user approval, while keeping explicit relay flags authoritative and rejecting invalid configuration before dispatch.

## User and developer impact

Users can define reusable model routes and select one with `--route <name>`. Project configuration overrides global configuration per field, and every result records the selected route, model source, and effective timeout for review. Existing version 1 configuration remains readable.

The configuration flow presents proposed JSON before writing and requires explicit user approval or adjustment.

## Validation

- `node test/relay-smoke.mjs`
- `npx skills add . --list`
- Node syntax checks for every relay and utility script
- `git diff --check`
- live discovery smoke for installed CLIs

Native Windows launch smoke was not run in this environment; no new Windows support claim is made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable delegation routes with project- and user-level settings.
  * Added route selection and configuration-aware options for models, timeouts, permissions, and sandboxing.
  * Added a configuration assistant that discovers available tools and models, validates settings, and saves approved configurations.
  * Delegation results now show the selected route, resolved timeout, and model source.

* **Documentation**
  * Updated setup, configuration, dispatch, and repository guidance for delegation routes and discovery.

* **Tests**
  * Expanded coverage for configuration discovery, precedence, validation, compatibility, and overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->