### PR TITLE
feat: ground lane proposals in evidence (grounding menu + Basis column + --usage)

### DIFF
--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -46,6 +46,8 @@ Example lane: **feature** → implementer `opencode`, model `opencode/grok`, var
 
 ## Flow
 
+`discover → load → grounding menu → propose (with Basis) → scope → approve → write`
+
 ### 1. Discover
 
 ```bash
@@ -72,14 +74,39 @@ Details: [references/setup-dialogue.md](references/setup-dialogue.md).
 
 ### 3. Propose
 
-Propose a compact set of lanes from discovery + what the user cares about. Starters when useful:
-`feature`, `tests`, `ui`, `fast`, `complex` — only for installed implementers.
+Discovery reports capability, never task fit. So ask **one** grounding question before proposing
+anything — one question, three options, not a wizard:
+
+> How should I pick the lanes? **(1) Quick defaults** — I decide, no questions.
+> **(2) Interview** — about four questions on how you want work allocated.
+> **(3) Usage scan** — I re-read your CLIs’ local session folders (counts and dates only, never the
+> conversations) and let the numbers pick your main lanes. Happy to do 2 and 3 together.
+
+- **Quick defaults** → propose immediately, and say plainly that the map is your opinion and cheap to
+  revise.
+- **Interview** → the four questions live in [references/setup-dialogue.md](references/setup-dialogue.md).
+  Ask about allocation policy, never about model rankings — ranking models is your job.
+- **Usage scan** → `node "<skill-dir>/scripts/discover.mjs" --usage`. Tell the user it is metadata
+  only before running it. Each discovered CLI gains `usage: { sessions, lastUsed }`; `null` means no
+  probe is wired — unknown, not unused.
+- **Both** → run the scan first, then ask only what the numbers cannot answer.
+- Inside a git repo, repo signals (languages, test weight, frontend share) are a fourth source of
+  evidence. They do not change the menu; they feed the proposal and the `repo` basis.
+
+Then propose the lanes. Name them after the work the user described; fall back to `feature`, `tests`,
+`ui`, `fast`, `complex`. Installed implementers only.
 
 Show:
 
-| Lane | Implementer | Model | Effort / variant | Source (if updating) |
-| --- | --- | --- | --- | --- |
-| feature | opencode | opencode/grok | variant: high | — |
+| Lane | Implementer | Model | Effort / variant | Basis | Source (if updating) |
+| --- | --- | --- | --- | --- | --- |
+| feature | opencode | opencode/grok | variant: high | your answer | — |
+| tests | codex | — | effort: medium | usage data | — |
+| ui | claude | sonnet | — | my opinion | — |
+
+**Basis** is mandatory on every lane: `your answer` / `usage data` / `repo` / `my opinion`. A lane you
+picked from model-quality priors is `my opinion` — never present it as something the tooling
+determined. “Installed and authenticated” is capability, not evidence of fit.
 
 Then the **complete** JSON (`version`: `delegate-fleet.v1`). One line of why per lane; flag auth or
 model uncertainty.

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -13,6 +13,48 @@ When loading existing config:
    that they cannot dispatch until the user approves a project write.
 5. Paste both raw JSON files only if the user asks.
 
+## Grounding the lane map
+
+Ask the grounding menu as **one** question with three options (quick defaults / interview / usage
+scan), then act on the answer. One question — never a wizard.
+
+### The four interview questions
+
+Allocation policy only. Users cannot rank model IDs — that is your job, not theirs.
+
+| # | Ask | What it settles |
+| --- | --- | --- |
+| 1 | What kind of work do you hand off most? | The main lane — and its **name**. “migrations”, “wp-plugin”, “bug triage” beat the canned `feature`/`tests`/`ui`/`fast`/`complex` five |
+| 2 | Which paid subscriptions should I burn, and which should I spare? | Quota economics. Discovery cannot see plans, limits, or what a run costs — only the user knows |
+| 3 | Any CLI you already trust, or one that has burned you? | Lived experience outranks your priors about the underlying models |
+| 4 | Default to fast and cheap, or slow and thorough? | Effort / variant dials, and who gets the `complex` lane |
+
+Stop at four. Skip any the usage scan already answered.
+
+### Reading a usage scan
+
+`node <skill-dir>/scripts/discover.mjs --usage` adds `usage` to each discovered CLI:
+`{ "sessions": <int>, "lastUsed": <ISO-8601 | null> }`, or `null`.
+
+- Say what it does **before** running it: it counts session files and reads their timestamps. It never
+  opens one, so no conversation content is read.
+- `usage: null` = no probe wired for that CLI, or no local state directory. Unknown, not unused —
+  never report it as zero.
+- Large disparities are honest evidence: 1600 codex sessions against 20 pi sessions tells you where
+  the user actually works. That earns the main lane.
+- Small differences are noise. 97 against 61 decides nothing — fall back to the interview or to your
+  opinion, and label it as such.
+- `lastUsed` weighs as much as the count. A big count that stopped months ago is a CLI the user moved
+  off; a recent date on a small count is one they are adopting.
+- Counts are lifetime totals for that machine, not “this month”, and only cover sessions the CLI still
+  keeps on disk.
+
+### Labelling the basis
+
+Give every proposed lane a Basis: `your answer`, `usage data`, `repo`, or `my opinion`. Use
+`my opinion` whenever the choice came from your own sense of which model is better at the work —
+including when discovery confirmed the CLI is installed and authenticated.
+
 ## Scope
 
 | User said / situation | Scope |

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -24,7 +24,7 @@ Allocation policy only. Users cannot rank model IDs — that is your job, not th
 
 | # | Ask | What it settles |
 | --- | --- | --- |
-| 1 | What kind of work do you hand off most? | The main lane — and its **name**. “migrations”, “wp-plugin”, “bug triage” beat the canned `feature`/`tests`/`ui`/`fast`/`complex` five |
+| 1 | What kind of work do you delegate most? | The main lane — and its **name**. “migrations”, “wp-plugin”, “bug triage” beat the canned `feature`/`tests`/`ui`/`fast`/`complex` five |
 | 2 | Which paid subscriptions should I burn, and which should I spare? | Quota economics. Discovery cannot see plans, limits, or what a run costs — only the user knows |
 | 3 | Any CLI you already trust, or one that has burned you? | Lived experience outranks your priors about the underlying models |
 | 4 | Default to fast and cheap, or slow and thorough? | Effort / variant dials, and who gets the `complex` lane |

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -315,13 +315,13 @@ function probeUsage(impl) {
   let lastUsed = 0;
   for (const dir of usageContainers(base, probe.path)) {
     for (const entry of readEntries(dir)) {
-      if (entry.isDirectory() !== (probe.entry === "dir")) continue;
+      if (probe.entry !== "any" && entry.isDirectory() !== (probe.entry === "dir")) continue;
       if (!probe.match.test(entry.name)) continue;
       sessions += 1;
       const entryPath = join(dir, entry.name);
       try {
         lastUsed = Math.max(lastUsed, statSync(entryPath).mtimeMs);
-        if (probe.entry === "dir") {
+        if (entry.isDirectory()) {
           // A directory's mtime does not advance when a file inside it grows, so a
           // resumed session would read as abandoned; stat the children too (never open them).
           for (const child of readEntries(entryPath)) {

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -318,8 +318,16 @@ function probeUsage(impl) {
       if (entry.isDirectory() !== (probe.entry === "dir")) continue;
       if (!probe.match.test(entry.name)) continue;
       sessions += 1;
+      const entryPath = join(dir, entry.name);
       try {
-        lastUsed = Math.max(lastUsed, statSync(join(dir, entry.name)).mtimeMs);
+        lastUsed = Math.max(lastUsed, statSync(entryPath).mtimeMs);
+        if (probe.entry === "dir") {
+          // A directory's mtime does not advance when a file inside it grows, so a
+          // resumed session would read as abandoned; stat the children too (never open them).
+          for (const child of readEntries(entryPath)) {
+            lastUsed = Math.max(lastUsed, statSync(join(entryPath, child.name)).mtimeMs);
+          }
+        }
       } catch {
         // Entry vanished mid-scan; the count still holds.
       }

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -4,6 +4,11 @@
  *
  * Usage:
  *   node discover.mjs           JSON report on stdout
+ *   node discover.mjs --usage   same report, plus a `usage` field per discovered CLI:
+ *                               { sessions, lastUsed } counted from that CLI's local
+ *                               session store, or null where no probe is wired.
+ *                               Metadata only — session entries are listed and stat'd,
+ *                               never opened, because they hold the user's conversations.
  *   node discover.mjs --help
  *
  * Exit 0 even when nothing is installed. Exit 2 on usage errors.
@@ -11,7 +16,7 @@
  */
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { accessSync, constants as fsConstants, readFileSync, statSync } from "node:fs";
+import { accessSync, constants as fsConstants, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 import { IMPLEMENTERS } from "./implementers.mjs";
@@ -22,6 +27,7 @@ const HELP = `discover.mjs — probe PATH for installed implementer CLIs
 
 Usage:
   node discover.mjs
