### PR TITLE
fix: realpath argv for isMain so symlinked installs run main

### DIFF
--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -457,5 +457,15 @@ function main(argv) {
   }
 }
 
-const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+// realpath, not resolve: skill dirs are commonly symlinked (e.g. ~/.claude/skills →
+// ~/.agents/skills), and Node's module URL is already symlink-resolved — a plain
+// resolve() mismatch made this file silently no-op when run through a symlink.
+const isMain = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  }
+})();
 if (isMain) main(process.argv.slice(2));

--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -457,15 +457,19 @@ function main(argv) {
   }
 }
 
-// realpath, not resolve: skill dirs are commonly symlinked (e.g. ~/.claude/skills →
-// ~/.agents/skills), and Node's module URL is already symlink-resolved — a plain
-// resolve() mismatch made this file silently no-op when run through a symlink.
+// realpath BOTH sides, not resolve: skill dirs are commonly symlinked (e.g.
+// ~/.claude/skills → ~/.agents/skills) and a plain resolve() mismatch made this file
+// silently no-op when run through a symlink. The module URL side needs it too —
+// under --preserve-symlinks-main it keeps the symlink path.
 const isMain = (() => {
   if (!process.argv[1]) return false;
-  try {
-    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
-  } catch {
-    return resolve(process.argv[1]) === fileURLToPath(import.meta.url);
-  }
+  const toReal = (path) => {
+    try {
+      return realpathSync(path);
+    } catch {
+      return resolve(path);
+    }
+  };
+  return toReal(process.argv[1]) === toReal(fileURLToPath(import.meta.url));
 })();
 if (isMain) main(process.argv.slice(2));

--- a/skills/delegate-setup/scripts/lane.mjs
+++ b/skills/delegate-setup/scripts/lane.mjs
@@ -182,14 +182,19 @@ function main(argv) {
   }
 }
 
-// realpath, not resolve: mirrors config.mjs — symlinked install paths otherwise
-// make this silently no-op, and relays call it for every --lane dispatch.
+// realpath BOTH sides, not resolve: mirrors config.mjs — symlinked install paths
+// otherwise make this silently no-op (including under --preserve-symlinks-main,
+// where the module URL keeps the symlink path), and relays call it for every
+// --lane dispatch.
 const isMain = (() => {
   if (!process.argv[1]) return false;
-  try {
-    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
-  } catch {
-    return resolvePath(process.argv[1]) === fileURLToPath(import.meta.url);
-  }
+  const toReal = (path) => {
+    try {
+      return realpathSync(path);
+    } catch {
+      return resolvePath(path);
+    }
+  };
+  return toReal(process.argv[1]) === toReal(fileURLToPath(import.meta.url));
 })();
 if (isMain) main(process.argv.slice(2));

--- a/skills/delegate-setup/scripts/lane.mjs
+++ b/skills/delegate-setup/scripts/lane.mjs
@@ -16,6 +16,7 @@
  * Node built-ins only.
  */
 
+import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { resolve as resolvePath } from "node:path";
 import {
@@ -181,5 +182,14 @@ function main(argv) {
   }
 }
 
-const isMain = process.argv[1] && resolvePath(process.argv[1]) === fileURLToPath(import.meta.url);
+// realpath, not resolve: mirrors config.mjs — symlinked install paths otherwise
+// make this silently no-op, and relays call it for every --lane dispatch.
+const isMain = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return resolvePath(process.argv[1]) === fileURLToPath(import.meta.url);
+  }
+})();
 if (isMain) main(process.argv.slice(2));


### PR DESCRIPTION
Found live by the first non-author test run of `delegate-setup` v0.3.0, and it retroactively explains #45.

## The bug

`config.mjs` and `lane.mjs` gate `main()` behind:

```js
const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
```

`resolve()` normalizes but never follows symlinks, while Node resolves module URLs to real paths by default — so any invocation through a symlinked skill directory (the common `~/.claude/skills → ~/.agents/skills` layout) compares the symlink path against the real path, misses, and **exits 0 with no output**. `discover.mjs` has no such guard, which is why only these two scripts misbehaved.

For `config.mjs` the symptom is the orchestrator reading silence as "no lanes configured" (#45's exact report). For `lane.mjs` it would be every relay `--lane` dispatch silently resolving nothing.

## The fix

`realpathSync(process.argv[1])` with a `resolve()` fallback when the path can't be realpath'd, in both files.

## Verified

Live repro before the fix (symlink path → 0 bytes, exit 0), then after: `config.mjs load` prints the envelope via the symlinked path, the real path, and the repo path; `lane.mjs` prints its usage loudly via the symlink; `discover.mjs` unaffected.

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)