### PR TITLE
Add wordpress-delegate: route WordPress tasks to the best-suited implementer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ node_modules/
 
 # local agent config symlink (see AGENTS.md)
 CLAUDE.md
+
+# Skills CLI install output, if you install this package into the repo while working on it
+# (`npx skills add .` — the validation step in AGENTS.md). The agent directory is whichever
+# agent the CLI detects; add yours here if it differs.
+.claude/
+skills-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,13 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Ten skills ship today: `claude-delegate` (Claude Code), `codex-delegate` (OpenAI
-Codex), `opencode-delegate` (OpenCode), `agy-delegate` (Google Antigravity), `grok-delegate` (Grok
-Build), `kimi-delegate` (Kimi Code), `qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe),
-`cursor-delegate` (Cursor Agent CLI), and `pi-delegate` (Pi CLI); siblings like `gemini-delegate` can
-be added later without renaming the repo.
+and land the result. Eleven skills ship today. Ten are **implementer skills**, one per CLI:
+`claude-delegate` (Claude Code), `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode),
+`agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code),
+`qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI),
+and `pi-delegate` (Pi CLI); siblings like `gemini-delegate` can be added later without renaming the
+repo. One is a **domain skill**: `wordpress-delegate` picks the implementer from the brief and
+dispatches through that sibling's relay, launching no CLI of its own.
 
 ## Vocabulary
 
@@ -33,6 +35,9 @@ jargon. Use these terms; don't invent synonyms.
 | `session`, `-c`, `--resume`, `permission mode` (`default`/`accept_edits`/`auto`/`bypass_permissions`/`dont_ask`/`plan`), `print mode`, `stream-json`, `model`, `context window` | Qoder CLI's own terms — use verbatim when discussing Qoder | don't paraphrase them |
 | `--prompt`, `--output` (`streaming`/`json`/`text`), `--agent` (`plan`/`accept-edits`/`auto-approve`), `--max-turns`, `--max-price`, `--max-tokens`, `--trust`, `--resume`, `--continue`, `--enabled-tools`, `--disabled-tools` | Mistral Vibe's own terms — use verbatim when discussing `vibe` | don't invent a Vibe sandbox enum; `--trust` is not a permission mode |
 | `session`, `--continue`, `--session`, `print mode`, `--mode json`, `tools`, `context files`, `project trust` | Pi's own terms — use verbatim when discussing `pi` | don't paraphrase them |
+| **implementer skill** / **domain skill** | the two kinds of skill here — one per CLI, versus one that routes to them | "wrapper", "meta-skill", "meta-delegate" |
+| **lane** (what kind of work), **domain** (what the work is about), **confidence**, **preamble** | `wordpress-delegate`'s own terms — a lane routes, a domain informs the preamble | never use "domain" for a lane, or "category" for either |
+| `hook`, `filter`, `action`, `nonce`, `capability`, `WPCS`, `HPOS`, `text domain`, `child theme`, `WP-CLI` | WordPress's own terms — use verbatim when discussing `wordpress-delegate` | don't paraphrase them, and don't coin WordPress jargon that WordPress doesn't use |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -59,10 +64,16 @@ the skill's `relay.mjs`.
 - **Executables:** keep them minimal and inspectable. Today there is one per skill — a
   `scripts/relay.mjs` under each of `skills/claude-delegate/`, `skills/codex-delegate/`,
   `skills/opencode-delegate/`, `skills/agy-delegate/`, `skills/grok-delegate/`,
-  `skills/kimi-delegate/`, `skills/qoder-delegate/`, `skills/vibe-delegate/`, and
-  `skills/cursor-delegate/`, and `skills/pi-delegate/` — each Node built-ins only, no dependencies,
-  no network calls of its own, no credentials, no telemetry. New scripts must hold the same line,
-  and the README's trust section must stay accurate.
+  `skills/kimi-delegate/`, `skills/qoder-delegate/`, `skills/vibe-delegate/`,
+  `skills/cursor-delegate/`, `skills/pi-delegate/`, and `skills/wordpress-delegate/` — each Node
+  built-ins only, no dependencies, no network calls of its own, no credentials, no telemetry. New
+  scripts must hold the same line, and the README's trust section must stay accurate.
+- **A domain skill routes; it does not re-implement.** `wordpress-delegate` dispatches through a
+  sibling's `relay.mjs` rather than launching a CLI, so dispatch, polling, sandboxes, sessions, and
+  the process-tree kill stay owned by exactly one file per implementer. A domain relay that grew its
+  own version preflight, its own stream parser, or its own kill logic would be a bug, not a feature.
+  Its routing table is the extension point: one row per lane, and nothing else in the file knows the
+  lane names.
 
 ## Before publishing a change
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,11 +69,18 @@ the skill's `relay.mjs`.
   built-ins only, no dependencies, no network calls of its own, no credentials, no telemetry. New
   scripts must hold the same line, and the README's trust section must stay accurate.
 - **A domain skill routes; it does not re-implement.** `wordpress-delegate` dispatches through a
-  sibling's `relay.mjs` rather than launching a CLI, so dispatch, polling, sandboxes, sessions, and
-  the process-tree kill stay owned by exactly one file per implementer. A domain relay that grew its
-  own version preflight, its own stream parser, or its own kill logic would be a bug, not a feature.
-  Its routing table is the extension point: one row per lane, and nothing else in the file knows the
-  lane names.
+  sibling's `relay.mjs` rather than launching a CLI, so the version preflight, the stream parser, and
+  the argv and sandbox translation for a given CLI stay owned by exactly one file per implementer. A
+  domain relay that grew its own copy of any of those would be a bug, not a feature. Its routing
+  table is the extension point: one row per lane, and nothing else in the file knows the lane names.
+- **Killing its own child is the one exception, and it is bounded.** A domain relay owns a watchdog
+  backstop and forwards `SIGTERM`/`SIGINT`/`SIGHUP`, and neither is possible without killing the
+  process it spawned. It kills exactly one thing — the sibling relay — and the sibling's own handler
+  is what reaches the implementer CLI, which leads a process group of its own. (On Windows there are
+  no process groups to signal, so the `taskkill /t` that fells the sibling fells the tree under it
+  too; the sibling's handler does not get to run. Same asymmetry every relay here already has.) That
+  is also the only case where a domain relay may override the sibling's verdict: it did the killing,
+  so the sibling could not know why it died.
 
 ## Before publishing a change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,16 @@ working tree, nothing commits, Node built-ins only, and autonomy is still stated
 own terms. Three extra rules keep it from becoming a second implementation of the loop:
 
 - **It launches no implementer CLI.** It shells out to `node` (for the sibling) and `git`. A domain
-  relay that grew its own version preflight, stream parser, or process-tree kill has forked the loop.
+  relay that grew its own version preflight, stream parser, or CLI argv and sandbox translation has
+  forked the loop.
+- **It kills its own child, and only its own child.** A watchdog backstop and signal forwarding both
+  need it, so this is an owned exception rather than a forked mechanic — but the domain relay
+  terminates the sibling relay and stops there. Reaching past the sibling to the implementer CLI is
+  the sibling's job, and it already does it. (Windows is the usual exception: with no process groups
+  to signal, the `taskkill /t` that fells the sibling fells everything under it.)
 - **The sibling's result is the authority.** Lift the contract fields, embed the sibling's own result
   verbatim, and override the verdict only where the domain relay did the killing and the sibling
-  could not know.
+  could not know — the one case the rule above creates.
 - **Routing is a table, and the table is the extension point.** One row per lane; adding a lane must
   not require touching anything else in the file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,27 @@ Four invariants hold for every skill here, and they are the bar for a new one:
 - **Autonomy is stated in the CLI's own terms**, and whatever it cannot enforce is said plainly. A
   CLI with no read-only mode is mergeable; a skill that implies it has one is not.
 
+## Domain skills
+
+Most skills here are **implementer skills** — one per CLI. A **domain skill** is the other kind: it
+picks the implementer from the brief and dispatches through that sibling's `relay.mjs`.
+`wordpress-delegate` is the first.
+
+The four invariants hold for a domain skill too, transitively — a separate CLI still edits a real
+working tree, nothing commits, Node built-ins only, and autonomy is still stated in the chosen CLI's
+own terms. Three extra rules keep it from becoming a second implementation of the loop:
+
+- **It launches no implementer CLI.** It shells out to `node` (for the sibling) and `git`. A domain
+  relay that grew its own version preflight, stream parser, or process-tree kill has forked the loop.
+- **The sibling's result is the authority.** Lift the contract fields, embed the sibling's own result
+  verbatim, and override the verdict only where the domain relay did the killing and the sibling
+  could not know.
+- **Routing is a table, and the table is the extension point.** One row per lane; adding a lane must
+  not require touching anything else in the file.
+
+A domain skill needs the same directory shape, the same four references, the same `result.json`
+contract, and the same smoke registration as any other. Claim it the same way.
+
 ## Merge checklist for a new skill
 
 - [ ] `skills/<name>-delegate/SKILL.md` — a `description` that triggers on delegation to that CLI and

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ Each skill name links to its `SKILL.md`, which owns that implementer's prerequis
 caveats. Building one for another CLI? [Claim it first](../../issues?q=is%3Aissue+label%3Aimplementer),
 then see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### Domain skills
+
+One skill picks the row for you. It launches no CLI of its own — it classifies the brief, prepends
+the domain's engineering standards, and dispatches through a sibling above, whose relay owns every
+CLI-specific mechanic and writes the result.
+
+| Skill | Domain | Routes to | Override |
+| --- | --- | --- | --- |
+| [`wordpress-delegate`](skills/wordpress-delegate/SKILL.md) | WordPress, WooCommerce, Elementor, ACF, WPForms | `codex`, `grok`, `kimi`, `opencode` — by lane | `--implementer`, `--lane`, `--strict-routing` |
+
+Reach for it when the user wants WordPress work delegated but hasn't named the implementer; reach for
+a row above when they have. `--dry-run` prints the routing decision without dispatching, and
+`--list-routes` prints the lane table.
+
 ## Install
 
 Browse first:
@@ -177,6 +191,16 @@ Per skill — platform, CLI version, and what the run exercised:
 - `codex-delegate`, `opencode-delegate`, `vibe-delegate` — contract-tested only: argument validation,
   bounded version preflight, missing binary, result parsing, and whole-process-tree timeout/abort
   cleanup. No end-to-end run is recorded here.