+  node discover.mjs --usage
   node discover.mjs --help
 
 Prints JSON:
@@ -34,6 +40,11 @@ Prints JSON:
 authenticated is true | false | null (null = unknown / no probe).
 models.status is reported | aliases | unsupported | failed
 (aliases = curated aliases from the registry, not a live listing).
+
+--usage adds "usage" to each discovered entry:
+  { "sessions": <int>, "lastUsed": <ISO-8601 | null> }, or null when no usage probe
+  is wired or the CLI has no local state directory (null = unknown, not zero).
+It counts session entries and reads their mtimes; it never opens a session file.
 `;
 
 function resolveBinary(binary) {
@@ -260,12 +271,70 @@ function probeModels(impl, binaryPath) {
   }
 }
 
+/** Session containers under `base`; "*" matches any directory at that level. */
+function usageContainers(base, path) {
+  let dirs = [base];
+  for (const segment of path) {
+    const next = [];
+    for (const dir of dirs) {
+      for (const entry of readEntries(dir)) {
+        if (!entry.isDirectory()) continue;
+        if (segment !== "*" && entry.name !== segment) continue;
+        next.push(join(dir, entry.name));
+      }
+    }
+    dirs = next;
+  }
+  return dirs;
+}
+
+function readEntries(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * How much the user works in this CLI, from directory listings and mtimes only.
+ * Session files hold the user's conversations; none of them is ever opened.
+ */
+function probeUsage(impl) {
+  const probe = impl.usageProbe;
+  if (!probe) return null;
+  const base = (probe.envDir && process.env[probe.envDir]) || join(homedir(), probe.homeSubdir);
+  try {
+    if (!statSync(base).isDirectory()) return null;
+  } catch {
+    // No state directory at all: unknown, not zero.
+    return null;
+  }
+
+  let sessions = 0;
+  let lastUsed = 0;
+  for (const dir of usageContainers(base, probe.path)) {
+    for (const entry of readEntries(dir)) {
+      if (entry.isDirectory() !== (probe.entry === "dir")) continue;
+      if (!probe.match.test(entry.name)) continue;
+      sessions += 1;
+      try {
+        lastUsed = Math.max(lastUsed, statSync(join(dir, entry.name)).mtimeMs);
+      } catch {
+        // Entry vanished mid-scan; the count still holds.
+      }
+    }
+  }
+  return { sessions, lastUsed: lastUsed > 0 ? new Date(lastUsed).toISOString() : null };
+}
+
 function main(argv) {
   if (argv.includes("--help") || argv.includes("-h")) {
     process.stdout.write(HELP);
     process.exit(0);
   }
-  if (argv.length > 0) {
+  const withUsage = argv.includes("--usage");
+  if (argv.some((arg) => arg !== "--usage")) {
     process.stderr.write("discover.mjs: unexpected arguments. Use --help.\n");
     process.exit(2);
   }
@@ -279,7 +348,7 @@ function main(argv) {
       missing.push({ key: impl.key, binary: impl.binary, skill: impl.skill });
       continue;
     }
-    discovered.push({
+    const entry = {
       key: impl.key,
       skill: impl.skill,
       binary: impl.binary,
@@ -288,7 +357,9 @@ function main(argv) {
       authenticated: probeAuth(impl, binaryPath),
       supports: [...impl.supports],
       models: probeModels(impl, binaryPath),
-    });
+    };
+    if (withUsage) entry.usage = probeUsage(impl);
+    discovered.push(entry);
   }
 
   process.stdout.write(

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -4,6 +4,11 @@
  * One table: skill key → binary, launch hints, supported lane dials, probes.
  * Consumed by discover.mjs and config.mjs. Relays will share this in Phase 2.
  *
+ * `usageProbe.path` walks down from the CLI's state directory to the folders that
+ * hold session entries ("*" matches any directory at that level); `entry` + `match`
+ * say which names count as one session. Session files hold the user's conversations,
+ * so these are listed and stat'd only — never opened.
+ *
  * Node built-ins only. No network, credentials, or telemetry.
  */
 
@@ -28,6 +33,13 @@
  *     | { args: string[], format: "lines"|"cursor"|"grok"|"table" }
  *     | { envDir: string, homeSubdir: string, file: string, format: "codex-cache" }
  *     | { static: readonly string[] },
+ *   usageProbe: null | {
+ *     envDir?: string,
+ *     homeSubdir: string,
+ *     path: readonly string[],
+ *     entry: "file"|"dir",
+ *     match: RegExp,
+ *   },
  *   supports: Dial[],
  *   winShell: boolean,
  * }[]}
@@ -41,6 +53,14 @@ export const IMPLEMENTERS = Object.freeze([
     authProbe: { args: ["auth", "status"], jsonField: "loggedIn" },
     // No listing command; `--model` takes one of these aliases or a full model name.
     modelProbe: { static: ["fable", "opus", "sonnet", "haiku"] },
+    // <config>/projects/<project-slug>/<session-uuid>.jsonl — one file per session.
+    usageProbe: {
+      envDir: "CLAUDE_CONFIG_DIR",
+      homeSubdir: ".claude",
+      path: ["projects", "*"],
+      entry: "file",
+      match: /\.jsonl$/,
+    },
     supports: ["model", "effort", "timeout", "readOnly"],
     winShell: true,
   },
@@ -63,6 +83,15 @@ export const IMPLEMENTERS = Object.freeze([
       file: "models_cache.json",
       format: "codex-cache",
     },
+    // sessions/<yyyy>/<mm>/<dd>/rollout-*.jsonl. archived_sessions is a second
+    // store of the same shape; counting only live rollouts keeps one meaning per number.
+    usageProbe: {
+      envDir: "CODEX_HOME",
+      homeSubdir: ".codex",
+      path: ["sessions", "*", "*", "*"],
+      entry: "file",
+      match: /^rollout-.*\.jsonl$/,
+    },
     supports: ["model", "effort", "sandbox", "timeout", "readOnly"],
     winShell: true,
   },
@@ -75,6 +104,10 @@ export const IMPLEMENTERS = Object.freeze([
     // without one is the logged-out state, not an ambiguous miss.
     authProbe: { args: ["auth", "list"], successPattern: /^●\s/m, missMeansFalse: true },
     modelProbe: { args: ["models"], format: "lines" },
+    // No usage probe: the session files under ~/.local/share/opencode/storage stopped
+    // being written when OpenCode moved to opencode.db, and a session count from that
+    // database would mean opening conversation content.
+    usageProbe: null,
     // OpenCode reasoning intensity is --variant, not --effort.
     supports: ["model", "variant", "timeout", "readOnly"],
     winShell: true,
@@ -87,6 +120,13 @@ export const IMPLEMENTERS = Object.freeze([
     versionFormat: "colon-prefix",
     authProbe: null,
     modelProbe: { args: ["models"], format: "lines" },
+    // Antigravity keeps CLI state under ~/.gemini, one .db per conversation.
+    usageProbe: {
+      homeSubdir: ".gemini/antigravity-cli",
+      path: ["conversations"],
+      entry: "file",
+      match: /\.db$/,
+    },
     supports: ["model", "timeout"],
     winShell: false,
   },
@@ -98,6 +138,14 @@ export const IMPLEMENTERS = Object.freeze([
     versionFallbackArgs: ["--version"],
     authProbe: { args: ["models"], failPattern: /not authenticated/i },
     modelProbe: { args: ["models"], format: "grok" },
+    // sessions/<url-encoded-cwd>/<session-uuid>/ — one directory per session; the
+    // prompt_history.jsonl sitting beside them is per-workspace, not per-session.
+    usageProbe: {
+      homeSubdir: ".grok",
+      path: ["sessions", "*"],
+      entry: "dir",
+      match: /^[0-9a-f]{8}-[0-9a-f]{4}-/i,
+    },
     supports: ["model", "effort", "sandbox", "timeout", "readOnly"],
     winShell: true,
   },
@@ -110,6 +158,13 @@ export const IMPLEMENTERS = Object.freeze([
     // No credential-free listing exists: the provider-list JSON and the config file behind it
     // both inline provider api keys, and this script may not buffer credentials.
     modelProbe: null,
+    // sessions/<wd_workspace>/session_<uuid>/ — one directory per session.
+    usageProbe: {
+      homeSubdir: ".kimi-code",
+      path: ["sessions", "*"],
+      entry: "dir",
+      match: /^session_/,
+    },
     supports: ["model", "timeout"],
     winShell: false,
   },
@@ -120,6 +175,8 @@ export const IMPLEMENTERS = Object.freeze([
     versionArgs: ["--version"],
     authProbe: null,
     modelProbe: null,
+    // No documented local session store; usage stays unknown rather than guessed.
+    usageProbe: null,
     supports: ["model", "permissionMode", "timeout", "readOnly"],
     winShell: false,
   },
@@ -130,6 +187,7 @@ export const IMPLEMENTERS = Object.freeze([
     versionArgs: ["--version"],
     authProbe: null,
     modelProbe: null,
+    usageProbe: null,
     supports: ["timeout", "readOnly"],
     winShell: false,
   },
@@ -144,6 +202,14 @@ export const IMPLEMENTERS = Object.freeze([
       failPattern: /not logged in/i,
     },
     modelProbe: { args: ["models"], format: "cursor" },
+    // projects/<project-slug>/agent-transcripts/<chat-uuid>/ — what the CLI writes per
+    // chat. ~/.cursor/chats holds only a handful of older IDE-side entries.
+    usageProbe: {
+      homeSubdir: ".cursor",
+      path: ["projects", "*", "agent-transcripts"],
+      entry: "dir",
+      match: /^[0-9a-f]{8}-[0-9a-f]{4}-/i,
+    },
     // cursor-agent has no --sandbox; autonomy is --force / --read-only.
     supports: ["model", "force", "timeout", "readOnly"],
     winShell: true,
@@ -156,6 +222,13 @@ export const IMPLEMENTERS = Object.freeze([
     authProbe: null,
     // Must stay a flag: `pi models` is read as a prompt and hits the API.
     modelProbe: { args: ["--list-models"], format: "table" },
+    // ~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl.
+    usageProbe: {
+      homeSubdir: ".pi/agent",
+      path: ["sessions", "*"],
+      entry: "file",
+      match: /\.jsonl$/,
+    },
     supports: ["provider", "model", "timeout", "readOnly"],
     winShell: true,
   },

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -37,7 +37,7 @@
  *     envDir?: string,
  *     homeSubdir: string,
  *     path: readonly string[],
- *     entry: "file"|"dir",
+ *     entry: "file"|"dir"|"any",
  *     match: RegExp,
  *   },
  *   supports: Dial[],
@@ -203,11 +203,12 @@ export const IMPLEMENTERS = Object.freeze([
     },
     modelProbe: { args: ["models"], format: "cursor" },
     // projects/<project-slug>/agent-transcripts/<chat-uuid>/ — what the CLI writes per
-    // chat. ~/.cursor/chats holds only a handful of older IDE-side entries.
+    // chat; some layouts write flat <chat-uuid>.txt files instead, so accept either.
+    // ~/.cursor/chats holds only a handful of older IDE-side entries.
     usageProbe: {
       homeSubdir: ".cursor",
       path: ["projects", "*", "agent-transcripts"],
-      entry: "dir",
+      entry: "any",
       match: /^[0-9a-f]{8}-[0-9a-f]{4}-/i,
     },
     // cursor-agent has no --sandbox; autonomy is --force / --read-only.


### PR DESCRIPTION
Stacked on #44. Implements the propose-step redesign that came out of the first live test of `delegate-setup`.

## Why

Discovery reports **capability** (installed, auth, dials, model IDs) but zero **task-fit** signal. The orchestrator filled that gap with model-quality priors and presented them with false authority — in the live test, every lane assignment except one was opinion dressed as determination.

## What

**Basis column (mandatory).** Every proposed lane is labelled `your answer` / `usage data` / `repo` / `my opinion`. Opinion is allowed; disguised opinion is not.

**Grounding menu.** One question before proposing, three options — quick defaults (disclosed opinion, zero friction), a four-question allocation-policy interview (dominant work → lane names; subscriptions to burn vs spare; trusted/distrusted CLIs; fast-cheap vs slow-thorough — never model rankings, users can't rank model IDs), or a usage scan. Combining = scan first, ask less. In a git repo, repo signals are a fourth evidence source.

**`discover.mjs --usage`.** Metadata-only usage scan: `{ sessions, lastUsed }` per CLI from directory listings and mtimes. Session files are **never opened** — they hold the user's conversations. Registry gains per-CLI `usageProbe` state paths, wired for 8 of 10 CLIs with evidence comments; opencode stays `null` on purpose (sessions live in a database now — counting would mean reading content). `null` = unknown, never zero. Flagless output is unchanged (verified against a before-snapshot).

setup-dialogue.md gains interpretation guardrails: large disparities are evidence, small ones are noise, `lastUsed` weighs as much as the count, counts are lifetime-per-machine not per-month.

## Verified

Live run: flagless output byte-stable; `--usage` reported plausible counts for all 8 wired CLIs and `null` for opencode; `config.mjs load` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)