### PR TITLE
docs: specify how to ask the interview questions, not just what

### DIFF
--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -24,7 +24,7 @@ Allocation policy only. Users cannot rank model IDs — that is your job, not th
 
 | # | Ask | What it settles |
 | --- | --- | --- |
-| 1 | What kind of work do you delegate most? | The main lane — and its **name**. “migrations”, “wp-plugin”, “bug triage” beat the canned `feature`/`tests`/`ui`/`fast`/`complex` five |
+| 1 | What kind of work do you delegate most? | The main lane — and its **name**. “migrations”, “bug triage”, “release-prep” beat the canned `feature`/`tests`/`ui`/`fast`/`complex` five |
 | 2 | Which paid subscriptions should I burn, and which should I spare? | Quota economics. Discovery cannot see plans, limits, or what a run costs — only the user knows |
 | 3 | Any CLI you already trust, or one that has burned you? | Lived experience outranks your priors about the underlying models |
 | 4 | Default to fast and cheap, or slow and thorough? | Effort / variant dials, and who gets the `complex` lane |

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -31,6 +31,23 @@ Allocation policy only. Users cannot rank model IDs — that is your job, not th
 
 Stop at four. Skip any the usage scan already answered.
 
+### How to ask them
+
+The questions are conversation, not a survey — cramming all four into one cold multiple-choice
+form loses exactly what they exist to collect.
+
+- **Question 1 is open-ended.** You want the user's words — they become lane names. If your harness
+  forces options, derive them from evidence (repo, usage scan, what the user has said), keep them one
+  genre (kinds of work — never a mix of domains and task types, which overlap), and treat a selection
+  as a draft lane name, not a category.
+- **Questions 2 and 3 are set-valued.** The answer is a mapping across CLIs, so options must span the
+  *discovered* CLIs — never an arbitrary subset — with both directions expressible: burn *and* spare,
+  trust *and* burned-by. Multi-select if the harness has it; otherwise ask in prose.
+- **Question 4 may be a closed choice.** Do not pre-mark an option as recommended — recommendations
+  belong in the proposal, after the answers.
+- **Lead with question 1.** Its answer usually reshapes or removes the others. Stop at four also
+  means fewer is better.
+
 ### Reading a usage scan
 
 `node <skill-dir>/scripts/discover.mjs --usage` adds `usage` to each discovered CLI:


### PR DESCRIPTION
Live finding from the first non-author setup run: the orchestrator rendered the four interview questions as one blocking multiple-choice form, and the user declined to answer.

What went wrong, per question:

- **Q1 (work type)** — designed to harvest the user's own words as lane names; canned options handed back canned categories, mixing genres that overlap (a domain like "WordPress" vs task types like "bug fixing").
- **Q2 (subscriptions)** — the answer is a burn/spare mapping across CLIs; four single-select fragments covering a subset of CLIs cannot express it.
- **Q3 (trust)** — a two-sided question rendered with trust-only options; the burned-by half (often the stronger signal) was unexpressible.
- **Q4 (bias)** — fine as a closed choice, but pre-marked "(Recommended)", smuggling priors back in before any answer.

setup-dialogue.md specified the questions' content but not their form. This adds a "How to ask them" section: Q1 open-ended (selections are draft lane names), Q2/Q3 set-valued across *discovered* CLIs with both directions expressible, Q4 closed but unrecommended, lead with Q1 and prefer fewer questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)