+- `wordpress-delegate` — native Windows, through `codex-delegate` with `codex` 0.144.1: a write run
+  on a throwaway plugin repo, routed by the table, with the preamble visible in the result
+  (`check_ajax_referer` + `current_user_can`, `wp_unslash`/`absint`, `$wpdb->prepare()`, `esc_html`
+  at output, text domain, and the `wp_ajax_nopriv` registration dropped), the thread id lifted for
+  resume, and no commit made. Contract-tested besides: every shipped lane's routing decision, the
+  read-only demotion rule, `--strict-routing`'s refusal, the read-only and resume flag translation
+  for all ten implementers, a missing sibling relay, and the shared atomic-publish, `--timeout`
+  validation, and whole-process-tree timeout cleanup. Only `codex` has been driven live; the other
+  three lane targets are contract-tested. The aborted path is POSIX-only in the suite and has not
+  been driven for this relay on any platform.
 
 Not yet verified: native Windows launches for `agy`, `claude`, `grok`, `kimi`, `pi`, `qoder`, and
 `vibe` (the `codex`/`opencode`/`grok` `.cmd` shim handling is in place and quoted; Cursor serializes a
@@ -202,6 +226,9 @@ skills/
         ├── review-and-land.md
         └── multi-task-queues.md
 ```
+
+A domain skill has the same shape and the same four invariants; its `relay.mjs` dispatches through a
+sibling's rather than launching a CLI directly, so the sibling's guarantees are the ones in force.
 
 Adding an implementer is a new directory plus two lines here: a table row, and a verification line once
 a run backs it.

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -16,6 +16,13 @@
         "cursor-delegate",
         "pi-delegate"
       ]
+    },
+    {
+      "title": "Delegate by domain",
+      "description": "Route a domain task to the CLI implementer best suited to it, then review the diff and commit it yourself.",
+      "skills": [
+        "wordpress-delegate"
+      ]
     }
   ]
 }

--- a/skills/wordpress-delegate/SKILL.md
+++ b/skills/wordpress-delegate/SKILL.md
@@ -139,6 +139,7 @@ performance is routed as security.
 | `refactor-sweep` | `opencode` | Sustained context across many files beats depth on any one. |
 | `plugin-architecture` | `codex` | Structural decisions compound. |
 | `elementor-widget` | `codex` | The control/render/editor contract fails silently when wrong. |
+| `block-editor` | `codex` | An invalid block is an editor validation error, not a test failure. |
 | `performance` | `codex` | Measurement-driven and easy to get plausibly wrong. |
 | `implementation` (fallback) | `codex` | No lane signal dominated. |
 

--- a/skills/wordpress-delegate/SKILL.md
+++ b/skills/wordpress-delegate/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: wordpress-delegate
+description: >-
+  Delegate a WordPress coding task to the CLI implementer best suited to it — routing by the kind of
+  work, prepending the WordPress engineering standards, then handing off to a sibling delegate — and
+  review its diff and land it yourself. Use this whenever the user wants implementation work done on a
+  WordPress site, theme, plugin, or block — phrasings like "have an agent build this WooCommerce
+  feature", "delegate this Elementor widget", "audit the plugin for nonce and escaping issues", or
+  "run this queue of WordPress tasks" — and you want the implementer chosen for you rather than named.
+  DO NOT USE when the user names the implementer themselves (use that CLI's own delegate skill), for
+  tasks small enough to do inline, or for non-WordPress work.
+license: MIT
+compatibility: Requires at least one sibling delegate from this package installed beside it (codex-delegate, grok-delegate, kimi-delegate, and opencode-delegate are the shipped routing targets), its implementer CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.1.0
+---
+
+# WordPress Delegate
+
+You are the **orchestrator**, acting as the WordPress technical lead. This skill lets you hand a
+bounded WordPress task to a separate **implementer** — chosen for you by the kind of work, not named
+by you — then review what it produced and land it yourself.
+
+It is the one skill in this package that launches no implementer CLI of its own. It does three things
+and then gets out of the way:
+
+1. **Classifies the brief** — what kind of work it is (the *lane*) and what it is about (the
+   *domains*).
+2. **Prepends the WordPress engineering standards** — security, platform APIs, coding standards,
+   backward compatibility, performance — so the same bar applies whichever implementer runs.
+3. **Dispatches through that implementer's own sibling delegate**, whose `relay.mjs` owns every
+   CLI-specific mechanic and writes the result contract.
+
+The loop is otherwise identical to every sibling: brief → dispatch → poll → review → **you commit**.
+
+## When NOT to use this
+
+- The user named the implementer ("have Codex do this") — use that CLI's own delegate skill directly.
+- The task is small enough to just do inline.
+- The work is not WordPress. The preamble and the domain notes would be noise at best.
+- No sibling delegate is installed beside this one. This skill dispatches through them; it cannot run
+  alone. `node "<skill-dir>/scripts/relay.mjs" --list-routes` names its targets.
+
+## Prerequisites (check once)
+
+1. At least the routed sibling is installed — the four shipped routing targets are
+   `codex-delegate`, `grok-delegate`, `kimi-delegate`, and `opencode-delegate`. Install the whole
+   package (`npx skills add amElnagdy/delegate-skills`) and all ten are there.
+2. That sibling's implementer CLI is installed and authenticated. Each sibling's own `SKILL.md`
+   carries its install and login commands; this skill does not restate them.
+3. You are in (or will point `--cd` at) the target git repository — the WordPress install, the theme,
+   or the plugin, whichever is the repo.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+The implementer sees **only** the text sent — no repo memory, no chat history. Everything the task
+needs goes in the brief: the goal, the current state, what to change, what to leave untouched, the
+project's **actual** gate commands, and a report contract.
+
+You do **not** need to restate the WordPress standards. The relay prepends them, plus notes for the
+domains it detects (WooCommerce, Elementor, ACF, WPForms, database, security, integrations, hosting,
+deployment). Read the exact text with `--print-preamble`. What you must supply is the part no
+preamble can know: **which** site, **which** plugin versions, **which** gates, and what is out of
+scope. Full guidance and a WordPress template:
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/wp-content/plugins/acme
+# see where it would route, without dispatching:  add --dry-run
+# make the router refuse when it is unsure:       add --strict-routing
+# override the router:                            add --implementer codex   (or --lane performance)
+# read-only (audit/diagnosis, no edits):          add --read-only
+# hard time limit (watchdog):                     add --timeout 2h  (default: off)
+# see all options and the lane table:             node .../relay.mjs --help   ·   --list-routes
+```
+
+(`<skill-dir>` is this skill's installed directory — the folder containing this `SKILL.md`. Claude
+Code prints it as "Base directory for this skill" when the skill loads; on other orchestrators use
+that same directory. If unsure where it landed, run
+`find ~ -name relay.mjs -path '*wordpress-delegate*'` and substitute the directory above it.)
+
+Artifacts go to a temp dir so the repo under review stays clean; the sibling's own artifacts land in
+`<out-dir>/implementer/`. It **never commits** — see step 5. Mechanics, flags, the routing table, and
+the `result.json` shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until the sibling finishes, which is until the implementer finishes. Back it with
+whatever your orchestrator offers:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** foreground for short tasks, or background it and poll the result
+  file. The run is done when `result.json` exists with a `status`. A pre-run usage error exits 2 (and
+  a refusal under `--strict-routing` exits 3) **before** writing any result file, so check the exit
+  code too. A missing sibling relay exits 127 but *does* write a `result.json` with status
+  `implementer_unavailable`.
+
+Do not trust progress trackers over reality. Read the working tree, not a status line.
+
+### 4. Review — do not trust the self-report
+
+Everything in the sibling's review discipline applies unchanged, and WordPress adds its own failure
+modes that a green test suite cannot see: a missing nonce, an unescaped echo, `$wpdb` interpolation,
+an `update_option` that autoloads a megabyte, a direct write to a Woo order's post meta under HPOS.
+
+**Start with the routing decision.** `result.json` records the lane, the confidence, and the signals
+that matched. A `low`, `none`, or `contested` confidence means the router guessed — read the diff
+against what the user actually asked for, not against what the lane assumed.
+
+Then: re-run the project's gates yourself, read the diff against the brief, and run the WordPress
+sweep. Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+No relay in this package commits. Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--session <id>` from `implementerSession` in the
+  prior `result.json`, and review again. The relay translates that into the chosen CLI's own resume
+  flag and skips the preamble, which the session already carries.
+
+## Routing
+
+The relay picks the implementer from the brief. Lanes are scored by keyword signals; the
+highest-scoring lane wins, and lane order breaks ties, so a brief that trips both security and
+performance is routed as security.
+
+| Lane | Implementer | Why |
+| --- | --- | --- |
+| `security-audit` | `grok` (read-only) | Adversarial reading, not editing; the deliverable is findings. |
+| `research` | `grok` (read-only) | Breadth and a defended recommendation, not a diff. |
+| `documentation` | `kimi` | High-volume, low-branching prose work. |
+| `refactor-sweep` | `opencode` | Sustained context across many files beats depth on any one. |
+| `plugin-architecture` | `codex` | Structural decisions compound. |
+| `elementor-widget` | `codex` | The control/render/editor contract fails silently when wrong. |
+| `performance` | `codex` | Measurement-driven and easy to get plausibly wrong. |
+| `implementation` (fallback) | `codex` | No lane signal dominated. |
+
+**Domains are not lanes.** WooCommerce, ACF, WPForms, database, integrations, hosting, and deployment
+work is *understood* — detected, recorded, and given its own preamble notes — but it does not pick the
+implementer. A WooCommerce checkout bug is implementation work; a WooCommerce security review is a
+security audit. The kind of work routes; the subject informs.
+
+**When the router is unsure, ask.** Confidence is `high` (two or more signals), `low` (one),
+`contested` (a tie), or `none`. On anything below `high`, put the question to the user rather than
+letting the fallback decide — or pass `--strict-routing` and let the relay refuse, which prints the
+exact question to ask.
+
+One rule overrides the score: **a read-only lane needs two signals to win.** "Fix the cart hook, it's
+missing a nonce check" is a bugfix that says "nonce", not an audit request — it demotes to
+`implementation` and keeps its writes, with `security-audit` recorded in `alternates`. A lane that
+withholds writes on one keyword returns an empty diff to someone who asked for a fix.
+
+Adding a lane is one row in the table at the top of `scripts/relay.mjs`; see
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+## Read-only audits
+
+The `security-audit` and `research` lanes run read-only by default, which makes this the clean way to
+get a WordPress security review with no write risk: dispatch the audit brief, get findings in the
+final report, touch no files. Verify `touchedFiles` came back empty rather than assuming it — Grok's
+read-only is best-effort and flagged after the fact (`readOnlyViolation`), not enforced. Route to
+`codex` with `--implementer codex --read-only` when you want the guarantee enforced by a sandbox.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have, committing verified, gate-passing work
+is the agreed contract. Two limits: **surface, don't absorb** (report the implementer's design
+decisions and defensible-but-unasked turns, and report a low-confidence routing decision as one of
+them) and **stop for scope changes** (if correct completion needs going beyond the brief, ask). Full
+treatment in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — what the preamble covers so you
+  don't restate it, what only you can supply, and a WordPress brief template.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the routing
+  table and how to extend it, the `result.json` contract, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the WordPress review sweep, the
+  routing-confidence check, the commit boundary, and the rework cycle.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a WordPress queue:
+  per-task routing, carrying constraints forward, and the end-of-run coherence check.

--- a/skills/wordpress-delegate/references/dispatch-and-poll.md
+++ b/skills/wordpress-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,175 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the routing layer. It classifies the brief, composes it with the WordPress
+preamble, and dispatches through the chosen sibling's own `relay.mjs`, which owns every CLI-specific
+mechanic. Your job collapses to: run one command, then read one file.
+
+This relay launches **no implementer CLI of its own**. It shells out to `node` (for the sibling) and
+`git`, and nothing else. Every guarantee about sandboxes, sessions, streaming, and process-tree kills
+is the sibling's, unchanged — this layer adds the routing decision and passes the rest through.
+
+## Before the first run: check the siblings
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --list-routes    # the lane table and its targets
+```
+
+Every lane target must be installed beside this skill for that lane to work. The shipped targets are
+`codex-delegate`, `grok-delegate`, `kimi-delegate`, and `opencode-delegate`; installing the whole
+package gets you all ten. Each sibling's own `SKILL.md` carries its CLI's install and login commands.
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path.)
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/plugin
+```
+
+### Routing options
+
+| Flag | Effect |
+| --- | --- |
+| `--dry-run` | Print the routing decision as JSON and exit 0 without dispatching. Writes no result file. Use it before any run you are unsure about. |
+| `--list-routes` | Print the lane table and the implementer table, then exit 0. |
+| `--implementer <name>` | Force the implementer, bypassing the lane table. `agy`, `claude`, `codex`, `cursor`, `grok`, `kimi`, `opencode`, `pi`, `qoder`, `vibe`. Recorded as `confidence: "forced"`. |
+| `--lane <name>` | Force the lane; the table still resolves the implementer. Use when you know the kind of work but not who should do it. |
+| `--strict-routing` | Refuse to dispatch when confidence is `low`, `none`, or `contested`. Exits **3** with the exact question to put to the user, before any artifact exists. |
+| `--print-preamble` | Print the WordPress engineering preamble and exit 0. |
+| `--no-preamble` | Send the brief verbatim. Implied on `--session` / `--resume-last`. |
+| `--implementer-relay <path>` | Absolute path to a sibling `relay.mjs`. Use when only this skill is installed and the sibling directories are absent. |
+
+### Forwarded options
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root (default: current directory). |
+| `--model <name>` | Implementer model. **Required** when routing to `opencode`; the relay says so by name rather than letting the sibling exit 2. |
+| `--read-only` | Review/diagnosis with no edits, translated to the chosen CLI's own flag — `--read-only`, `--plan-only` (Vibe), or `--permission-mode plan` (Qoder). Rejected with exit 2 for `kimi` and `agy`, which have no read-only mode. |
+| `--session <id>` | Continue a specific session, translated to the chosen CLI's own resume flag (`--session`, Qoder's `--resume`, Antigravity's `--conversation`). Send only the delta brief. |
+| `--resume-last` | Continue the most recent session of the chosen implementer. |
+| `--timeout <dur>` | Watchdog (e.g. `30m`, `2h`), forwarded to the sibling, which owns the kill. This relay arms a backstop 60s later for the one case the sibling cannot cover — the sibling itself wedging. Off by default. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). The sibling's own artifacts land in `<out-dir>/implementer/`. |
+| `-- <args…>` | Everything after `--` is forwarded to the sibling verbatim, for implementer-specific flags this relay does not model — `--sandbox`, `--effort`, `--permission-mode`, `--skip-git-repo-check`. |
+
+The passthrough is the escape hatch: this relay deliberately models only the flags that mean the same
+thing across implementers. Anything specific to one CLI goes after `--` and is that CLI's business.
+
+## The routing table
+
+Two tables at the top of `scripts/relay.mjs` decide everything:
+
+- **`LANES`** — what *kind* of work this is. Each row has a name, an implementer, a list of regex
+  signals, a `readOnly` flag, and a one-line `why` that is recorded in `result.json`. Each distinct
+  signal that matches scores 1; the highest-scoring lane wins; **lane order breaks ties**, so a brief
+  that trips both `security-audit` and `performance` routes as a security audit.
+- **`DOMAINS`** — what the work is *about*. Domains do not route. They select the notes appended to
+  the preamble and are recorded in the result so a reviewer can see what the router thought it was
+  looking at.
+
+Confidence follows from the score: `high` (two or more signals), `low` (exactly one), `contested`
+(a tie above zero), `none` (nothing matched — the `implementation` fallback), `forced`
+(`--implementer` or `--lane` was given).
+
+One rule overrides the score. **A read-only lane needs two signals to win.** A lane that withholds
+writes on a single keyword returns findings and an empty diff to someone who asked for a fix, which
+reads as the implementer doing nothing — so "fix the cart hook, it's missing a nonce check" demotes
+to `implementation` at `low` confidence with `security-audit` recorded in `alternates`, rather than
+silently becoming an audit. A tie is left alone: `contested` already names both lanes and asks.
+
+### Extending it
+
+Adding a lane is one row. Nothing else in the file knows the lane names:
+
+```js
+{
+  name: "block-editor",
+  implementer: "codex",
+  readOnly: false,
+  why: "Block registration and the editor/save contract fail silently when the markup drifts.",
+  signals: [/\bblock\.json\b/, /\bregisterBlockType\b/, /\bblock (variation|pattern)s?\b/],
+},
+```
+
+Place it by precedence, not alphabetically — earlier rows win ties. Re-targeting a lane is a one-word
+change to its `implementer`. Teaching the preamble a new area is one row in `DOMAINS`, with its own
+`notes`. After either, run `node test/relay-smoke.mjs` and add a row to the routing table in
+`test/relay-smoke.mjs`'s `ROUTING_CASES` so the new lane is pinned.
+
+Two rules keep the table honest:
+
+- **Signals match the brief's wording, not the working tree.** The router reads text. If a lane needs
+  to know something only the repo can tell it, that lane does not belong here — put it in the brief.
+- **A lane that routes read-only must target an implementer that has a read-only mode.** `kimi` and
+  `agy` do not; the relay refuses at dispatch rather than letting the sibling reject an unknown flag.
+
+## The result
+
+`<out-dir>/result.json` is the contract. It speaks `delegate-relay.result.v1` like every sibling, with
+the contract fields lifted from the sibling's own result and a routing block on top.
+
+- `schema` — `delegate-relay.result.v1`
+- `status` — whatever the sibling reported (`completed` | `failed` | `<cli>_unavailable` | …), or one
+  of this relay's own: `timeout` (its backstop fired), `aborted` (it was killed and forwarded the
+  kill), `implementer_unavailable` (the sibling relay was not found)
+- `exitCode` — the sibling's, which mirrors the implementer's; `127` when the sibling relay is missing
+- `signal` — the signal that killed the run, otherwise `null`
+- `routing` — `lane`, `implementer`, `confidence`, `reason`, `matchedSignals`, `domains`,
+  `alternates` (the runners-up and their scores), `forced`
+- `implementer` / `implementerRelay` / `implementerResultPath` — who ran it, which relay dispatched
+  it, and where that relay's own result sits
+- `implementerResult` — the sibling's entire result object, verbatim. Everything CLI-specific lives
+  here: `threadId`, `sessionId`, `codexVersion`, `usage`, `cost`, `readOnlyViolation`, and so on
+- `implementerSession` — the session id lifted from whichever field that CLI uses, for a later
+  `--session`
+- `finalMessage` — the implementer's own final report
+- `touchedFiles` — `git status --porcelain` lines: your review starting point. `null` when git can't
+  report; `[]` when git ran and the tree is clean
+- `preamble` — whether the preamble was prepended (false on a resumed run)
+- `readOnly`, `model`, `session`, `resumeLast`, `workdir`, `briefPath`, `startedAt`, `finishedAt`
+- `stderrTail` — present when the sibling reported one
+- `error` — present on any run that did not complete
+
+`briefPath` points at `<out-dir>/dispatched-brief.txt` — the composed brief, preamble and all, exactly
+as the implementer received it. Read it when a run goes sideways and you want to know what was
+actually asked.
+
+## Waiting for completion
+
+The relay blocks until the sibling finishes, which is until the implementer finishes.
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll. A run is done
+  when `result.json` exists with a `status`. **But** a pre-run usage error exits 2, and a
+  `--strict-routing` refusal exits 3, both *before* writing any file — so check the exit code too.
+
+## When a run misbehaves
+
+- **exit 3, `--strict-routing refused to dispatch`:** the router was not confident. stderr carries
+  the question to put to the user. Answer it with `--lane` or `--implementer`, or ask them.
+- **`status: implementer_unavailable` (exit 127):** the routed sibling's `relay.mjs` was not found.
+  Install it, point `--implementer-relay` at it, or route elsewhere with `--implementer`. The error
+  names the path it looked at.
+- **exit 2, `requires an explicit model`:** the brief routed to `opencode`, which needs `--model`.
+  Pass one, or route elsewhere.
+- **exit 2, `has no read-only mode`:** a read-only lane or an explicit `--read-only` landed on `kimi`
+  or `agy`. Route to `codex` (sandbox-enforced) or `grok` (best-effort, flagged after the fact).
+- **`status: failed` with no `implementerResult`:** the sibling exited without writing a result,
+  which is almost always a usage error in the forwarded arguments. The sibling's own stderr was
+  inherited, so it is above the summary in the run output.
+- **The routing was wrong:** `result.json`'s `routing.matchedSignals` shows exactly which phrases
+  fired. Either the brief said something it did not mean, or the lane's signals need a row. Re-dispatch
+  with `--implementer`, and if the miss is systematic, fix the table.
+- **Everything else** — `timeout`, `aborted`, a `SIGKILL` from the OOM killer, an empty
+  `finalMessage`, recovering work from the event log — behaves exactly as it does for the sibling that
+  ran it. Read that skill's own `dispatch-and-poll.md`; `implementerResult` and
+  `implementerResultPath` point you at its artifacts.
+
+## The commit boundary
+
+Neither this relay nor any sibling commits — by design, not omission. The implementer edits the
+working tree; the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/wordpress-delegate/references/dispatch-and-poll.md
+++ b/skills/wordpress-delegate/references/dispatch-and-poll.md
@@ -5,8 +5,15 @@ preamble, and dispatches through the chosen sibling's own `relay.mjs`, which own
 mechanic. Your job collapses to: run one command, then read one file.
 
 This relay launches **no implementer CLI of its own**. It shells out to `node` (for the sibling) and
-`git`, and nothing else. Every guarantee about sandboxes, sessions, streaming, and process-tree kills
-is the sibling's, unchanged — this layer adds the routing decision and passes the rest through.
+`git`, and nothing else. Every guarantee about sandboxes, sessions, and streaming is the sibling's,
+unchanged — this layer adds the routing decision and passes the rest through.
+
+It does terminate one process: the sibling relay it spawned. A watchdog backstop and signal
+forwarding are impossible without that, so it is an owned exception, and a bounded one — reaching
+past the sibling to the implementer CLI is the sibling's own handler's job. (Windows is the usual
+exception: with no process groups to signal, the `taskkill /t` that fells the sibling fells the tree
+under it, and the sibling's handler never runs.) That is also the only case where this relay
+overrides the sibling's verdict — it did the killing, so the sibling could not know why it died.
 
 ## Before the first run: check the siblings
 

--- a/skills/wordpress-delegate/references/dispatch-and-poll.md
+++ b/skills/wordpress-delegate/references/dispatch-and-poll.md
@@ -86,18 +86,23 @@ Adding a lane is one row. Nothing else in the file knows the lane names:
 
 ```js
 {
-  name: "block-editor",
+  name: "multisite",
   implementer: "codex",
   readOnly: false,
-  why: "Block registration and the editor/save contract fail silently when the markup drifts.",
-  signals: [/\bblock\.json\b/, /\bregisterBlockType\b/, /\bblock (variation|pattern)s?\b/],
+  why: "Network-wide state and per-site state are different problems, and mixing them corrupts both.",
+  signals: [/\bmultisite\b/, /\bnetwork admin\b/, /\bswitch_to_blog\b/, /\bsite meta\b/],
 },
 ```
 
 Place it by precedence, not alphabetically — earlier rows win ties. Re-targeting a lane is a one-word
 change to its `implementer`. Teaching the preamble a new area is one row in `DOMAINS`, with its own
-`notes`. After either, run `node test/relay-smoke.mjs` and add a row to the routing table in
-`test/relay-smoke.mjs`'s `ROUTING_CASES` so the new lane is pinned.
+`notes`. After either, run `node test/relay-smoke.mjs` and add a row to `ROUTING_CASES` in
+`test/relay-smoke.mjs` so the new lane is pinned.
+
+Signals are matched **case-insensitively** against the brief as written, so write each row in the
+casing its ecosystem uses — `Gutenberg`, `registerBlockType`, `$wpdb` — and don't hand-lower it.
+`matchedSignals` echoes back what the brief actually said, which is what makes a wrong routing
+decision diagnosable.
 
 Two rules keep the table honest:
 

--- a/skills/wordpress-delegate/references/dispatch-and-poll.md
+++ b/skills/wordpress-delegate/references/dispatch-and-poll.md
@@ -5,8 +5,9 @@ preamble, and dispatches through the chosen sibling's own `relay.mjs`, which own
 mechanic. Your job collapses to: run one command, then read one file.
 
 This relay launches **no implementer CLI of its own**. It shells out to `node` (for the sibling) and
-`git`, and nothing else. Every guarantee about sandboxes, sessions, and streaming is the sibling's,
-unchanged — this layer adds the routing decision and passes the rest through.
+`git`, plus the platform termination utility on Windows, where felling a process tree needs one.
+Every guarantee about sandboxes, sessions, and streaming is the sibling's, unchanged — this layer
+adds the routing decision and passes the rest through.
 
 It does terminate one process: the sibling relay it spawned. A watchdog backstop and signal
 forwarding are impossible without that, so it is an owned exception, and a bounded one — reaching

--- a/skills/wordpress-delegate/references/multi-task-queues.md
+++ b/skills/wordpress-delegate/references/multi-task-queues.md
@@ -1,0 +1,105 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and WordPress work arrives in queues more often than not — a
+security remediation list, a plugin-by-plugin compatibility pass, a block migration, a checkout
+refactor split across templates. The discipline that makes a queue trustworthy is sequencing and
+bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each (review + gates + commit) before
+dispatching the next.
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the `acme_booking_saved` hook
+  added in the previous step exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible — which matters
+  more on WordPress than most stacks, because the thing you may need to revert is often live.
+- **Each review is honest.** A clean tree before each dispatch means the next task's `touchedFiles`
+  shows only *its* changes.
+
+Parallelism is occasionally worth it for genuinely independent tasks in separate plugins, but it
+sacrifices the clean-tree-per-task property. Default to sequential.
+
+## Let each task route on its own
+
+Do not pick one implementer for the whole queue. Each task gets its own dispatch and its own routing
+decision, and a well-split WordPress queue usually spans several lanes:
+
+1. Audit the plugin for nonce and escaping gaps → `security-audit` → `grok`, read-only, findings only.
+2. Fix finding 1 → `implementation` → `codex`. Review. Commit.
+3. Fix finding 2 → `implementation` → `codex`. Review. Commit.
+4. Update the readme and changelog for the release → `documentation` → `kimi`. Review. Commit.
+
+That is the shape the router is built for. The audit that generates the queue is itself the first
+dispatch, and it costs nothing to run read-only.
+
+Two things to watch across a queue:
+
+- **Check the routing of each task, not just the first.** A queue derived from one audit can still
+  contain a task whose wording routes somewhere surprising. `--dry-run` is cheap; run it over the
+  whole queue before starting if you want the routing plan up front.
+- **Resume flags are per-implementer.** `implementerSession` from task 2's result resumes *that*
+  implementer's session. Pass the matching `--implementer` with it, or the flag goes to the wrong CLI.
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a hook got a
+priority, an option key was chosen, a capability was picked. When a later task depends on one,
+**fold it into that task's brief** as an explicit line. The implementer has no memory of the earlier
+run — and on a queue that spans implementers, it may not even be the same CLI.
+
+The preamble does not carry these forward either. It carries standards, not decisions.
+
+WordPress-specific constraints that almost always need carrying:
+
+- The prefix and text domain actually used, if the codebase was inconsistent and task 1 settled it.
+- The exact name, signature, and priority of any hook or filter an earlier task added.
+- The option keys and their autoload setting.
+- The capability chosen for a permission check, so the whole queue uses one.
+- Any deprecation shim left in place, so a later task doesn't remove it as dead code.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash),
+  plus **which lane and implementer it routed to**.
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **Public surface changed** — a running list of hooks, filters, shortcodes, REST routes, and option
+  shapes added, changed, or deprecated across the whole queue. This is the deploy note, and nobody
+  can reconstruct it afterwards from ten separate commits.
+- **"Needs your eyes"** — design decisions the implementer made, low-confidence routing decisions,
+  non-blocking nitpicks. This is the section the human reads first.
+- **End-of-run checklist** — what happens after the last task: push, PR, and the manual checks that
+  only make sense on a real site (an actual checkout, an actual form submission, the editor loading
+  the block).
+
+Update it as each task lands, not in a batch at the end.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task:
+
+- Run the full test suite and PHPCS once more on the final tree — not just the last task's slice.
+- **Activate the plugin or theme from a clean state** and load the front end and the admin. A queue of
+  individually-green commits can still produce a fatal on activation, and no unit test will say so.
+- Do a repo-wide check for whatever the queue was about — after a removal, grep for surviving
+  references; after a rename, confirm no stragglers in templates or JS.
+- For schema work, replay every new migration from a clean database and check for drift, then confirm
+  the upgrade routine is safe to run twice.
+- Reconcile the public-surface list against the actual diff (`git diff <base>..HEAD`), and put it in
+  the PR description. That list is what a site owner needs before deploying.
+- Then push and open or update the PR.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope — a scope change is the human's call.
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+- **A task's routing came back `contested` and the two lanes imply genuinely different work.** That is
+  usually a sign the queue was split wrong, and it is cheaper to ask than to land the wrong half.
+
+Then report where you are, what's committed, and what the open question is — and wait.

--- a/skills/wordpress-delegate/references/review-and-land.md
+++ b/skills/wordpress-delegate/references/review-and-land.md
@@ -1,0 +1,163 @@
+# Review and land
+
+The implementer did the typing; you own the judgment. This is where delegation earns its keep or
+quietly ships a mistake — and WordPress is unusually good at hiding mistakes behind a green test
+suite, because most of what goes wrong is a missing check rather than a wrong answer.
+
+The discipline: **verify against reality, never against the self-report.**
+
+## Start with the routing decision
+
+This skill picks the implementer for you, so the first thing to review is that pick.
+
+`result.json`'s `routing` block records the lane, the confidence, the signals that matched, and the
+runners-up. Read it before the diff:
+
+- **`confidence: "high"`** — two or more signals agreed. Proceed to the normal review.
+- **`confidence: "low"` or `"none"`** — the router guessed. Read the diff against *what the user
+  asked for*, not against what the lane assumed. A brief that fell through to `implementation` and
+  came back with an audit-shaped answer is a routing miss, not an implementation failure.
+- **`confidence: "contested"`** — the brief read as two kinds of work at once. That usually means the
+  brief should have been two briefs. Check that the run did the half you cared about.
+- **`matchedSignals` naming something you did not mean** — e.g. an offhand "for performance reasons"
+  routing a bugfix into the performance lane. Re-dispatch with `--implementer` or `--lane`.
+
+Report a below-`high` routing decision to the user as one of the things you surfaced. They opted into
+delegation; they did not opt into a keyword scan choosing the agent silently.
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means
+anything. A weakened assertion, an added skip, or a deleted test makes the gate measure less than it
+did before the run.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** Flag them.
+- **Skipped or commented-out tests added in this diff:** treat the underlying test as failing.
+- **Loosened assertions:** same treatment.
+
+## Re-run the gates yourself
+
+Re-run the project's actual commands — `vendor/bin/phpunit`, `vendor/bin/phpcs --standard=WordPress`,
+`npm run build`, whatever the brief named — and read the output. **Passing is necessary, not
+sufficient.** PHPCS with the WordPress standard catches a good deal of the escaping and prefixing
+rules mechanically; it catches none of the authorization ones.
+
+## The WordPress sweep
+
+Walk these against every diff before you commit. Each can sit in a diff whose tests are all green,
+and most of them are invisible to PHPCS.
+
+**Authorization and input**
+
+- **A nonce without a capability, or a capability without a nonce.** Both, on every state-changing
+  request. `check_ajax_referer()` proves the request came from your page; it proves nothing about who
+  the user is.
+- **`current_user_can()` with the wrong capability** — `manage_options` where an editor should
+  qualify, or an author-level capability guarding a site-wide setting.
+- **Unescaped output.** Every echo of a variable, at the point of output: `esc_html`, `esc_attr`,
+  `esc_url`, `wp_kses_post`. Escaping at assignment and echoing later is the classic near-miss.
+- **`$wpdb` interpolation.** `prepare()` for every value, including in `ORDER BY` and `LIMIT` clauses
+  built from input. A `prepare()` call whose placeholders don't match its arguments silently produces
+  the wrong query.
+- **Missing `wp_unslash()`** before sanitizing a superglobal, which quietly corrupts quoted input.
+- **REST routes with `permission_callback` set to `__return_true`** on anything that is not genuinely
+  public.
+
+**Platform**
+
+- **A core, plugin, or theme file edited in place** rather than extended through a hook. Check
+  `touchedFiles` for paths outside the brief's scope.
+- **A hand-rolled equivalent of an existing API** — cURL instead of `wp_remote_get()`, direct
+  filesystem writes instead of `WP_Filesystem`, a custom cron loop instead of `wp_schedule_event()`.
+- **Unprefixed globals** — a function, class, constant, option, or hook name without the project's
+  prefix is a collision waiting for the next plugin.
+- **Scripts or styles printed rather than enqueued**, or enqueued on every page instead of the one
+  that needs them.
+- **Strings without a translation function, or with the wrong text domain.** A hardcoded domain
+  string that doesn't match the plugin's own silently drops the translation.
+
+**Data and compatibility**
+
+- **A public hook, filter, shortcode, REST route, or option shape changed without a deprecation
+  shim.** This is how a WordPress change breaks code you don't own.
+- **`update_option()` on a large value without `false` for autoload**, or a new autoloaded option
+  that gets read once a month.
+- **Direct post-meta access to WooCommerce orders** — under HPOS the post tables are not the source
+  of truth. CRUD objects (`wc_get_order`, `$order->save()`) or nothing.
+- **A schema change without a version-gated upgrade routine**, or one that isn't safe to run twice.
+- **An unguarded dependency on another plugin** — a call into ACF, Elementor, or Woo with no
+  `function_exists` / `class_exists` guard and no graceful degradation.
+- **A query added inside a loop**, or a `meta_query` on a hot path that will not survive real data
+  volume.
+
+**The generated-code sweep** (these are not WordPress-specific, and they still apply)
+
+- **Hardcoded success or fixture data** on a path the brief says does real work.
+- **Catch-all error handling that returns a default** instead of propagating.
+- **Unverified imports and API calls** — confirm every function exists in the *installed* version of
+  the plugin being extended, not just in its current documentation.
+- **Dead weight** — unused imports, helpers nothing calls, comments restating the line below.
+- **Speculative surface** — options, filters, or abstractions with no caller in this diff.
+- **New tests that assert internals**, or near-duplicate test bodies differing by one value.
+
+Anything the sweep catches goes back as a delta brief (below) or gets fixed in the tree before commit
+— and either way is reported to the user.
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment.
+The sweep above is the built-in floor.
+
+## Verify a read-only run was read-only
+
+The `security-audit` and `research` lanes run read-only, and read-only means different things by
+implementer. Grok's is **best-effort**: it cannot be prevented from writing headlessly, so the
+sibling snapshots the tree and sets `readOnlyViolation: true` when a read-only run wrote anyway.
+Check `implementerResult.readOnlyViolation` and confirm `touchedFiles` is `[]` — do not assume. If
+you need the guarantee enforced, route the audit to `codex`, whose sandbox does enforce it.
+
+An audit that wrote files is not an audit that helpfully fixed things; it is a run that ignored its
+mode, and its findings deserve the same scepticism.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — never the implementer. Committing should be
+the act of the party that verified the work.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work. Never run `git checkout`, `reset`, `clean`, or a branch switch in the workspace
+between those two points — however messy an interrupted run looks, inspect it first: `git status`,
+`git diff`, `git diff --cached` for anything staged, and open any untracked files (`??`) directly,
+since no diff shows their contents. The tree is evidence, not clutter. After that inspection the
+verdict can legitimately be to discard; the ban is on reflexive cleanup before anyone has looked.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same session with just
+the correction:
+
+```bash
+echo "The nonce check is right, but esc_attr on line 84 should be esc_url — it's a redirect target." \
+  | node "<skill-dir>/scripts/relay.mjs" --implementer codex --session <implementerSession> --cd /path/to/plugin
+```
+
+Take `<implementerSession>` from the prior `result.json`. Pass the same `--implementer` you routed to
+the first time, or the resume flag will be sent to the wrong CLI. The relay skips the preamble on a
+resumed run — the session already carries it — so a short delta is genuinely short.
+
+Then review again: rework gets the same gate re-run, test check, diff read, and WordPress sweep as the
+original. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+Keep them in the loop on anything that changes the shape of the work:
+
+- **Report the routing decision** when confidence was below `high`, and which implementer ran.
+- **Report design decisions** the implementer made, and any defensible-but-unrequested turns.
+- **Report every public-surface change** — new or changed hooks, filters, shortcodes, REST routes,
+  and option shapes. In WordPress this is the blast radius, and it is the thing a site owner most
+  needs to know before deploy.
+- **Note non-blocking nitpicks** you chose not to block on, so they can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/wordpress-delegate/references/writing-the-brief.md
+++ b/skills/wordpress-delegate/references/writing-the-brief.md
@@ -1,0 +1,156 @@
+# Writing the brief
+
+A brief is the entire task as the implementer will see it. It runs in a fresh process with **no
+memory of your conversation, no access to your prior notes, and no shared context** — only the text
+sent and whatever it can read from the working tree.
+
+This skill changes what you have to write, not how much rigour the brief needs. The relay prepends a
+standing WordPress preamble to every fresh brief, so you write the part no preamble can know.
+
+## What the preamble already covers
+
+Read the exact text with `node "<skill-dir>/scripts/relay.mjs" --print-preamble` — that is the
+canonical copy, and it is what the implementer actually receives. In summary it fixes:
+
+- **Security as a property of every line** — nonce *and* capability on state-changing requests,
+  sanitize on input, escape at output, `$wpdb->prepare()` for every interpolated value, superglobals
+  and REST payloads treated as hostile.
+- **Use the platform** — never edit core or a third-party plugin in place, extend through hooks and
+  filters, child themes for theme changes, prefer an existing WordPress API to a hand-rolled one,
+  enqueue rather than print tags.
+- **Maintainability** — WordPress Coding Standards, match the file being edited over any general
+  rule, prefix every global symbol, no dead code and no abstraction without a second caller.
+- **Backward compatibility** — public hooks, filters, shortcodes, REST routes, and option shapes are
+  contracts; guard every dependency on another plugin and degrade cleanly when it is absent.
+- **Performance** — no queries in loops, no unbounded queries, caches with an explicit invalidation
+  path, nothing large in autoloaded options.
+- **The commit boundary** — do not `git add` or `git commit`; leave the work in the working tree.
+
+On top of that, the relay appends **domain notes** for whatever its keyword scan detected —
+WooCommerce, Elementor, ACF, WPForms, performance, database, security, integrations, hosting,
+deployment. The notes are a hint from a scan of your brief's wording, not a survey of the working
+tree, and the block says so to the implementer. If the brief is about HPOS but never says
+"WooCommerce", the notes will not fire — check with `--dry-run` and name the domain in the brief if
+it matters.
+
+Do not restate any of this. A brief that repeats the preamble spends tokens and buries the part that
+is actually specific to your task.
+
+## What only you can supply
+
+The preamble knows WordPress. It does not know *your* WordPress. These are the facts a delegated
+WordPress task fails on, and none of them are guessable:
+
+- **Which repo is the repo.** A whole install, `wp-content/`, one plugin, one theme? Set `--cd`
+  accordingly and say in the brief what is in scope and what merely sits nearby.
+- **Versions that constrain the change.** PHP, WordPress, and the versions of the plugins being
+  extended — WooCommerce, Elementor, and ACF all move APIs between majors. "Compatible with our
+  Woo version" is not a constraint; the number is.
+- **The real gate commands.** Read the repo's `CLAUDE.md` / `AGENTS.md` / `composer.json` /
+  `package.json` / `Makefile` and copy them in verbatim: `composer test`, `vendor/bin/phpunit`,
+  `vendor/bin/phpcs --standard=WordPress`, `npm run build`, `wp-env run tests-wordpress ...`. A brief
+  that says "run the tests" gets an implementer that guesses, or skips.
+- **The prefix and the text domain.** Every global symbol takes the project's prefix and every string
+  takes the project's text domain — the preamble says so, but only your brief knows what they are.
+- **What must not move.** Templates other themes override, hooks other plugins listen on, an option
+  shape a migration depends on. This is the list that keeps a fix from becoming a refactor.
+- **Whether the site is live, and what that forbids.** No schema change without a migration path, no
+  destructive `wp` command, no writes to production data.
+
+## The shape that works
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched.
+</task>
+
+<environment>
+Repo root: wp-content/plugins/acme-bookings (this is what --cd points at)
+PHP 8.1 · WordPress 6.5 · WooCommerce 8.9 (HPOS enabled) · ACF Pro 6.2
+Prefix: acme_  ·  Text domain: acme-bookings
+Live site: yes — no schema changes without a versioned upgrade routine.
+</environment>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint command, e.g. vendor/bin/phpcs --standard=WordPress src/>
+  <the project's real build command, if assets are touched>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the PHPUnit and PHPCS counts)
+  4. Every hook, filter, option, or REST route added, changed, or deprecated
+  5. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Item 4 in the report contract is WordPress-specific and worth keeping: the public surface is where a
+WordPress change breaks other people's code, and it is the part a diff read makes you hunt for.
+
+Add a block when the task profile calls for it — `<completeness_contract>` for open-ended debugging,
+`<grounding_rules>` for a read-only audit, `<research_mode>` for a recommendation. The lane the relay
+picks does not change what you must write; it changes who receives it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Audit the plugin, fix what you find, and document it" is
+three lanes — the router will pick one, and the run will be muddled whichever it picks. Split it: an
+audit dispatch (read-only, routes to `grok`), then a fix dispatch per finding, then a docs dispatch
+(routes to `kimi`). One brief → one run → one commit.
+
+That split is also how routing is *meant* to be used. A brief that reads as one kind of work routes
+confidently; a brief that reads as three routes at `contested` and tells you so.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+`<environment>` block before sending — a wrong plugin version or a wrong assumption about HPOS
+invalidates the whole run. If a premise turns out wrong while the run is live, stop it and
+re-dispatch a corrected brief rather than discounting the output afterward; inspect the working tree
+and reconcile any partial edits first.
+
+## A worked example
+
+```xml
+<task>
+In wp-content/plugins/acme-bookings, the AJAX endpoint acme_cancel_booking (src/Ajax/Cancel.php)
+cancels a booking for any booking id the caller sends: it verifies no nonce and checks no capability,
+and it interpolates $_POST['booking_id'] straight into a $wpdb->get_row() call. Fix all three: verify
+a nonce, require the capability that already gates the admin screen (acme_manage_bookings), and
+prepare the query. Touch only src/Ajax/Cancel.php, the JS that calls it, and their tests. Leave the
+booking model, the REST routes, and the admin screen untouched.
+</task>
+
+<environment>
+Repo root: wp-content/plugins/acme-bookings (--cd points here)
+PHP 8.1 · WordPress 6.5 · WooCommerce 8.9 (HPOS enabled)
+Prefix: acme_  ·  Text domain: acme-bookings
+Live site: yes. The endpoint is public-facing — do not change its action name or response shape.
+</environment>
+
+<verification_loop>
+Run and make green before finishing:
+  vendor/bin/phpunit --testsuite ajax
+  vendor/bin/phpcs --standard=WordPress src/Ajax/
+  npm run build
+Confirm git status shows only Cancel.php, its JS, and their tests changed.
+</verification_loop>
+
+<structured_output_contract>
+Report: (1) each of the three issues and your fix, (2) files touched, (3) PHPUnit and PHPCS counts,
+(4) any hook, filter, option, or route added or changed, (5) anything you left open.
+</structured_output_contract>
+```
+
+Note what is *not* in it: no reminder to escape output, no reminder about `$wpdb->prepare()`, no
+"follow WordPress Coding Standards", no "don't commit". The preamble carries all of that. The brief
+carries the booking system.
+
+Send it with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/wordpress-delegate/scripts/relay.mjs
+++ b/skills/wordpress-delegate/scripts/relay.mjs
@@ -828,8 +828,12 @@ function resolveSiblingRelay(implementer, opts) {
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // The kill must reach the whole family: this relay's child is another relay, whose own child
-  // is the implementer CLI, whose children are its tools. Same idiom as every sibling relay.
+  // The one mechanic this relay owns rather than delegates, because a watchdog backstop and signal
+  // forwarding are impossible without it. It is deliberately bounded: the target is the sibling
+  // relay and nothing past it. The sibling spawns the implementer CLI detached, into a process
+  // group of its own, so this signal does not reach it — the sibling's own handler does, and it
+  // already knows how. Windows is the usual exception: with no process groups to signal, the
+  // taskkill /t below fells the tree under the sibling too and its handler never runs.
   if (process.platform === "win32") {
     if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
     try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }

--- a/skills/wordpress-delegate/scripts/relay.mjs
+++ b/skills/wordpress-delegate/scripts/relay.mjs
@@ -12,9 +12,10 @@
  *
  * Trust posture: relay.mjs itself makes no network calls, reads or writes no
  * credentials, and sends no telemetry; it has no dependencies (Node built-ins
- * only). It shells out only to `node` (for the sibling relay) and `git`. The
- * implementer CLI the sibling launches does authenticate — exactly as you do at
- * the terminal. Read this file, and the sibling's, before you run them.
+ * only). It shells out to `node` (for the sibling relay) and `git`, plus the
+ * platform termination utility on Windows, where felling a process tree needs
+ * one. The implementer CLI the sibling launches does authenticate — exactly as
+ * you do at the terminal. Read this file, and the sibling's, before you run them.
  *
  * It deliberately does NOT commit, and neither does any sibling. Committing is
  * always the orchestrator's job — after it reviews the diff and re-runs the
@@ -315,7 +316,9 @@ const LANES = [
       /\b(dynamic|static|custom|inner) blocks?\b/,
       /\bInnerBlocks\b/,
       /\bblock (attribute|deprecation|variation|pattern|style|template|support|binding)s?\b/,
-      /\b@wordpress\/(blocks|block-editor|element|data|components|scripts|i18n)\b/,
+      // No leading \b: the boundary would have to sit between a non-word character and `@`, which
+      // is not a boundary at all, so `\b@wordpress` only ever matched glued to a word (`x@wordpress`).
+      /@wordpress\/(blocks|block-editor|element|data|components|scripts|i18n)\b/,
       /\buseBlockProps\b/,
       /\btheme\.json\b/,
       /\b(full site editing|FSE|block theme)\b/,

--- a/skills/wordpress-delegate/scripts/relay.mjs
+++ b/skills/wordpress-delegate/scripts/relay.mjs
@@ -293,13 +293,34 @@ const LANES = [
     readOnly: false,
     why: "Elementor's control/render/editor contract is unforgiving; a wrong control schema fails silently in the editor.",
     signals: [
-      /\belementor\b/,
+      /\bElementor\b/,
       /\bdynamic tag(s)?\b/,
       /\b(loop|theme) builder\b/,
       /\bcustom (widget|control)s?\b/,
       /\bwidget_(controls|render)\b/,
       /\bregister_controls\b/,
-      /\b\\?Elementor\\/,
+    ],
+  },
+  {
+    name: "block-editor",
+    implementer: "codex",
+    readOnly: false,
+    why: "The block registration and edit/save contract fails silently when markup drifts — an invalid block is a validation error in the editor, not a test failure.",
+    signals: [
+      /\bGutenberg\b/,
+      /\bblock editor\b/,
+      /\bblock\.json\b/,
+      /\bregisterBlockType\b/,
+      /\bregister_block_type\b/,
+      /\b(dynamic|static|custom|inner) blocks?\b/,
+      /\bInnerBlocks\b/,
+      /\bblock (attribute|deprecation|variation|pattern|style|template|support|binding)s?\b/,
+      /\b@wordpress\/(blocks|block-editor|element|data|components|scripts|i18n)\b/,
+      /\buseBlockProps\b/,
+      /\btheme\.json\b/,
+      /\b(full site editing|FSE|block theme)\b/,
+      /\binteractivity api\b/,
+      /\brender_callback\b/,
     ],
   },
   {
@@ -439,6 +460,14 @@ const DOMAINS = [
     ],
   },
 ];
+
+// Signals are matched case-insensitively, so a row can be written in whatever case reads best —
+// `Gutenberg`, `registerBlockType`, `$wpdb` — without its author having to know that the brief is
+// folded first. Normalizing once at load keeps that out of the matching path, and keeps a stray
+// capital from silently producing a signal that can never fire.
+const caseInsensitive = (signal) => (signal.flags.includes("i") ? signal : new RegExp(signal.source, `${signal.flags}i`));
+for (const lane of [...LANES, DEFAULT_LANE]) lane.signals = lane.signals.map(caseInsensitive);
+for (const domain of DOMAINS) domain.signals = domain.signals.map(caseInsensitive);
 
 /* ------------------------------------------------------------------ *
  * The preamble — the standing instruction every WordPress brief carries,
@@ -635,7 +664,9 @@ function detectDomains(text) {
 }
 
 function classify(brief, opts) {
-  const text = brief.toLowerCase();
+  // Matched against the brief as written: the signals themselves are case-insensitive, and keeping
+  // the original casing means matchedSignals echoes back what the brief actually said.
+  const text = brief;
   const domains = detectDomains(text);
 
   if (opts.implementer && !opts.lane) {

--- a/skills/wordpress-delegate/scripts/relay.mjs
+++ b/skills/wordpress-delegate/scripts/relay.mjs
@@ -1,0 +1,1142 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · wordpress-delegate · relay.mjs
+ *
+ * Route a WordPress coding task to the sibling delegate best suited to it, then
+ * dispatch through that sibling's own relay. This relay launches no implementer
+ * CLI of its own: it classifies the brief, prepends the WordPress engineering
+ * preamble, and hands the composed brief to `skills/<implementer>-delegate/
+ * scripts/relay.mjs`, which owns every CLI-specific mechanic. One layer, one
+ * job — routing — with dispatch, polling, and the result contract reused from
+ * the sibling verbatim.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `node` (for the sibling relay) and `git`. The
+ * implementer CLI the sibling launches does authenticate — exactly as you do at
+ * the terminal. Read this file, and the sibling's, before you run them.
+ *
+ * It deliberately does NOT commit, and neither does any sibling. Committing is
+ * always the orchestrator's job — after it reviews the diff and re-runs the
+ * project gates.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options] [-- <implementer relay args>]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Routing options:
+ *   --implementer <name>    Force the implementer, bypassing the router. One of:
+ *                           agy, claude, codex, cursor, grok, kimi, opencode, pi,
+ *                           qoder, vibe.
+ *   --lane <name>           Force the lane; the lane table still resolves the
+ *                           implementer. See --list-routes.
+ *   --strict-routing        Refuse to dispatch when the router's confidence is
+ *                           "low" or "none", or when two lanes tie. Exits 3 with
+ *                           the question to put to the user.
+ *   --dry-run               Print the routing decision as JSON and exit 0 without
+ *                           dispatching. Writes no result file.
+ *   --list-routes           Print the lane table and the implementer table, then exit 0.
+ *   --print-preamble        Print the WordPress engineering preamble and exit 0.
+ *   --no-preamble           Send the brief verbatim, with no preamble prepended.
+ *                           (Implied on --session / --resume-last: the preamble is
+ *                           already in the resumed session's context.)
+ *   --implementer-relay <p> Absolute path to a sibling relay.mjs. Use when only this
+ *                           skill is installed and the sibling directories are absent.
+ *
+ * Forwarded options (passed to the sibling relay):
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root (default: current directory).
+ *   --model <name>          Implementer model. Required when routing to opencode.
+ *   --read-only             Review/diagnosis with no edits. Translated to the chosen
+ *                           implementer's own flag (`--read-only`, `--plan-only`, or
+ *                           `--permission-mode plan`). Rejected for implementers that
+ *                           have no read-only mode — see --list-routes.
+ *   --session <id>          Continue a specific session; translated to the chosen
+ *                           implementer's own resume flag. Send only the delta brief.
+ *   --resume-last           Continue the most recent session of the chosen implementer.
+ *   --timeout <dur>         Watchdog, honoured by the sibling. Durations use h/m/s
+ *                           strings like 30m or 2h. This relay arms a backstop 60s
+ *                           later in case the sibling itself wedges.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir). The sibling's own artifacts land in
+ *                           <out-dir>/implementer/.
+ *   --                      Everything after this is forwarded to the sibling relay
+ *                           verbatim, for implementer-specific flags this relay does
+ *                           not model (e.g. --sandbox, --effort, --permission-mode).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout. It speaks
+ *   delegate-relay.result.v1 — status, exitCode, signal, finalMessage, touchedFiles,
+ *   session — lifted from the sibling's own result, plus a `routing` block recording
+ *   the lane, implementer, confidence, matched signals, and detected domains, and
+ *   `implementerResult` carrying the sibling's result verbatim.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief, unknown
+ * implementer, unroutable brief under --strict-routing) exits 2 or 3 before any run
+ * and writes no result file; a missing sibling relay exits 127 with a result file;
+ * otherwise the exit code mirrors the sibling's, which mirrors the implementer's.
+ * Once the brief validates and a sibling is resolved, result.json is written on every
+ * outcome — whatever the sibling reports, plus timeout (this relay's backstop fired)
+ * and aborted (this relay was killed and forwarded the kill).
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve, dirname, basename } from "node:path";
+import { constants, tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const MAX_TIMER_MS = 2_147_483_647;
+// The sibling owns the watchdog for --timeout. This relay arms a backstop one grace
+// window later, for the one case the sibling cannot cover: the sibling itself wedging
+// before it arms its own timer. Long enough that the two never race on a healthy run.
+const BACKSTOP_GRACE_MS = 60_000;
+// A sibling handling SIGTERM writes its result, then refreshes touchedFiles ~2s later
+// before exiting. Wait past that so the forwarded kill still yields a complete snapshot.
+const SIBLING_SHUTDOWN_GRACE_MS = 8_000;
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/* ------------------------------------------------------------------ *
+ * Implementer table — one row per sibling delegate.
+ *
+ * Each row states, in that CLI's own terms, only what this relay needs to
+ * translate a portable flag into the sibling's flag. Everything else about the
+ * implementer stays in the sibling's own SKILL.md and relay.mjs.
+ *
+ *   dir          the sibling skill directory under skills/
+ *   readOnly     argv for a read-only run, or null when the CLI has no such mode
+ *   sessionFlag  the sibling's flag for resuming one specific session
+ *   requiresModel  the sibling rejects a run with no --model
+ *   note         one line, surfaced by --list-routes
+ * ------------------------------------------------------------------ */
+const IMPLEMENTERS = {
+  agy: {
+    dir: "agy-delegate",
+    readOnly: null,
+    sessionFlag: "--conversation",
+    requiresModel: false,
+    note: "Google Antigravity (agy) — no CLI-enforced read-only mode.",
+  },
+  claude: {
+    dir: "claude-delegate",
+    readOnly: ["--read-only"],
+    sessionFlag: "--session",
+    requiresModel: false,
+    note: "Claude Code (claude) — read-only is plan mode, with a porcelain tripwire.",
+  },
+  codex: {
+    dir: "codex-delegate",
+    readOnly: ["--read-only"],
+    sessionFlag: "--session",
+    requiresModel: false,
+    note: "OpenAI Codex (codex) — read-only is sandbox-enforced.",
+  },
+  cursor: {
+    dir: "cursor-delegate",
+    readOnly: ["--read-only"],
+    sessionFlag: "--session",
+    requiresModel: false,
+    note: "Cursor Agent (cursor-agent) — read-only is plan mode.",
+  },
+  grok: {
+    dir: "grok-delegate",
+    readOnly: ["--read-only"],
+    sessionFlag: "--session",
+    requiresModel: false,
+    note: "Grok Build (grok) — read-only is best-effort; check readOnlyViolation.",
+  },
+  kimi: {
+    dir: "kimi-delegate",
+    readOnly: null,
+    sessionFlag: "--session",
+    requiresModel: false,
+    note: "Kimi Code (kimi) — auto permission mode always; no read-only mode.",
+  },
+  opencode: {
+    dir: "opencode-delegate",
+    readOnly: ["--read-only"],
+    sessionFlag: "--session",
+    requiresModel: true,
+    note: "OpenCode (opencode) — agent build/plan; --model is required.",
+  },
+  pi: {
+    dir: "pi-delegate",
+    readOnly: ["--read-only"],
+    sessionFlag: "--session",
+    requiresModel: false,
+    note: "Pi (pi) — read-only restricts tools to read,grep,find,ls.",
+  },
+  qoder: {
+    dir: "qoder-delegate",
+    readOnly: ["--permission-mode", "plan"],
+    sessionFlag: "--resume",
+    requiresModel: false,
+    note: "Qoder CLI (qodercli) — read-only is permission mode plan.",
+  },
+  vibe: {
+    dir: "vibe-delegate",
+    readOnly: ["--plan-only"],
+    sessionFlag: "--session",
+    requiresModel: false,
+    note: "Mistral Vibe (vibe) — read-only is the plan agent.",
+  },
+};
+
+/* ------------------------------------------------------------------ *
+ * Lane table — the routing rules. THIS is the extension point.
+ *
+ * To add a lane: append a row. To re-target one: change its `implementer`.
+ * Nothing else in this file knows the lane names.
+ *
+ *   name         lane id, also accepted by --lane
+ *   implementer  key into IMPLEMENTERS
+ *   signals      regexes; each DISTINCT match adds 1 to the lane's score
+ *   readOnly     true when the lane is diagnosis, not edits (implies --read-only)
+ *   why          one line explaining the routing choice, recorded in result.json
+ *
+ * Scoring: the highest-scoring lane wins. Two or more lanes tied above zero are
+ * "contested" and the first tied row wins, because lane order encodes precedence —
+ * a security audit that also mentions performance is still a security audit.
+ * A zero score falls through to DEFAULT_LANE.
+ * ------------------------------------------------------------------ */
+const LANES = [
+  {
+    name: "security-audit",
+    implementer: "grok",
+    readOnly: true,
+    why: "Security review wants an adversarial reader, not an editor; the run is read-only and the deliverable is findings.",
+    signals: [
+      /\bsecurity (audit|review|assessment|hardening)\b/,
+      /\bvulnerab(le|ility|ilities)\b/,
+      /\b(sql ?injection|xss|csrf|ssrf|rce|lfi|object injection)\b/,
+      /\bnonce(s)?\b/,
+      /\b(capability|capabilities) check\b/,
+      /\bcurrent_user_can\b/,
+      /\b(escap(e|ing)|sanitiz(e|ation|ing)|unslash)\b/,
+      /\b(esc_html|esc_attr|esc_url|wp_kses|sanitize_text_field|wp_verify_nonce|check_admin_referer)\b/,
+      /\b(privilege escalation|auth(entication|orization) bypass)\b/,
+      /\bharden(ing)?\b/,
+    ],
+  },
+  {
+    name: "research",
+    implementer: "grok",
+    readOnly: true,
+    why: "Open questions want breadth and a defended recommendation, not a diff; the run is read-only.",
+    signals: [
+      /\bresearch\b/,
+      /\binvestigate\b/,
+      /\b(compare|comparison|evaluate|evaluation) (of |the )?(options|approaches|plugins|libraries|gateways)\b/,
+      /\bfeasibilit(y|ies)\b/,
+      /\bspike\b/,
+      /\bwhich (plugin|library|gateway|approach|host)\b/,
+      /\bpros and cons\b/,
+      /\btrade[- ]?offs?\b/,
+      /\brecommend(ation)? (which|what|an approach)\b/,
+    ],
+  },
+  {
+    name: "documentation",
+    implementer: "kimi",
+    readOnly: false,
+    why: "Documentation is high-volume, low-branching prose work — the cheapest capable implementer wins.",
+    signals: [
+      /\b(write|update|generate|improve) (the )?(docs|documentation)\b/,
+      /\breadme(\.txt|\.md)?\b/,
+      /\bchangelog\b/,
+      /\b(docblock|phpdoc|inline comments)\b/,
+      /\b(user|developer|migration|upgrade) guide\b/,
+      /\bdocument the\b/,
+      /\bcode comments\b/,
+    ],
+  },
+  {
+    name: "refactor-sweep",
+    implementer: "opencode",
+    readOnly: false,
+    why: "A wide mechanical sweep needs sustained context across many files more than it needs deep reasoning on any one.",
+    signals: [
+      /\b(large|big|wide|sweeping|codebase[- ]wide|repo[- ]wide|plugin[- ]wide) refactor\b/,
+      /\brefactor(ing)? (the (whole|entire)|all|every)\b/,
+      /\brename .* (across|throughout|everywhere)\b/,
+      /\b(migrate|convert|port) all\b/,
+      /\bacross (all|every) (file|template|module|class)/,
+      /\b(restructure|reorganiz(e|ation)) the\b/,
+      /\bextract .* into (a )?(class|trait|service|module)\b/,
+      /\bnamespace the\b/,
+      /\bpsr-4 (migration|conversion)\b/,
+      /\bdeprecat(e|ion) sweep\b/,
+    ],
+  },
+  {
+    name: "plugin-architecture",
+    implementer: "codex",
+    readOnly: false,
+    why: "Structural design decisions compound; this lane gets the strongest reasoning available.",
+    signals: [
+      /\bplugin (architecture|structure|scaffold|skeleton|boilerplate)\b/,
+      /\b(new|build a|create a|write a) (custom )?plugin\b/,
+      /\b(activation|deactivation|uninstall) hook\b/,
+      /\bregister_activation_hook\b/,
+      /\b(service container|dependency injection|autoload(er|ing))\b/,
+      /\bcomposer (package|autoload)\b/,
+      /\bmu-plugin\b/,
+      /\bchild theme (scaffold|structure|setup)\b/,
+      /\btheme (architecture|structure|scaffold)\b/,
+      /\bmultisite (architecture|network plugin)\b/,
+    ],
+  },
+  {
+    name: "elementor-widget",
+    implementer: "codex",
+    readOnly: false,
+    why: "Elementor's control/render/editor contract is unforgiving; a wrong control schema fails silently in the editor.",
+    signals: [
+      /\belementor\b/,
+      /\bdynamic tag(s)?\b/,
+      /\b(loop|theme) builder\b/,
+      /\bcustom (widget|control)s?\b/,
+      /\bwidget_(controls|render)\b/,
+      /\bregister_controls\b/,
+      /\b\\?Elementor\\/,
+    ],
+  },
+  {
+    name: "performance",
+    implementer: "codex",
+    readOnly: false,
+    why: "Performance work is measurement-driven and easy to get plausibly wrong; it gets the strongest reasoning available.",
+    signals: [
+      /\b(performance|optimi[sz](e|ation)) (work|pass|audit|task)?\b/,
+      /\b(slow|expensive|n\+1) quer(y|ies)\b/,
+      /\bobject cache\b/,
+      /\b(redis|memcached|opcache)\b/,
+      /\bwp[- ]rocket\b/,
+      /\blitespeed\b/,
+      /\bcloudflare\b/,
+      /\b(transient|autoload(ed)? options)\b/,
+      /\b(asset|image) optimi[sz]ation\b/,
+      /\b(core web vitals|lcp|cls|ttfb)\b/,
+      /\bquery monitor\b/,
+      /\b(index|indexes|indices) on wp_/,
+      /\bcach(e|ing) layer\b/,
+    ],
+  },
+];
+
+// Anything WordPress-shaped that matched no lane. Implementation is the common case,
+// so the fallback is an implementer that can carry a normal feature or bugfix brief.
+const DEFAULT_LANE = {
+  name: "implementation",
+  implementer: "codex",
+  readOnly: false,
+  why: "No lane signal dominated, so the brief is treated as ordinary implementation work.",
+  signals: [],
+};
+
+/* ------------------------------------------------------------------ *
+ * Domain table — what the brief is ABOUT, as opposed to what KIND of work it is.
+ *
+ * Domains do not pick the implementer. They select the notes appended to the
+ * preamble, and they are recorded in result.json so a reviewer can see what the
+ * router thought it was looking at. Add a row to teach the preamble a new area.
+ * ------------------------------------------------------------------ */
+const DOMAINS = [
+  {
+    name: "core",
+    signals: [/\b(add_action|add_filter|do_action|apply_filters)\b/, /\b(hook|filter|action)s?\b/, /\bwp[- ]cli\b/, /\bwp_cron|wp_schedule_event|cron job\b/, /\brest (api|route|endpoint)\b/, /\bregister_rest_route\b/, /\b(gutenberg|block editor|block\.json|classic editor)\b/, /\bmultisite\b/, /\b(i18n|l10n|internationali[sz]ation|localis|localiz)/, /\btext domain\b/, /\b(custom post type|taxonom(y|ies))\b/],
+    notes: [
+      "Hooks: register on the documented hook, not on `init` by default; respect priority and accepted-args counts.",
+      "i18n: every user-facing string goes through a translation function with this plugin's or theme's own text domain, and translator comments accompany any placeholder.",
+      "Never edit WordPress core files. Extend through hooks, filters, and the documented APIs.",
+    ],
+  },
+  {
+    name: "woocommerce",
+    signals: [/\bwoo ?commerce\b/, /\bwc_[a-z_]+\b/, /\b(cart|checkout|order|coupon|shipping (zone|method)|payment gateway)\b/, /\b(product|variation) (type|attribute|field)s?\b/, /\bsubscription(s)? plugin\b/, /\bmembership(s)?\b/, /\bhpos|high[- ]performance order storage\b/],
+    notes: [
+      "WooCommerce: prefer CRUD objects (`wc_get_order`, `$order->save()`) over direct post/meta access — HPOS makes post-table assumptions wrong.",
+      "Cart, checkout, and gateway work must survive a partial or retried request: make writes idempotent and never trust a client-supplied price or total.",
+      "Declare compatibility explicitly when a change touches order storage or the checkout block.",
+    ],
+  },
+  {
+    name: "elementor",
+    signals: [/\belementor\b/, /\bdynamic tag(s)?\b/, /\b(loop|theme) builder\b/, /\bregister_controls\b/, /\bpopup(s)?\b/],
+    notes: [
+      "Elementor: widgets register controls in `register_controls()` and render in `render()`; editor preview and front-end output must agree.",
+      "Escape every control value at output — control input is user input.",
+      "Register widgets and dynamic tags on Elementor's own hooks so the plugin degrades cleanly when Elementor is inactive.",
+    ],
+  },
+  {
+    name: "acf",
+    signals: [/\bacf\b/, /\badvanced custom fields\b/, /\b(flexible content|repeater|relationship field|options page)\b/, /\bget_field|the_field|have_rows\b/, /\bacf[- ]json\b/],
+    notes: [
+      "ACF: field definitions belong in version control via ACF JSON sync — do not rely on the database as the source of truth.",
+      "Guard every `get_field()` call for a missing plugin and a missing value; `have_rows()` loops must be reset.",
+      "Reference fields by key, not by label, and escape field output at render.",
+    ],
+  },
+  {
+    name: "wpforms",
+    signals: [/\bwp ?forms\b/, /\bform (validation|entry|submission)\b/, /\bconditional logic\b/, /\bmulti[- ]step form\b/],
+    notes: [
+      "WPForms: server-side validation is the real validation — conditional logic and client-side rules are a convenience, not a control.",
+      "Entry handlers must verify the nonce and the capability before acting, and sanitize every field on the way in.",
+    ],
+  },
+  {
+    name: "performance",
+    signals: [/\b(object cache|transient|autoload(ed)? options)\b/, /\b(redis|memcached|opcache)\b/, /\bwp[- ]rocket|litespeed|cloudflare\b/, /\b(slow|expensive|n\+1) quer(y|ies)\b/, /\bcore web vitals|lcp|cls|ttfb\b/],
+    notes: [
+      "Performance: measure before and after with the same method, and put the numbers in the report. An optimization without a measurement is a guess.",
+      "Cache with an explicit invalidation path. A cache nobody clears is a bug with a delay.",
+      "Watch autoloaded options: anything large or rarely read should not autoload.",
+    ],
+  },
+  {
+    name: "database",
+    signals: [/\bwp_(posts|postmeta|options|users|usermeta|terms|termmeta|term_relationships|comments|commentmeta)\b/, /\b(meta_query|tax_query|wp_query|get_posts)\b/, /\b\$wpdb\b/, /\bdbdelta\b/, /\bcustom table\b/, /\b(index|indexes|indices) on\b/, /\b(migration|backfill)\b/],
+    notes: [
+      "Database: use `$wpdb->prepare()` for every interpolated value — no exceptions, including ORDER BY built from input.",
+      "`meta_query` and `tax_query` do not scale; for hot paths prefer a custom table or an indexed column and say so in the report.",
+      "Schema changes go through `dbDelta()` with a version-gated upgrade routine, and must be safe to run twice.",
+    ],
+  },
+  {
+    name: "security",
+    signals: [/\bnonce(s)?\b/, /\bcurrent_user_can\b/, /\b(capability|capabilities) check\b/, /\b(escap(e|ing)|sanitiz(e|ation|ing))\b/, /\b(sql ?injection|xss|csrf|ssrf)\b/, /\b(auth(entication|orization))\b/],
+    notes: [
+      "Security: every state-changing request verifies a nonce AND a capability. A nonce alone is not authorization.",
+      "Sanitize on input, escape on output, at the point of output — late escaping, every time.",
+      "Never build SQL by concatenation; never trust `$_POST`, `$_GET`, `$_REQUEST`, or a REST payload unslashed.",
+    ],
+  },
+  {
+    name: "integrations",
+    signals: [/\b(stripe|paypal|mailchimp|hubspot|zapier|make\.com|n8n)\b/, /\b(openai|claude|anthropic|gemini) api\b/, /\b(aws|azure|s3|lambda)\b/, /\bwebhook(s)?\b/, /\bthird[- ]party api\b/],
+    notes: [
+      "Integrations: use `wp_remote_*` with an explicit timeout and full error handling — never cURL directly, never assume a 200.",
+      "Credentials come from constants or a secrets store, never from the repo, and never get logged.",
+      "Webhook endpoints authenticate the caller (signature or shared secret) and are idempotent on replay.",
+    ],
+  },
+  {
+    name: "hosting",
+    signals: [/\b(apache|nginx|php[- ]fpm)\b/, /\b(cpanel|plesk|cyberpanel|cloudways)\b/, /\b(digitalocean|ec2|lightsail)\b/, /\b(\.htaccess|vhost|server block)\b/],
+    notes: [
+      "Hosting: keep server configuration out of application logic; state the assumed stack in the report so the reviewer can check it against the real host.",
+    ],
+  },
+  {
+    name: "deployment",
+    signals: [/\b(ci\/cd|github actions|gitlab ci|bitbucket pipelines)\b/, /\bcomposer\b/, /\bbedrock\b/, /\b(deploy|deployment|rollback)\b/, /\b(backup|restore)\b/, /\bwp[- ]cli\b/],
+    notes: [
+      "Deployment: every change needs a stated rollback path and a database-migration story, or it is not deployable.",
+      "Never ship a step that writes to production without a backup taken in the same run.",
+    ],
+  },
+];
+
+/* ------------------------------------------------------------------ *
+ * The preamble — the standing instruction every WordPress brief carries,
+ * whichever implementer runs it. Print it with --print-preamble; suppress it
+ * with --no-preamble. Domain notes are appended only for detected domains, so
+ * the brief stays short.
+ * ------------------------------------------------------------------ */
+const PREAMBLE = `<wordpress_engineering_standards>
+You are implementing inside a WordPress codebase, as a senior WordPress engineer would. These
+standards hold for every task and outrank your own defaults where they conflict.
+
+Security is not a feature of the task; it is a property of every line.
+  - Verify a nonce AND a capability on every state-changing request. Neither alone is authorization.
+  - Sanitize on input, escape on output, at the point of output.
+  - Every interpolated SQL value goes through $wpdb->prepare(). No exceptions.
+  - Treat $_GET, $_POST, $_REQUEST, $_COOKIE and REST payloads as hostile, and unslash before sanitizing.
+
+Use the platform, do not fight it.
+  - Never edit core, and never edit a third-party plugin or theme in place. Extend through hooks,
+    filters, and the documented APIs; child themes for theme changes.
+  - Prefer an existing WordPress API to a hand-rolled equivalent (HTTP, filesystem, cron, options,
+    transients, REST). If you hand-roll one, say why in the report.
+  - Enqueue scripts and styles; do not print tags. Register on the documented hook.
+
+Write it so the next person can maintain it.
+  - Follow WordPress Coding Standards for the language in play, and match the file you are editing
+    over any general rule.
+  - Prefix every global function, class, constant, option, and hook name with the project's own prefix.
+  - No dead code, no speculative options, no abstraction without a second caller in this diff.
+
+Do not break what already works.
+  - Preserve backward compatibility for public hooks, filters, shortcodes, REST routes, and option
+    shapes. If a break is unavoidable, deprecate with a shim and call it out in the report.
+  - Assume the site has other plugins. Guard every dependency on one, and degrade cleanly when it is
+    absent or a different major version.
+  - State the minimum PHP and WordPress versions your change assumes if it is above the project's.
+
+Performance is measured, not asserted.
+  - Never query inside a loop when a single batched query will do; never add an unbounded query.
+  - Cache with an explicit invalidation path, and keep large values out of autoloaded options.
+
+Verification and reporting.
+  - Run the project's real gates and fix what they surface. Do not report a failure as done.
+  - Do NOT run git add or git commit. Leave the work uncommitted; the orchestrator reviews and commits.
+  - If a required fact about the site, stack, or plugin versions is missing, find it in the working
+    tree or state plainly that it is unknown. Do not guess and do not invent an API.
+</wordpress_engineering_standards>`;
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — route a WordPress brief to a sibling delegate\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    implementer: null,
+    lane: null,
+    strictRouting: false,
+    dryRun: false,
+    preamble: true,
+    readOnly: false,
+    session: null,
+    resumeLast: false,
+    timeout: null,
+    outDir: null,
+    implementerRelay: null,
+    passthrough: [],
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--list-routes":
+        process.stdout.write(renderRoutes());
+        process.exit(0);
+        break;
+      case "--print-preamble":
+        process.stdout.write(`${PREAMBLE}\n`);
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--implementer": opts.implementer = next(); break;
+      case "--lane": opts.lane = next(); break;
+      case "--strict-routing": opts.strictRouting = true; break;
+      case "--dry-run": opts.dryRun = true; break;
+      case "--no-preamble": opts.preamble = false; break;
+      case "--read-only": opts.readOnly = true; break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--timeout": opts.timeout = next(); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      case "--implementer-relay": opts.implementerRelay = resolve(next()); break;
+      case "--":
+        opts.passthrough = argv.slice(i + 1);
+        i = argv.length;
+        break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  if (opts.implementer !== null && !Object.hasOwn(IMPLEMENTERS, opts.implementer)) {
+    fail(`unknown --implementer "${opts.implementer}" (expected: ${Object.keys(IMPLEMENTERS).join(", ")})`);
+  }
+  if (opts.lane !== null && !laneByName(opts.lane)) {
+    fail(`unknown --lane "${opts.lane}" (expected: ${[...LANES, DEFAULT_LANE].map((l) => l.name).join(", ")})`);
+  }
+  // The sibling validates --timeout too, but it must be rejected here as well: this relay
+  // arms a backstop timer from the same value, and a malformed duration would otherwise fire
+  // on the next tick as a silent instant "timeout" before the sibling ever spoke.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  if (opts.session !== null && opts.resumeLast) {
+    fail("--session and --resume-last are mutually exclusive; pass only one");
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  // Whole-string match: "1mtypo" must be rejected, not read as one minute. The accepted range is
+  // exactly a sibling's, so a duration this relay forwards is never one the sibling then rejects.
+  // The backstop's own grace is clamped at schedule time rather than subtracted here, which would
+  // otherwise make the largest sibling-legal duration a usage error at this layer only.
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds = BigInt(match[1] || 0) * 3600n + BigInt(match[2] || 0) * 60n + BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function laneByName(name) {
+  return [...LANES, DEFAULT_LANE].find((l) => l.name === name) || null;
+}
+
+function renderRoutes() {
+  const lines = ["Lanes (first match wins on a tie — order is precedence):", ""];
+  for (const lane of [...LANES, DEFAULT_LANE]) {
+    lines.push(`  ${lane.name.padEnd(20)} -> ${lane.implementer}${lane.readOnly ? "  (read-only)" : ""}`);
+    lines.push(`  ${" ".repeat(20)}    ${lane.why}`);
+    lines.push("");
+  }
+  lines.push("Implementers:", "");
+  for (const [name, impl] of Object.entries(IMPLEMENTERS)) {
+    lines.push(`  ${name.padEnd(10)} ${impl.note}`);
+    lines.push(`  ${" ".repeat(10)} read-only: ${impl.readOnly ? impl.readOnly.join(" ") : "unsupported"}  ·  resume: ${impl.sessionFlag} <id>${impl.requiresModel ? "  ·  --model required" : ""}`);
+    lines.push("");
+  }
+  lines.push("Extend routing by adding a row to LANES in this file; nothing else knows the lane names.");
+  return `${lines.join("\n")}\n`;
+}
+
+/* ------------------------------------------------------------------ *
+ * Classification.
+ * ------------------------------------------------------------------ */
+function matchedSignals(signals, text) {
+  const hits = [];
+  for (const signal of signals) {
+    const found = signal.exec(text);
+    if (found) hits.push(found[0].trim());
+  }
+  return hits;
+}
+
+function detectDomains(text) {
+  return DOMAINS.filter((d) => d.signals.some((s) => s.test(text))).map((d) => d.name);
+}
+
+function classify(brief, opts) {
+  const text = brief.toLowerCase();
+  const domains = detectDomains(text);
+
+  if (opts.implementer && !opts.lane) {
+    return {
+      lane: "(forced)",
+      implementer: opts.implementer,
+      confidence: "forced",
+      why: "--implementer was given, so the lane table was not consulted.",
+      matchedSignals: [],
+      alternates: [],
+      domains,
+      laneReadOnly: false,
+    };
+  }
+
+  if (opts.lane) {
+    const lane = laneByName(opts.lane);
+    return {
+      lane: lane.name,
+      implementer: opts.implementer || lane.implementer,
+      confidence: "forced",
+      why: opts.implementer
+        ? `--lane and --implementer were both given; the lane's own target (${lane.implementer}) was overridden.`
+        : lane.why,
+      matchedSignals: matchedSignals(lane.signals, text),
+      alternates: [],
+      domains,
+      laneReadOnly: lane.readOnly,
+    };
+  }
+
+  const scored = LANES
+    .map((lane) => ({ lane, hits: matchedSignals(lane.signals, text) }))
+    .filter((entry) => entry.hits.length > 0);
+  // Stable sort by score keeps LANES order as the tie-break, which is deliberate:
+  // lane order encodes precedence, so a brief that trips security and performance
+  // alike is routed as security.
+  scored.sort((a, b) => b.hits.length - a.hits.length);
+
+  if (scored.length === 0) {
+    return {
+      lane: DEFAULT_LANE.name,
+      implementer: DEFAULT_LANE.implementer,
+      confidence: "none",
+      why: DEFAULT_LANE.why,
+      matchedSignals: [],
+      alternates: [],
+      domains,
+      laneReadOnly: DEFAULT_LANE.readOnly,
+    };
+  }
+
+  const [winner, ...rest] = scored;
+  const contested = rest.some((entry) => entry.hits.length === winner.hits.length);
+  const confidence = contested ? "contested" : winner.hits.length >= 2 ? "high" : "low";
+
+  // A read-only lane on one weak signal is the worst failure this router has: the run comes back
+  // with findings and an empty diff, and the caller who asked for a fix reads that as the
+  // implementer doing nothing. One mention of "nonce" in a bugfix brief is not an audit request, so
+  // a lone signal demotes to the implementation fallback rather than silently withholding writes.
+  // A tie is left alone — "contested" already names both lanes and asks.
+  if (winner.lane.readOnly && confidence === "low") {
+    return {
+      lane: DEFAULT_LANE.name,
+      implementer: DEFAULT_LANE.implementer,
+      confidence: "low",
+      why: `only one signal matched the read-only ${winner.lane.name} lane, which is too weak to withhold writes; treated as implementation work instead`,
+      matchedSignals: winner.hits,
+      alternates: [{ lane: winner.lane.name, implementer: winner.lane.implementer, score: winner.hits.length }],
+      domains,
+      laneReadOnly: false,
+    };
+  }
+
+  return {
+    lane: winner.lane.name,
+    implementer: winner.lane.implementer,
+    confidence,
+    why: winner.lane.why,
+    matchedSignals: winner.hits,
+    alternates: rest.slice(0, 3).map((entry) => ({
+      lane: entry.lane.name,
+      implementer: entry.lane.implementer,
+      score: entry.hits.length,
+    })),
+    domains,
+    laneReadOnly: winner.lane.readOnly,
+  };
+}
+
+function clarificationQuestion(routing) {
+  if (routing.confidence === "contested") {
+    const options = [routing.lane, ...routing.alternates.map((a) => a.lane)].join(" or ");
+    return `the brief matches several lanes equally (${options}); ask the user which one this task is, or pass --lane`;
+  }
+  if (routing.confidence === "low") {
+    return `only one weak signal matched (${routing.matchedSignals.join(", ") || "none"}); ask the user what kind of work this is, or pass --lane/--implementer`;
+  }
+  return "no lane signal matched; ask the user what kind of work this is, or pass --lane/--implementer";
+}
+
+function capabilityBlocker(routing, opts) {
+  // The two mismatches that would otherwise surface as a bare "unknown option" from the sibling,
+  // which reads like a bug in this relay rather than a property of the chosen CLI.
+  const impl = IMPLEMENTERS[routing.implementer];
+  if ((opts.readOnly || routing.laneReadOnly) && !impl.readOnly) {
+    return `${routing.implementer} has no read-only mode, so this run cannot be one` +
+      `${routing.laneReadOnly ? ` (lane ${routing.lane} is read-only by default)` : ""}. ` +
+      "Route to an implementer that has one (--implementer codex), or drop --read-only and rely on touchedFiles.";
+  }
+  if (impl.requiresModel && opts.model === null) {
+    return `${routing.implementer} requires an explicit model; pass --model <name> (lane ${routing.lane} routes here)`;
+  }
+  return null;
+}
+
+function composeBrief(brief, routing, opts) {
+  // A resumed session already carries the preamble in its context; re-sending it would
+  // spend tokens restating standards the implementer has already been given.
+  if (!opts.preamble || opts.session || opts.resumeLast) return brief;
+  const notes = DOMAINS.filter((d) => routing.domains.includes(d.name)).flatMap((d) => d.notes);
+  const blocks = [PREAMBLE];
+  if (notes.length) {
+    blocks.push([
+      "<domain_notes>",
+      `Detected in this brief: ${routing.domains.join(", ")}. These are a hint from a keyword scan, not`,
+      "a survey of the working tree — verify each against the actual code before relying on it.",
+      ...notes.map((n) => `  - ${n}`),
+      "</domain_notes>",
+    ].join("\n"));
+  }
+  blocks.push(brief.trim());
+  return `${blocks.join("\n\n")}\n`;
+}
+
+/* ------------------------------------------------------------------ *
+ * Dispatch.
+ * ------------------------------------------------------------------ */
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function resolveSiblingRelay(implementer, opts) {
+  if (opts.implementerRelay) return opts.implementerRelay;
+  // Siblings live beside this skill: skills/<x>-delegate/scripts/relay.mjs, and the Skills CLI
+  // preserves that layout when it installs the package into an agent directory.
+  return join(here, "..", "..", IMPLEMENTERS[implementer].dir, "scripts", "relay.mjs");
+}
+
+function killChild(child, signal = "SIGTERM") {
+  // The kill must reach the whole family: this relay's child is another relay, whose own child
+  // is the implementer CLI, whose children are its tools. Same idiom as every sibling relay.
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
+    catch { /* already gone — nothing left to kill */ }
+  } else {
+    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  // null (not []) when git can't report, so the caller can tell "git unavailable" apart from
+  // "the implementer changed nothing". Only used as a fallback: on any run where the sibling
+  // wrote a result, its own snapshot is the authoritative one.
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function prepareRunDir(opts, brief, routing) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-wordpress-${timestamp()}`);
+  const implOutDir = join(outDir, "implementer");
+  mkdirSync(implOutDir, { recursive: true });
+  const run = {
+    startedAt,
+    outDir,
+    implOutDir,
+    briefPath: join(outDir, "dispatched-brief.txt"),
+    resultPath: join(outDir, "result.json"),
+    implResultPath: join(implOutDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, composeBrief(brief, routing, opts), "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, routing, run, relayPath) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      workdir: opts.cd,
+      routing: {
+        lane: routing.lane,
+        implementer: routing.implementer,
+        confidence: routing.confidence,
+        reason: routing.why,
+        matchedSignals: routing.matchedSignals,
+        domains: routing.domains,
+        alternates: routing.alternates,
+        forced: routing.confidence === "forced",
+      },
+      implementer: routing.implementer,
+      implementerRelay: relayPath,
+      implementerResultPath: existsSync(run.implResultPath) ? run.implResultPath : null,
+      preamble: opts.preamble && !opts.session && !opts.resumeLast,
+      readOnly: opts.readOnly || routing.laneReadOnly,
+      model: opts.model,
+      session: opts.session,
+      resumeLast: opts.resumeLast,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file.
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function readImplementerResult(run) {
+  if (!existsSync(run.implResultPath)) return null;
+  try {
+    return JSON.parse(readFileSync(run.implResultPath, "utf8"));
+  } catch {
+    // A sibling killed mid-write leaves nothing parseable. Every sibling publishes atomically,
+    // so this is close to unreachable — but a corrupt file must not mask the run's outcome.
+    return null;
+  }
+}
+
+function liftSessionId(implResult) {
+  if (!implResult) return null;
+  return implResult.sessionId ?? implResult.threadId ?? implResult.conversationId ?? null;
+}
+
+function reportRelayMissing(opts, routing, run, relayPath) {
+  const writeResult = makeResultWriter(opts, routing, run, relayPath);
+  const result = writeResult({
+    status: "implementer_unavailable",
+    exitCode: 127,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: null,
+    implementerSession: null,
+    implementerResult: null,
+    error: `the ${routing.implementer}-delegate relay was not found at ${relayPath}; wordpress-delegate dispatches through its siblings and cannot run alone`,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(
+    `relay: ${routing.implementer}-delegate is not installed beside this skill.\n` +
+    `       Install it (npx skills add amElnagdy/delegate-skills --skill ${IMPLEMENTERS[routing.implementer].dir}),\n` +
+    `       or point --implementer-relay at its scripts/relay.mjs, or route elsewhere with --implementer.\n`,
+  );
+  process.exit(127);
+}
+
+function implementerFlags(routing, opts) {
+  // The only part of the sibling command line that differs by implementer: this relay's portable
+  // --read-only and --session are spelled in the chosen CLI's own terms. Exposed by --dry-run so
+  // the translation is inspectable without launching anything.
+  const impl = IMPLEMENTERS[routing.implementer];
+  const flags = [];
+  if ((opts.readOnly || routing.laneReadOnly) && impl.readOnly) flags.push(...impl.readOnly);
+  if (opts.session !== null) flags.push(impl.sessionFlag, opts.session);
+  if (opts.resumeLast) flags.push("--resume-last");
+  return flags;
+}
+
+function buildSiblingArgv(relayPath, opts, routing, run) {
+  const argv = [relayPath, "--brief", run.briefPath, "--cd", opts.cd, "--out-dir", run.implOutDir];
+  if (opts.timeout !== null) argv.push("--timeout", opts.timeout);
+  if (opts.model !== null) argv.push("--model", opts.model);
+  argv.push(...implementerFlags(routing, opts));
+  argv.push(...opts.passthrough);
+  return argv;
+}
+
+function dispatchToSibling(opts, routing, run, relayPath, writeResult) {
+  const argv = buildSiblingArgv(relayPath, opts, routing, run);
+  // The sibling is a Node script, so it is launched with this process's own interpreter —
+  // no PATH lookup, no shell, and no Windows .cmd shim to resolve. detached on POSIX so the
+  // sibling leads its own process group and killChild can fell the whole family.
+  const child = spawn(process.execPath, argv, {
+    cwd: opts.cd,
+    stdio: ["ignore", "inherit", "inherit"],
+    detached: process.platform !== "win32",
+  });
+
+  let settled = false;
+  let backstopFired = false;
+  let aborting = null;
+  let backstopTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+
+  if (timeoutMs !== null) {
+    // Clamp rather than overflow: a delay past 2^31-1 ms wraps and fires on the next tick,
+    // which would report a 24-day budget as already spent.
+    const backstopMs = Math.min(timeoutMs + BACKSTOP_GRACE_MS, MAX_TIMER_MS);
+    backstopTimer = setTimeout(() => {
+      backstopFired = true;
+      killChild(child);
+      sigkillTimer = setTimeout(() => { if (!settled) killChild(child, "SIGKILL"); }, 10_000);
+    }, backstopMs);
+  }
+
+  const clearTimers = () => {
+    if (backstopTimer) clearTimeout(backstopTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // This relay's own death must still produce a result. Unlike a sibling, it does not have to
+  // synthesize one: it forwards the signal and lets the sibling write its own, then lifts it.
+  // The sibling refreshes its touched-files snapshot ~2s into its shutdown, so the grace window
+  // here is longer than that — cutting it short would publish a stale file list.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled || aborting) return;
+      aborting = sig;
+      clearTimers();
+      killChild(child);
+      sigkillTimer = setTimeout(() => { if (!settled) killChild(child, "SIGKILL"); }, SIBLING_SHUTDOWN_GRACE_MS);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimers();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      finalMessage: "",
+      touchedFiles: gitTouchedFiles(opts.cd),
+      implementerSession: null,
+      implementerResult: null,
+      error: `could not launch the ${routing.implementer}-delegate relay: ${String(err && err.message ? err.message : err)}`,
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearTimers();
+    // A descendant that ignored SIGTERM must not outlive the report.
+    if (backstopFired || aborting) killChild(child, "SIGKILL");
+
+    const implResult = readImplementerResult(run);
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+
+    // The sibling's own result is the authority whenever it managed to write one: it saw the
+    // implementer's exit, its final message, and the working tree at the right moment. This
+    // relay only overrides the verdict where it did the killing and the sibling could not know.
+    let status;
+    let exitCode;
+    let error;
+    if (backstopFired) {
+      status = "timeout";
+      exitCode = mapped === 0 ? 1 : mapped;
+      error = `the ${routing.implementer}-delegate relay did not finish within --timeout ${opts.timeout} plus a ${BACKSTOP_GRACE_MS / 1000}s backstop; killed by the wordpress-delegate watchdog`;
+    } else if (aborting && (!implResult || implResult.status !== "aborted")) {
+      status = "aborted";
+      exitCode = 128 + (constants.signals[aborting] || 15);
+      error = `the relay was killed by ${aborting}; the ${routing.implementer}-delegate relay was terminated with it — inspect the working tree before re-dispatching`;
+    } else if (implResult) {
+      status = implResult.status;
+      exitCode = Number.isInteger(implResult.exitCode) ? implResult.exitCode : mapped;
+      error = implResult.error;
+    } else {
+      status = "failed";
+      exitCode = mapped === 0 ? 1 : mapped;
+      error = `the ${routing.implementer}-delegate relay exited ${mapped} without writing a result file; this is usually a usage error in the forwarded arguments — check the relay output above`;
+    }
+
+    const result = writeResult({
+      status,
+      exitCode,
+      signal: implResult?.signal ?? signal ?? null,
+      finalMessage: implResult?.finalMessage ?? "",
+      touchedFiles: implResult ? implResult.touchedFiles : gitTouchedFiles(opts.cd),
+      implementerSession: liftSessionId(implResult),
+      implementerResult: implResult,
+      ...(implResult?.stderrTail ? { stderrTail: implResult.stderrTail } : {}),
+      ...(error ? { error } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  wordpress → ${result.implementer}`);
+  lines.push(`routing: lane ${result.routing.lane} → ${result.routing.implementer} (confidence: ${result.routing.confidence})`);
+  lines.push(`  why: ${result.routing.reason}`);
+  if (result.routing.matchedSignals.length) lines.push(`  matched: ${result.routing.matchedSignals.join(", ")}`);
+  if (result.routing.domains.length) lines.push(`  domains: ${result.routing.domains.join(", ")}`);
+  if (result.routing.alternates.length) {
+    lines.push(`  runners-up: ${result.routing.alternates.map((a) => `${a.lane} (${a.score})`).join(", ")}`);
+  }
+  if (result.routing.confidence === "low" || result.routing.confidence === "none" || result.routing.confidence === "contested") {
+    lines.push("  note: routing was not confident. Re-read the diff against what the user actually asked for,");
+    lines.push("        and consider re-dispatching with --lane or --implementer.");
+  }
+  if (result.readOnly) lines.push("mode: read-only — the diff should be empty; verify touchedFiles, do not assume");
+  if (result.implementerSession) lines.push(`implementer session (resume with: --session ${result.implementerSession}): ${result.implementerSession}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push(`--- ${result.implementer} final report ---`);
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  if (result.implementerResultPath) lines.push(`implementer result: ${result.implementerResultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const routing = classify(brief, opts);
+
+  if (opts.strictRouting && ["low", "none", "contested"].includes(routing.confidence)) {
+    process.stderr.write(`relay: --strict-routing refused to dispatch — ${clarificationQuestion(routing)}\n`);
+    process.exit(3);
+  }
+
+  const blocker = capabilityBlocker(routing, opts);
+
+  // --dry-run reports the decision, including a blocker, rather than exiting on one: the point
+  // of the flag is to see where a brief would go, and "it would go to opencode, which needs a
+  // --model you did not pass" is exactly the answer being asked for.
+  if (opts.dryRun) {
+    process.stdout.write(`${JSON.stringify({
+      lane: routing.lane,
+      implementer: routing.implementer,
+      confidence: routing.confidence,
+      reason: routing.why,
+      matchedSignals: routing.matchedSignals,
+      domains: routing.domains,
+      alternates: routing.alternates,
+      readOnly: opts.readOnly || routing.laneReadOnly,
+      implementerFlags: implementerFlags(routing, opts),
+      clarification: ["low", "none", "contested"].includes(routing.confidence) ? clarificationQuestion(routing) : null,
+      blocker,
+    }, null, 2)}\n`);
+    process.exit(0);
+  }
+
+  if (blocker) fail(blocker);
+
+  const relayPath = resolveSiblingRelay(routing.implementer, opts);
+  const run = prepareRunDir(opts, brief, routing);
+
+  if (!existsSync(relayPath)) {
+    reportRelayMissing(opts, routing, run, relayPath);
+    return;
+  }
+
+  const writeResult = makeResultWriter(opts, routing, run, relayPath);
+  dispatchToSibling(opts, routing, run, relayPath, writeResult);
+}
+
+main();

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -1426,6 +1426,8 @@ for (const scenario of [
       "plugin-architecture", "codex", false],
     ["build a complex Elementor widget with custom controls and a dynamic tag for the loop builder",
       "elementor-widget", "codex", false],
+    ["add a dynamic block: registerBlockType with a block.json, InnerBlocks, and a render_callback",
+      "block-editor", "codex", false],
     ["performance pass: slow queries on the archive, 4MB of autoloaded options, object cache with redis",
       "performance", "codex", false],
   ];
@@ -1439,6 +1441,15 @@ for (const scenario of [
       decision?.confidence === "high" &&
       Array.isArray(decision?.matchedSignals) && decision.matchedSignals.length >= 2);
   }
+
+  // Signals are matched case-insensitively, so a table row written in the casing its ecosystem uses
+  // still fires. Without this a capital letter produces a signal that can never match, which is
+  // invisible: the lane just quietly scores lower than it should.
+  const cased = routed(["--dry-run"], "Register the GUTENBERG block with registerBlockType and theme.json");
+  check("wordpress routing: signals match regardless of the brief's casing",
+    cased.decision?.lane === "block-editor" &&
+    cased.decision.matchedSignals.some((s) => /GUTENBERG/.test(s)) &&
+    cased.decision.matchedSignals.some((s) => /registerBlockType/.test(s)));
 
   // A read-only lane winning on one weak signal would return findings and an empty diff to someone
   // who asked for a fix, and read as the implementer doing nothing. One mention of "nonce" in a

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -1451,6 +1451,14 @@ for (const scenario of [
     cased.decision.matchedSignals.some((s) => /GUTENBERG/.test(s)) &&
     cased.decision.matchedSignals.some((s) => /registerBlockType/.test(s)));
 
+  // A signal that can never fire is invisible — the lane just scores lower than it should. `\b@` is
+  // the trap: the boundary would have to sit between a non-word character and `@`, which is not a
+  // boundary, so a leading \b there matches only when glued to a word. Pin the package mention.
+  const pkg = routed(["--dry-run"], "Import the block from @wordpress/blocks and register it");
+  check("wordpress routing: an @wordpress package mention is a block-editor signal",
+    pkg.decision?.lane === "block-editor" &&
+    pkg.decision.matchedSignals.some((s) => s.startsWith("@wordpress/")));
+
   // A read-only lane winning on one weak signal would return findings and an empty diff to someone
   // who asked for a fix, and read as the implementer doing nothing. One mention of "nonce" in a
   // bugfix brief demotes to implementation rather than silently withholding writes.

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -47,8 +47,11 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi"];
-const binaryName = (skill) => skill === "qoder" ? "qodercli" : skill === "cursor" ? "cursor-agent" : skill;
+const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "wordpress"];
+// wordpress-delegate launches no CLI of its own — it dispatches through a sibling relay, so the
+// binary at the end of its chain is whichever implementer it routed to. EXTRA_ARGS pins it to
+// codex for the shared matrix, which is why it answers to codex's fake here.
+const binaryName = (skill) => skill === "qoder" ? "qodercli" : skill === "cursor" ? "cursor-agent" : skill === "wordpress" ? "codex" : skill;
 const relayPath = (skill) => join(here, "..", "skills", `${skill}-delegate`, "scripts", "relay.mjs");
 const WIN = process.platform === "win32";
 let failed = 0;
@@ -458,7 +461,9 @@ const emptyEffortRun = spawnSync(process.execPath,
 check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
 
 // opencode refuses a fresh run without an explicit model
-const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [], vibe: [], cursor: [], pi: [] };
+// wordpress-delegate routes by brief content; the shared smoke brief carries no WordPress signal,
+// so pin the implementer rather than letting the matrix depend on the router's default.
+const EXTRA_ARGS = { claude: [], codex: [], opencode: ["--model", "fake/model"], agy: [], grok: [], kimi: [], qoder: [], vibe: [], cursor: [], pi: [], wordpress: ["--implementer", "codex"] };
 
 // ---- Cursor's session/model controls and structured result ----
 {
@@ -1391,6 +1396,216 @@ for (const scenario of [
   if (exitCode !== 0) console.error(`claude chunked relay stderr:\n${stderr}`);
 }
 
+// ---- wordpress routing: the lane table, the flag translation, and the sibling boundary ----
+// This relay's own job is the routing decision, so the decision is what gets asserted. --dry-run
+// makes that testable without launching anything; the dispatch path below then proves the decision
+// survives the hand-off to a sibling.
+{
+  const routed = (args, briefText, extraEnv) => {
+    const file = join(scratch, `wp-brief-${Buffer.from(briefText).toString("hex").slice(0, 24)}.txt`);
+    writeFileSync(file, briefText);
+    const run = spawnSync(process.execPath, [relayPath("wordpress"), "--brief", file, ...args], {
+      env: { ...baseEnv, ...extraEnv }, encoding: "utf8", timeout: 15_000,
+    });
+    let decision = null;
+    try { decision = JSON.parse(run.stdout); } catch { /* left null: the check below reports it */ }
+    return { run, decision };
+  };
+
+  // One row per lane the table ships, phrased the way a WordPress task actually arrives.
+  const ROUTING_CASES = [
+    ["security audit of the checkout AJAX handlers: no nonce check, and I suspect SQL injection",
+      "security-audit", "grok", true],
+    ["research which payment gateway to use for subscriptions; compare the options with pros and cons",
+      "research", "grok", true],
+    ["write the documentation: update readme.txt, add a changelog entry and PHPDoc docblocks",
+      "documentation", "kimi", false],
+    ["large refactor: rename the legacy prefix across all files and migrate all helpers into a class",
+      "refactor-sweep", "opencode", false],
+    ["build a new custom plugin with PSR-4 autoloading, a service container, and an activation hook",
+      "plugin-architecture", "codex", false],
+    ["build a complex Elementor widget with custom controls and a dynamic tag for the loop builder",
+      "elementor-widget", "codex", false],
+    ["performance pass: slow queries on the archive, 4MB of autoloaded options, object cache with redis",
+      "performance", "codex", false],
+  ];
+  for (const [text, lane, implementer, readOnly] of ROUTING_CASES) {
+    const { run, decision } = routed(["--dry-run", "--model", "fake/model"], text);
+    check(`wordpress routing: "${lane}" → ${implementer}`,
+      run.status === 0 &&
+      decision?.lane === lane &&
+      decision?.implementer === implementer &&
+      decision?.readOnly === readOnly &&
+      decision?.confidence === "high" &&
+      Array.isArray(decision?.matchedSignals) && decision.matchedSignals.length >= 2);
+  }
+
+  // A read-only lane winning on one weak signal would return findings and an empty diff to someone
+  // who asked for a fix, and read as the implementer doing nothing. One mention of "nonce" in a
+  // bugfix brief demotes to implementation rather than silently withholding writes.
+  const weakAudit = routed(["--dry-run"], "fix the cart hook: the wc_get_order lookup is missing a nonce check");
+  check("wordpress routing: a read-only lane on one signal demotes to implementation, keeping writes",
+    weakAudit.run.status === 0 &&
+    weakAudit.decision?.lane === "implementation" &&
+    weakAudit.decision?.readOnly === false &&
+    weakAudit.decision?.confidence === "low" &&
+    weakAudit.decision?.alternates?.[0]?.lane === "security-audit" &&
+    /too weak to withhold writes/.test(weakAudit.decision?.reason ?? ""));
+
+  // Two signals is enough for the same lane to keep its read-only default.
+  const realAudit = routed(["--dry-run"], "security audit of the cart hook: no nonce check anywhere");
+  check("wordpress routing: two signals let the read-only lane stand",
+    realAudit.decision?.lane === "security-audit" && realAudit.decision?.readOnly === true);
+
+  // A brief with no lane signal must not silently pick a lane and pretend to be sure about it.
+  const vague = routed(["--dry-run"], "please make the thing better");
+  check("wordpress routing: an unroutable brief falls back with confidence \"none\" and a question",
+    vague.run.status === 0 &&
+    vague.decision?.lane === "implementation" &&
+    vague.decision?.confidence === "none" &&
+    typeof vague.decision?.clarification === "string" && vague.decision.clarification.length > 0);
+
+  // ... and --strict-routing turns that question into a refusal, before any artifact exists.
+  const strictOutDir = join(scratch, "out-wordpress-strict");
+  const strictBrief = join(scratch, "wp-strict-brief.txt");
+  writeFileSync(strictBrief, "please make the thing better");
+  const strict = spawnSync(process.execPath, [
+    relayPath("wordpress"), "--brief", strictBrief, "--out-dir", strictOutDir, "--strict-routing",
+  ], { env: baseEnv, encoding: "utf8", timeout: 15_000 });
+  check("wordpress routing: --strict-routing refuses with exit 3 and writes no artifacts",
+    strict.status === 3 && !existsSync(strictOutDir) && /strict-routing refused/.test(strict.stderr));
+
+  // An explicit --implementer bypasses the table entirely, and says so rather than inventing a lane.
+  const forced = routed(["--dry-run", "--implementer", "pi"],
+    "security audit of the checkout AJAX handlers: no nonce check, and I suspect SQL injection");
+  check("wordpress routing: --implementer overrides the table and is marked forced",
+    forced.run.status === 0 && forced.decision?.implementer === "pi" && forced.decision?.confidence === "forced");
+
+  // The portable --read-only must be spelled in each CLI's own terms, since three of them spell it
+  // differently and two cannot do it at all. A wrong translation surfaces as an unknown option from
+  // the sibling, which reads like a bug here rather than a property of that CLI.
+  const READ_ONLY_TRANSLATION = [
+    ["codex", ["--read-only"]],
+    ["claude", ["--read-only"]],
+    ["cursor", ["--read-only"]],
+    ["grok", ["--read-only"]],
+    ["opencode", ["--read-only"]],
+    ["pi", ["--read-only"]],
+    ["qoder", ["--permission-mode", "plan"]],
+    ["vibe", ["--plan-only"]],
+  ];
+  for (const [implementer, expected] of READ_ONLY_TRANSLATION) {
+    const { run, decision } = routed(["--dry-run", "--read-only", "--model", "fake/model", "--implementer", implementer],
+      "review the plugin bootstrap");
+    check(`wordpress routing: --read-only becomes "${expected.join(" ")}" for ${implementer}`,
+      run.status === 0 && JSON.stringify(decision?.implementerFlags) === JSON.stringify(expected));
+  }
+  for (const implementer of ["kimi", "agy"]) {
+    const { run } = routed(["--read-only", "--implementer", implementer], "review the plugin bootstrap");
+    check(`wordpress routing: --read-only is refused for ${implementer}, which has no such mode`,
+      run.status === 2 && /has no read-only mode/.test(run.stderr));
+  }
+  // Resume is the same problem: qoder spells it --resume, agy --conversation, everyone else --session.
+  const qoderResume = routed(["--dry-run", "--implementer", "qoder", "--session", "abc123"], "fix the shortcode");
+  const agyResume = routed(["--dry-run", "--implementer", "agy", "--session", "abc123"], "fix the shortcode");
+  check("wordpress routing: --session is spelled in the chosen CLI's own terms",
+    JSON.stringify(qoderResume.decision?.implementerFlags) === JSON.stringify(["--resume", "abc123"]) &&
+    JSON.stringify(agyResume.decision?.implementerFlags) === JSON.stringify(["--conversation", "abc123"]));
+
+  // opencode is the one sibling that rejects a run with no --model. Catch it here, where the message
+  // can name the lane that routed there, rather than letting the sibling exit 2 on its own.
+  const noModel = routed(["--dry-run"],
+    "large refactor: rename the legacy prefix across all files and migrate all helpers into a class");
+  check("wordpress routing: a missing --model for opencode is reported as a blocker, not a crash",
+    noModel.run.status === 0 && /requires an explicit model/.test(noModel.decision?.blocker ?? ""));
+
+  // The preamble is the other half of this skill: every brief carries the WordPress standards, and
+  // the domain notes are selected by what the router detected.
+  const preamble = spawnSync(process.execPath, [relayPath("wordpress"), "--print-preamble"], { encoding: "utf8" });
+  check("wordpress preamble: --print-preamble emits the standards block",
+    preamble.status === 0 &&
+    /wordpress_engineering_standards/.test(preamble.stdout) &&
+    /nonce AND a capability/.test(preamble.stdout) &&
+    /\$wpdb->prepare\(\)/.test(preamble.stdout) &&
+    /Do NOT run git add or git commit/.test(preamble.stdout));
+
+  // End to end through a real sibling: the decision must survive the hand-off, the composed brief
+  // must carry the preamble and the domain notes, and the sibling's result must be lifted intact.
+  {
+    const outDir = join(scratch, "out-wordpress-dispatch");
+    const workDir = freshRepo("work-wordpress-dispatch");
+    const wpBrief = join(scratch, "wp-dispatch-brief.txt");
+    writeFileSync(wpBrief, "Fix the WooCommerce checkout: the wc_get_order lookup in the cart hook is missing a nonce check.");
+    const run = spawnSync(process.execPath, [
+      relayPath("wordpress"), "--brief", wpBrief, "--cd", workDir, "--out-dir", outDir, "--implementer", "codex",
+    ], {
+      env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: join(scratch, "args-wordpress-dispatch") },
+      encoding: "utf8", timeout: 20_000,
+    });
+    const value = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+    const dispatched = existsSync(join(outDir, "dispatched-brief.txt"))
+      ? readFileSync(join(outDir, "dispatched-brief.txt"), "utf8") : "";
+    check("wordpress dispatch: the run completes through the sibling relay",
+      run.status === 0 && value.status === "completed" && value.implementer === "codex");
+    check("wordpress dispatch: the routing decision is recorded in result.json",
+      value.routing?.implementer === "codex" &&
+      value.routing?.forced === true &&
+      Array.isArray(value.routing?.domains) &&
+      value.routing.domains.includes("woocommerce") &&
+      value.routing.domains.includes("security"));
+    check("wordpress dispatch: the sibling's own result is embedded verbatim, not paraphrased",
+      value.implementerResult?.schema === "delegate-relay.result.v1" &&
+      value.implementerResult?.status === "completed" &&
+      value.implementerResultPath === join(outDir, "implementer", "result.json"));
+    check("wordpress dispatch: the composed brief carries the preamble, the detected domains, and the original text",
+      /wordpress_engineering_standards/.test(dispatched) &&
+      /<domain_notes>/.test(dispatched) &&
+      /HPOS makes post-table assumptions wrong/.test(dispatched) &&
+      /wc_get_order lookup in the cart hook/.test(dispatched));
+    if (run.status !== 0) console.error(`wordpress dispatch stderr:\n${run.stderr}`);
+  }
+
+  // A resumed session already holds the preamble; re-sending it would restate standards the
+  // implementer was given on the first pass.
+  {
+    const outDir = join(scratch, "out-wordpress-resume");
+    const workDir = freshRepo("work-wordpress-resume");
+    const wpBrief = join(scratch, "wp-resume-brief.txt");
+    writeFileSync(wpBrief, "Also escape the order id in the admin column.");
+    spawnSync(process.execPath, [
+      relayPath("wordpress"), "--brief", wpBrief, "--cd", workDir, "--out-dir", outDir,
+      "--implementer", "codex", "--session", "thread-1",
+    ], {
+      env: { ...baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: join(scratch, "args-wordpress-resume") },
+      encoding: "utf8", timeout: 20_000,
+    });
+    const dispatched = existsSync(join(outDir, "dispatched-brief.txt"))
+      ? readFileSync(join(outDir, "dispatched-brief.txt"), "utf8") : "";
+    check("wordpress dispatch: a resumed run sends the delta brief without the preamble",
+      dispatched.trim() === "Also escape the order id in the admin column." &&
+      existsSync(join(outDir, "result.json")) && result(outDir).preamble === false);
+  }
+
+  // The sibling boundary is this skill's one hard dependency, so its absence must be a named
+  // outcome with a result file — not an unhandled spawn error.
+  {
+    const outDir = join(scratch, "out-wordpress-missing-sibling");
+    const workDir = freshRepo("work-wordpress-missing-sibling");
+    const wpBrief = join(scratch, "wp-missing-brief.txt");
+    writeFileSync(wpBrief, "fix the shortcode output escaping");
+    const run = spawnSync(process.execPath, [
+      relayPath("wordpress"), "--brief", wpBrief, "--cd", workDir, "--out-dir", outDir,
+      "--implementer", "codex", "--implementer-relay", join(scratch, "no-such-relay.mjs"),
+    ], { env: baseEnv, encoding: "utf8", timeout: 15_000 });
+    const value = existsSync(join(outDir, "result.json")) ? result(outDir) : {};
+    check("wordpress: a missing sibling relay is implementer_unavailable at exit 127, with a result file",
+      run.status === 127 &&
+      value.status === "implementer_unavailable" &&
+      value.exitCode === 127 &&
+      /dispatches through its siblings/.test(value.error ?? ""));
+  }
+}
+
 // ---- 1. the watchdog fells the whole tree ----
 // Use agy's explicit watchdog here: this is the path that bounds a server-side hang
 // beyond agy's own --print-timeout, and it keeps the shared smoke fast.
@@ -1405,6 +1620,10 @@ const TIMEOUT_CASES = [
   { skill: "cursor", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "vibe", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "agy", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  // wordpress forwards --timeout to the sibling, which owns the kill, and arms a backstop a grace
+  // window later. The sibling must fire first: if the backstop is what fells the tree, the reported
+  // status is still "timeout" but the run overshot by a minute, which the deadline below catches.
+  { skill: "wordpress", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
 ];
 async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag) {
   const outDir = join(scratch, `out-${tag}-${skill}`);


### PR DESCRIPTION
**Claim:** none — no implementer is claimed here. This is not a new implementer skill, and that is the
one thing worth deciding before the code is read.

## This proposes a second *kind* of skill

`wordpress-delegate` launches no implementer CLI. It classifies a WordPress brief, prepends a
WordPress engineering preamble, and dispatches through a sibling's `relay.mjs`.

The four invariants hold, transitively — a separate CLI still edits a real working tree and the diff
is still the deliverable, nothing commits, Node built-ins only, and autonomy is still stated in the
chosen CLI's own terms because the sibling states it. But "one skill per implementer CLI" does not
describe it, so `CONTRIBUTING.md` gains a **Domain skills** section with three extra rules:

- **It launches no implementer CLI.** It shells out to `node` (the sibling) and `git`. A domain relay
  that grew its own version preflight, stream parser, or process-tree kill has forked the loop.
- **The sibling's result is the authority.** Contract fields are lifted, the sibling's own result is
  embedded verbatim, and the verdict is overridden only where the domain relay did the killing.
- **Routing is a table, and the table is the extension point.** One row per lane.

If you would rather this repo stayed one-skill-per-CLI, say so and I will close it — the skill is
self-contained and drops out cleanly. Everything below assumes the category is welcome.

## What ran

**Native Windows 11, `codex` 0.144.1, through `codex-delegate`** — a write run against a throwaway
plugin repo containing a deliberately unauthenticated, injectable AJAX handler. Routed by the table
(no `--implementer`), dispatched through the sibling, and the diff came back with
`check_ajax_referer` plus `current_user_can`, `wp_unslash`/`absint`, `$wpdb->prepare()` with
`%i`/`%d`/`%s`, `esc_html` at output, a text domain with a translator comment, and the
`wp_ajax_nopriv` registration dropped. None of that was in the brief — it is the preamble arriving at
the implementer. The thread id was lifted for resume, and the relay made no commit (the repo still
had one commit and a dirty tree afterwards).

**`node test/relay-smoke.mjs` — all green on native Windows.** `wordpress` enters the shared matrix
like every sibling (package shape, registration, syntax, atomic publish, the full `--timeout`
rejection matrix plus its positive control, and the whole-process-tree timeout kill). Routing gets
its own coverage, since routing is what this relay uniquely does:

- every shipped lane's decision, asserted on a brief phrased the way the task actually arrives
- the read-only demotion rule, and its two-signal counter-case
- the fallback's `confidence: "none"` and its clarification string
- `--strict-routing` refusing at exit 3 before any artifact exists
- `--read-only` and `--session` translated for all ten implementers, and refused for `kimi`/`agy`
- `opencode`'s missing `--model` reported as a blocker rather than a crash
- the preamble and the detected domain notes present in the composed brief
- a resumed run sending the delta brief *without* the preamble
- a missing sibling relay as `implementer_unavailable` at exit 127, with a result file
- a full dispatch with the sibling's result lifted intact

**Untested, and stated in the README's Verification status line:** only `codex` has been driven live
— `grok`, `kimi`, and `opencode` are contract-tested. The aborted path is POSIX-only in the suite and
has not been driven for this relay on any platform. No run against a real production WordPress site.

## Routing

Two tables at the top of `scripts/relay.mjs`.

**`LANES`** — what kind of work this is, and who gets it. Lanes score by distinct signal matches;
highest wins; **lane order breaks ties**, so a brief tripping both security and performance routes as
security.

| Lane | → | Why |
| --- | --- | --- |
| `security-audit` | `grok` (read-only) | adversarial reading, not editing; findings are the deliverable |
| `research` | `grok` (read-only) | breadth and a defended recommendation, not a diff |
| `documentation` | `kimi` | high-volume, low-branching prose |
| `refactor-sweep` | `opencode` | sustained context across files beats depth on any one |
| `plugin-architecture` | `codex` | structural decisions compound |
| `elementor-widget` | `codex` | the control/render/editor contract fails silently when wrong |
| `performance` | `codex` | measurement-driven, easy to get plausibly wrong |
| `implementation` (fallback) | `codex` | no lane signal dominated |

**`DOMAINS`** — what the work is *about* (WooCommerce, Elementor, ACF, WPForms, database, security,
integrations, hosting, deployment). Domains do not route. They select the preamble notes and are
recorded in the result so a reviewer can see what the router thought it was looking at.

One rule overrides the score, and it came out of a run that failed in review rather than from
design: **a read-only lane needs two signals to win.** "Fix the cart hook, it's missing a nonce
check" was routing to a read-only audit on the word *nonce* and would have returned findings with an
empty diff to someone who asked for a fix. It now demotes to `implementation`, keeps its writes, and
records `security-audit` in `alternates`.

Unknown tasks fall through with `confidence: "none"` and a `clarification` string;
`--strict-routing` turns that into exit 3 with the question to put to the user.

## Reading the relay

For the line-by-line read, the shape is: two data tables and a preamble constant at the top, then
`classify()`, then a dispatch path that is deliberately thin. Worth a second look:

- `killChild` / the SIGTERM handler — the cascade is wordpress → sibling → CLI → tools, each detached
  into its own group, and the grace window is longer than the sibling's own 2s touched-files refresh
  so a forwarded kill still publishes a complete snapshot.
- `parseDuration` — the accepted range is exactly a sibling's, so a duration this relay forwards is
  never one the sibling then rejects; the backstop's grace is clamped at schedule time instead.
- `--` passthrough — only flags meaning the same thing across implementers are modelled; anything
  CLI-specific goes after `--` and is that CLI's business.

## Second commit: `.gitignore`

`AGENTS.md` asks you to validate with `npx skills add .` before publishing; doing that inside the
repo drops a `.claude/` directory and a `skills-lock.json` that then show up as untracked forever.
Kept as its own commit (`ae0942c`) so it can be dropped or cherry-picked independently of the skill.
Only the two paths that actually appear are listed — the agent directory depends on which agent the
CLI detects, so the comment says to add yours rather than guessing at `.cursor/`, `.codex/` and the
rest. Say the word if you'd rather have it as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added WordPress task delegation with domain-aware routing to suitable implementation tools.
  - Added route inspection, dry-run execution, read-only audits, session resumption, and controlled dispatch options.
  - Added support for sequential multi-task workflows with review and commit guidance.

- **Documentation**
  - Expanded project and contributor documentation for domain skills, routing conventions, usage, verification, and review workflows.

- **Tests**
  - Added coverage for WordPress routing, dispatch behavior, flag handling, resumption, missing tools, and timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->