### PR TITLE
Harden delegate-setup discovery, validation, and lane lookup

### DIFF
--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -248,6 +248,13 @@ function validateLane(name, lane, label) {
     if (typeof lane[field] !== "string" || lane[field].length === 0) {
       return `${label}: lane ${name}.${field} must be a non-empty string`;
     }
+    // NUL rejected for every implementer, not just the ones with a character
+    // class: it survives trim(), so it validates and writes cleanly, then throws
+    // ERR_INVALID_ARG_VALUE out of spawn once the artifact directory already
+    // exists but before any result is written.
+    if (lane[field].includes("\0")) {
+      return `${label}: lane ${name}.${field} must not contain a null byte`;
+    }
     const valueError = validateDialValue(impl.key, field, lane[field], name, label);
     if (valueError) return valueError;
   }

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -16,6 +16,8 @@ import { delimiter, join, resolve } from "node:path";
 import { IMPLEMENTERS } from "./implementers.mjs";
 
 const PROBE_TIMEOUT_MS = 10_000;
+/** Generous for a version banner or model list, and bounded for a changelog dump. */
+const PROBE_MAX_BUFFER = 8 * 1024 * 1024;
 
 const HELP = `discover.mjs — probe PATH for installed implementer CLIs
 
@@ -74,7 +76,12 @@ function resolveBinary(binary) {
 }
 
 function needsWindowsShell(impl, binaryPath) {
-  return process.platform === "win32" && (impl.winShell || /\.(?:cmd|bat)$/i.test(binaryPath));
+  // impl.winShell describes how the RELAYS launch: they spawn a bare name and
+  // need the shell to find a .cmd shim. Discovery already resolved a full path,
+  // so only a real .cmd/.bat needs cmd.exe here - routing a native .exe through
+  // the shell would put every install path through quoteForCmd, which rejects
+  // the % and ! that are legal in Windows directory names.
+  return process.platform === "win32" && /\.(?:cmd|bat)$/i.test(binaryPath);
 }
 
 /** Quote a path for cmd.exe when shell:true; reject metacharacters. */
@@ -90,6 +97,13 @@ function runProbe(binaryPath, args, useShell) {
   return execFileSync(command, args, {
     encoding: "utf8",
     timeout: PROBE_TIMEOUT_MS,
+    // Without this the timeout is advisory: the default SIGTERM never escalates
+    // for a CLI that traps it for graceful shutdown, and spawnSync keeps
+    // blocking until the child decides to exit.
+    killSignal: "SIGKILL",
+    // Some version probes are inherently unbounded (agy's is `changelog`), and
+    // the 1 MiB default throws ENOBUFS, discarding a version that was on line 1.
+    maxBuffer: PROBE_MAX_BUFFER,
     stdio: ["pipe", "pipe", "pipe"],
     shell: useShell,
   });
@@ -97,15 +111,20 @@ function runProbe(binaryPath, args, useShell) {
 
 function probeVersion(impl, binaryPath) {
   const useShell = needsWindowsShell(impl, binaryPath);
+  const firstVersion = (raw) => {
+    const firstLine = (raw || "").trim().split(/\r?\n/, 1)[0].trim();
+    if (!firstLine) return null;
+    if (impl.versionFormat !== "colon-prefix") return firstLine;
+    return /^([^:\s]+):/.exec(firstLine)?.[1] ?? firstLine;
+  };
   const tryArgs = (versionArgs) => {
     try {
-      const raw = runProbe(binaryPath, versionArgs, useShell);
-      const firstLine = raw.trim().split(/\r?\n/, 1)[0].trim();
-      if (!firstLine) return null;
-      if (impl.versionFormat !== "colon-prefix") return firstLine;
-      return /^([^:\s]+):/.exec(firstLine)?.[1] ?? firstLine;
-    } catch {
-      return null;
+      return firstVersion(runProbe(binaryPath, versionArgs, useShell));
+    } catch (error) {
+      // An over-large or timed-out probe still wrote the bytes we need: the
+      // version is on the first line. Recover it from the partial stdout rather
+      // than reporting null, which is indistinguishable from a broken install.
+      return typeof error.stdout === "string" ? firstVersion(error.stdout) : null;
     }
   };
   let version = tryArgs(impl.versionArgs);
@@ -135,9 +154,13 @@ function probeAuth(impl, binaryPath) {
     return true;
   } catch (error) {
     if (impl.authProbe.jsonField) {
-      const combined = `${error.stdout || ""}${error.stderr || ""}`;
-      if (combined.trim()) {
-        const parsed = readAuthField(combined, impl.authProbe.jsonField);
+      // Parse the streams separately. Concatenating them meant a single line of
+      // unrelated stderr - an update notice, a Node warning - made the whole
+      // string invalid JSON, degrading a real `false` into "unknown". The
+      // logged-out answer arrives on a non-zero exit, so this is the common path.
+      for (const stream of [error.stdout, error.stderr]) {
+        if (typeof stream !== "string" || !stream.trim()) continue;
+        const parsed = readAuthField(stream, impl.authProbe.jsonField);
         if (parsed !== null) return parsed;
       }
       return null;

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -42,6 +42,10 @@ function resolveBinary(binary) {
   const pathEntries = pathValue
     .split(delimiter)
     .map((entry) => entry.replace(/^"(.*)"$/, "$1"))
+    // An empty component means the current directory in POSIX lookup, which is
+    // where a relay's own spawn would find the binary. Dropping it made
+    // discovery report a CLI as missing that dispatch can actually run.
+    .map((entry) => (entry.length === 0 && process.platform !== "win32" ? "." : entry))
     .filter((entry) => entry.length > 0);
 
   if (process.platform === "win32") {

--- a/skills/delegate-setup/scripts/lane.mjs
+++ b/skills/delegate-setup/scripts/lane.mjs
@@ -58,7 +58,10 @@ export function resolveLaneForRelay(cwd, laneName, implementerKey) {
         "fix or remove it, then approve it with delegate-setup before dispatch",
     );
   }
-  const entry = effective.lanes[laneName];
+  // Own properties only: LANE_NAME admits `toString`, `constructor`, `valueOf`
+  // and friends, and a plain-object map answers those off Object.prototype, so
+  // the not-found guard was skipped and the mismatch branch died on a TypeError.
+  const entry = Object.hasOwn(effective.lanes, laneName) ? effective.lanes[laneName] : undefined;
   if (!entry) {
     throw new Error(`fleet lane not found: ${laneName}`);
   }
@@ -122,38 +125,6 @@ function normalizeDials(implementerKey, raw) {
   return dials;
 }
 
-/**
- * Apply resolved dials onto relay opts. `flagged` lists fields set by CLI flags.
- */
-export function mergeDials(opts, dials, flagged) {
-  for (const [field, value] of Object.entries(dials)) {
-    if (flagged.has(field)) continue;
-    // read-only / sandbox / agent / autonomy often share a flag surface
-    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
-    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) {
-      continue;
-    }
-    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
-    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
-    if (
-      field === "planOnly" &&
-      (flagged.has("planOnly") || flagged.has("readOnly") || flagged.has("fullAccess"))
-    ) {
-      continue;
-    }
-    if (
-      field === "readOnly" &&
-      (flagged.has("readOnly") ||
-        flagged.has("dangerouslySkipPermissions") ||
-        flagged.has("fullAccess"))
-    ) {
-      continue;
-    }
-    if (field === "force" && flagged.has("force")) continue;
-    opts[field] = value;
-  }
-}
-
 function parseResolveArgs(argv) {
   let cwd = process.cwd();
   let lane = null;
@@ -162,7 +133,9 @@ function parseResolveArgs(argv) {
     const arg = argv[i];
     const next = () => {
       const value = argv[++i];
-      if (value === undefined) fail(`${arg} requires a value`);
+      // Same rule as the relays that spawn this: an empty value is not a value,
+      // it just reads as "flag omitted" at the use site.
+      if (value === undefined || value === "") fail(`${arg} requires a value`);
       return value;
     };
     if (arg === "--cwd") cwd = resolvePath(next());

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -1720,6 +1720,20 @@ if (WIN) {
   // Keep fixtures inside the repo tree so sandboxed CI/dev runs can write; seed a
   // minimal .git without `git init` (hooks/config writes are often blocked).
   const fleetRoot = mkdtempSync(join(here, "..", ".tmp-fleet-smoke-"));
+  // Same minimal seed, reusable. `git init` would contradict the note above, and
+  // an unchecked failure is worse than noisy: the fixture would not be a repo,
+  // rev-parse would resolve to the ENCLOSING checkout, and a project write would
+  // land .delegate/config.json in it.
+  const seedRepo = (dir) => {
+    mkdirSync(join(dir, ".git", "objects"), { recursive: true });
+    mkdirSync(join(dir, ".git", "refs", "heads"), { recursive: true });
+    writeFileSync(join(dir, ".git", "HEAD"), "ref: refs/heads/master\n");
+    writeFileSync(
+      join(dir, ".git", "config"),
+      "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = false\n",
+    );
+    return dir;
+  };
   const cfgHome = join(fleetRoot, "home");
   const cfgRepo = join(fleetRoot, "repo");
   const bare = join(fleetRoot, "bare");
@@ -2497,7 +2511,7 @@ if (WIN) {
     // enclosing checkout instead, leaving this .delegate unread.
     const brokenRepo = join(fleetRoot, "broken-project-repo");
     mkdirSync(join(brokenRepo, ".delegate"), { recursive: true });
-    spawnSync("git", ["init", "-q", brokenRepo], { encoding: "utf8" });
+    seedRepo(brokenRepo);
     writeFileSync(join(brokenRepo, ".delegate", "config.json"), "not json at all");
     const brokenLoad = spawnSync(
       process.execPath,
@@ -2538,7 +2552,7 @@ if (WIN) {
     // like a bad project file, not escape and take the global lanes down.
     const trustRepo = join(fleetRoot, "trust-marker-repo");
     mkdirSync(trustRepo, { recursive: true });
-    spawnSync("git", ["init", "-q", trustRepo], { encoding: "utf8" });
+    seedRepo(trustRepo);
     const trustProjectSrc = join(fleetRoot, "trust-marker-project.json");
     writeFileSync(trustProjectSrc, `${JSON.stringify({
       version: "delegate-fleet.v1",
@@ -2588,7 +2602,7 @@ if (WIN) {
       const spacedRepo = join(fleetRoot, "trailing space repo ");
       const sibling = join(fleetRoot, "trailing space repo");
       mkdirSync(spacedRepo, { recursive: true });
-      spawnSync("git", ["init", "-q", spacedRepo], { encoding: "utf8" });
+      seedRepo(spacedRepo);
       const spacedSrc = join(fleetRoot, "spaced-project.json");
       writeFileSync(spacedSrc, `${JSON.stringify({
         version: "delegate-fleet.v1",
@@ -2691,11 +2705,7 @@ if (WIN) {
     if (!WIN) {
       const gitRepo = join(fleetRoot, "git-ctx-repo");
       mkdirSync(gitRepo);
-      spawnSync("git", ["init", "-q", gitRepo], { encoding: "utf8" });
-      spawnSync("git", ["-C", gitRepo, "commit", "-q", "--allow-empty", "-m", "i"], {
-        encoding: "utf8",
-        env: { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" },
-      });
+      seedRepo(gitRepo);
 
       // Global `guard` lane is write-capable; the trusted project lane replacing it
       // is read-only. If git detection degrades, the global lane must NOT take over.

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -87,8 +87,14 @@ const alive = (pid) => {
 // the one thing a hard-coded list cannot catch is its own omission.
 {
   const skillsDir = join(here, "..", "skills");
-  const onDiskDelegate = readdirSync(skillsDir).filter((d) => d.endsWith("-delegate")).sort();
-  const onDiskUtility = readdirSync(skillsDir).filter((d) => UTILITY_SKILLS.includes(d)).sort();
+  // Directories only, read once. A stray file under skills/ (a .DS_Store, an
+  // editor swap file) says nothing about skill registration, and letting one
+  // red the suite reports a packaging defect that is not there.
+  const skillDirs = readdirSync(skillsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+  const onDiskDelegate = skillDirs.filter((d) => d.endsWith("-delegate")).sort();
+  const onDiskUtility = skillDirs.filter((d) => UTILITY_SKILLS.includes(d)).sort();
   const registered = new Set(
     JSON.parse(readFileSync(join(here, "..", "skills.sh.json"), "utf8"))
       .groupings.flatMap((g) => g.skills),
@@ -118,13 +124,11 @@ const alive = (pid) => {
   check("smoke matrix has no entry without a directory", SKILLS.every((s) => onDiskDelegate.includes(`${s}-delegate`)));
   check(
     "skills.sh.json has no entry without a directory",
-    [...registered].every((s) => existsSync(join(skillsDir, s))),
+    [...registered].every((s) => skillDirs.includes(s)),
   );
   check(
     "no unexpected skill directories",
-    readdirSync(skillsDir).every(
-      (d) => d.endsWith("-delegate") || UTILITY_SKILLS.includes(d),
-    ),
+    skillDirs.every((d) => d.endsWith("-delegate") || UTILITY_SKILLS.includes(d)),
   );
 }
 
@@ -2305,6 +2309,15 @@ if (WIN) {
         effective?.lanes?.feature?.effort === "high" &&
         effective?.projectTrusted === true,
     );
+    // The half that makes it a REPLACE rather than a merge: the global lane of
+    // this name also set model and variant, and neither may survive. Asserting
+    // only the project's own fields passes just as happily under a field-level
+    // merge, which would silently carry a global dial into a project lane.
+    check(
+      "whole-lane replace drops the global lane's other dials",
+      effective?.lanes?.feature?.model === undefined &&
+        effective?.lanes?.feature?.variant === undefined,
+    );
     check(
       "effective tests lane falls through to global",
       effective?.lanes?.tests?.implementer === "grok" && effective?.lanes?.tests?.source === "global",
@@ -2659,7 +2672,7 @@ if (WIN) {
     for (const implementer of ["agy", "kimi", "qoder"]) {
       writeFileSync(nulLane, JSON.stringify({
         version: "delegate-fleet.v1",
-        lanes: { x: { implementer, model: "a b" } },
+        lanes: { x: { implementer, model: "a\u0000b" } },
       }));
       const nulValidate = spawnSync(
         process.execPath,

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -1715,6 +1715,27 @@ if (WIN) {
     );
     rmSync(join(probeDir, "claude"), { force: true });
     rmSync(join(probeDir, "claude.impl.mjs"), { force: true });
+
+    // An empty PATH component is the current directory in POSIX lookup, so a
+    // relay's spawn would find a binary there. Discovery must agree, or it
+    // reports a CLI as missing that dispatch can actually run.
+    const cwdProbe = join(scratch, "discover-cwd");
+    mkdirSync(cwdProbe);
+    writeFileSync(
+      join(cwdProbe, "codex"),
+      '#!/bin/sh\ncase "$1" in --version) echo "9.9.9"; exit 0;; esac\nexit 0\n',
+    );
+    chmodSync(join(cwdProbe, "codex"), 0o755);
+    const cwdDiscover = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+      encoding: "utf8",
+      cwd: cwdProbe,
+      env: { ...process.env, PATH: `${delimiter}${probeDir}` },
+    });
+    const cwdReport = cwdDiscover.status === 0 ? JSON.parse(cwdDiscover.stdout) : null;
+    check(
+      "discover honours an empty PATH component as the current directory",
+      cwdReport?.discovered.find((d) => d.key === "codex")?.version === "9.9.9",
+    );
   }
 
   // Keep fixtures inside the repo tree so sandboxed CI/dev runs can write; seed a

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -2634,6 +2634,44 @@ if (WIN) {
       );
     }
 
+    // Uses `bare`, not cfgRepo: the read-path tests above deliberately leave
+    // cfgRepo's project config unreadable, so resolve there fails closed first.
+    // A lane name that exists on Object.prototype must report "not found", not
+    // crash: LANE_NAME admits toString/constructor/valueOf, and a plain-object
+    // lane map answers those through the prototype chain.
+    for (const inherited of ["toString", "constructor", "valueOf", "hasOwnProperty"]) {
+      const proto = spawnSync(
+        process.execPath,
+        [join(setupDir, "lane.mjs"), "resolve", "--cwd", bare, "--lane", inherited, "--implementer", "codex"],
+        { encoding: "utf8", env: process.env },
+      );
+      check(
+        `lane resolve reports "${inherited}" as not found rather than crashing`,
+        proto.status === 2 &&
+          /fleet lane not found/.test(proto.stderr) &&
+          !/Cannot read properties|TypeError/.test(proto.stderr),
+      );
+    }
+
+    // A NUL survives trim(), so it validated and wrote cleanly, then threw out of
+    // spawn after the artifact directory existed but before any result was written.
+    const nulLane = join(fleetRoot, "nul-lane.json");
+    for (const implementer of ["agy", "kimi", "qoder"]) {
+      writeFileSync(nulLane, JSON.stringify({
+        version: "delegate-fleet.v1",
+        lanes: { x: { implementer, model: "a b" } },
+      }));
+      const nulValidate = spawnSync(
+        process.execPath,
+        [join(setupDir, "config.mjs"), "validate", nulLane],
+        { encoding: "utf8", env: process.env },
+      );
+      check(
+        `config validate rejects a null byte in a ${implementer} model dial`,
+        nulValidate.status === 2 && /null byte/.test(nulValidate.stderr),
+      );
+    }
+
     // Git-context classification. Shims are shell scripts, so POSIX only; the
     // behaviour they guard (never silently swap a project lane for a global one)
     // is platform-independent.

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -1649,6 +1649,70 @@ if (WIN) {
     agyReport?.discovered.find(({ key }) => key === "agy")?.version === "1.2.3",
   );
 
+  // Probe hardening. These fixtures trap signals and emit megabytes, which needs
+  // a real interpreter, so POSIX only; the behaviour they pin is platform-neutral.
+  if (!WIN) {
+    const probeDir = join(scratch, "discover-probes");
+    mkdirSync(probeDir);
+    // PATH is deliberately just probeDir, so the fixture cannot reach a real CLI.
+    // That also means no interpreter lookup: exec node by absolute path from a
+    // /bin/sh stub rather than via `env node`.
+    const writeProbe = (name, body) => {
+      const script = join(probeDir, `${name}.impl.mjs`);
+      writeFileSync(script, body);
+      const p = join(probeDir, name);
+      writeFileSync(p, `#!/bin/sh\nexec "${process.execPath}" "${script}" "$@"\n`);
+      chmodSync(p, 0o755);
+      return p;
+    };
+    const runDiscover = () => {
+      const r = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+        encoding: "utf8",
+        env: { ...process.env, PATH: probeDir },
+      });
+      return r.status === 0 ? JSON.parse(r.stdout) : null;
+    };
+    const entry = (report, key) => report?.discovered.find((d) => d.key === key);
+
+    // A CLI that traps SIGTERM: without killSignal the timeout never escalates.
+    writeProbe("kimi", 'process.on("SIGTERM",()=>{});setTimeout(()=>process.exit(0),45000);\n');
+    const wedgedStart = Date.now();
+    const wedgedReport = runDiscover();
+    const wedgedElapsed = Date.now() - wedgedStart;
+    check(
+      "discover bounds a CLI that ignores SIGTERM",
+      wedgedReport !== null && wedgedElapsed < 30_000,
+    );
+    rmSync(join(probeDir, "kimi"), { force: true });
+    rmSync(join(probeDir, "kimi.impl.mjs"), { force: true });
+
+    // Version on line 1, then more output than the probe buffer holds.
+    writeProbe(
+      "agy",
+      'process.stdout.write("1.2.3: latest\\n");const b="x".repeat(1024*1024);for(let i=0;i<9;i++)process.stdout.write(b);\n',
+    );
+    check(
+      "discover recovers a version from output that overruns the probe buffer",
+      entry(runDiscover(), "agy")?.version === "1.2.3",
+    );
+    rmSync(join(probeDir, "agy"), { force: true });
+    rmSync(join(probeDir, "agy.impl.mjs"), { force: true });
+
+    // Logged-out answer on stdout, unrelated notice on stderr, non-zero exit.
+    writeProbe(
+      "claude",
+      'if(process.argv[2]==="--version"){console.log("1.0.0");process.exit(0)}\n' +
+        'console.error("npm notice: update available");\n' +
+        'console.log(JSON.stringify({loggedIn:false}));\nprocess.exit(1);\n',
+    );
+    check(
+      "discover reports authenticated false despite stderr noise",
+      entry(runDiscover(), "claude")?.authenticated === false,
+    );
+    rmSync(join(probeDir, "claude"), { force: true });
+    rmSync(join(probeDir, "claude.impl.mjs"), { force: true });
+  }
+
   // Keep fixtures inside the repo tree so sandboxed CI/dev runs can write; seed a
   // minimal .git without `git init` (hooks/config writes are often blocked).
   const fleetRoot = mkdtempSync(join(here, "..", ".tmp-fleet-smoke-"));


### PR DESCRIPTION
Stacked on #37. Targets `feature/delegate-setup-lanes` because `discover.mjs`, `config.mjs`, and `lane.mjs` do not exist on `master` — #37 introduces them. Retarget to `master` once #37 merges.

These are the robustness findings from the same audit that produced the security fixes already on #37. None of them silently escalates permission, which is why they were split out: #37 stays a reviewable security unit, and this stays small.

## What this fixes

**Discovery probes** (`discover.mjs`)
- `runProbe` had a timeout but no `killSignal`. `execFileSync` defaults to SIGTERM and `spawnSync` never escalates, so any CLI trapping SIGTERM for graceful shutdown made the 10s bound advisory — measured over 20s against it.
- No `maxBuffer`, so the 1 MiB default threw ENOBUFS on a large probe. Agy's version probe is `changelog`, whose whole job is to dump one. The version is on line 1, so it is now recovered from the partial stdout instead of reported as absent.
- `probeAuth` concatenated stdout and stderr before `JSON.parse`. The logged-out answer arrives on a non-zero exit, so one line of unrelated stderr turned a real `false` into `null`.
- `needsWindowsShell` keyed off `impl.winShell`, which describes how the *relays* launch (bare name, needs the shell to find a `.cmd` shim). Discovery already resolved a full path, so a native `.exe` went through `cmd.exe` and every install path through `quoteForCmd`, which rejects the `%` and `!` that are legal in Windows directory names.

**Validation** (`config.mjs`)
- A NUL survives `trim()`, so an agy/kimi/qoder `model` dial containing one validated, wrote, and resolved cleanly — then threw `ERR_INVALID_ARG_VALUE` out of `spawn` after the artifact directory existed but before any `result.json`. Rejected at the generic string boundary rather than by widening the per-relay character classes, since those three launch without a shell and legitimately accept model strings outside the Windows-shell-safe grammar.

**Lane lookup** (`lane.mjs`)
- `LANE_NAME` admits every `Object.prototype` key starting with a letter, and the lane map is a plain object, so `--lane toString` resolved to an inherited function: the not-found guard was skipped and the mismatch branch died on `Cannot read properties of undefined`. `IMPLEMENTER_BY_KEY` was already prototype-free; this lookup was missed.
- Removed `mergeDials`, which had zero callers repo-wide and had already drifted from the ten inline copies it appeared to be the source of truth for.

## Test corrections

Two existing checks passed against the behaviour they were meant to forbid:

- The whole-lane-replace check asserted only fields the *project* lane supplies — all of which hold under a field-level merge too. Mutating `effectiveLanes` into a merge produced byte-identical, all-green output. It now also asserts the global lane's other dials are gone.
- The skill-directory checks did not filter to directories, so a stray `.DS_Store` redded the suite under "no unexpected skill directories".

Fixture repositories now use the suite's documented minimal-`.git` seed instead of `git init`. Those calls also went unchecked — a failed `git init` leaves a non-repository, `rev-parse` resolves to the enclosing checkout, and a project write would land `.delegate/config.json` in the developer's own tree.

## Verification

- `node test/relay-smoke.mjs` green; `npx skills add . --list` green.
- Every fix carries a test proven to fail without it. Each was mutation-checked by reverting the fix in place and confirming the specific check goes red — including the field-level-merge regression the original whole-lane test survived.
- Probe fixtures are POSIX-only (they trap signals and emit megabytes); the behaviour they pin is platform-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to reject invalid lane, option, and model values before execution.
  - Prevented unsafe lane-name resolution from bypassing missing-lane checks.
  - Improved handling of command timeouts, partial output, oversized responses, and authentication output.
  - Corrected Windows shell detection for command-line tools.
  - Ensured replacing a lane removes inherited model and variant settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->