### PR TITLE
feat: consent scope — opinion may place, only evidence may spend

### DIFF
--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `agy` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows). Windows launch is not yet verified for this relay.
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Antigravity Delegate

--- a/skills/claude-delegate/SKILL.md
+++ b/skills/claude-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `claude` CLI (Claude Code) installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Claude's shell sandbox requires macOS, Linux, or WSL2; native Windows launch is pending verification.
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Claude Delegate

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 compatibility: Requires the `codex` CLI (OpenAI Codex) installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Codex Delegate

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `cursor-agent` CLI installed and authenticated, Node 18+, and git. The optional `--add-dir` flag requires cursor-agent 2026.07.23 or newer. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Cursor Delegate

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -38,9 +38,10 @@ Example lane: **feature** → implementer `opencode`, model `opencode/grok`, var
 4. Write **only** after an explicit approval (“yes”, “approve”, “write it”).
 5. Ask scope unless already clear: **global** (all projects) vs **this repo only**. Never create a project file just because cwd is a git repo. If there is no git repo, default to global and say so.
 6. Do not invent model identifiers.
-7. Prefer 3–5 useful lanes over a kitchen-sink map.
-8. Never edit `AGENTS.md`, `CLAUDE.md`, or other user agent-instruction files.
-9. Never run a `*-delegate` relay from this skill.
+7. In interview or usage-scan mode, never write a `model`, `effort` or `variant` the user did not give you and the schema does not require — omit it, so that CLI’s own configured default applies.
+8. Prefer 3–5 useful lanes over a kitchen-sink map.
+9. Never edit `AGENTS.md`, `CLAUDE.md`, or other user agent-instruction files.
+10. Never run a `*-delegate` relay from this skill.
 
 (`<skill-dir>` is this skill’s install directory — the folder that contains this `SKILL.md`.)
 
@@ -85,13 +86,31 @@ anything — one question, three options, not a wizard:
 - **Quick defaults** → propose immediately, and say plainly that the map is your opinion and cheap to
   revise.
 - **Interview** → the four questions live in [references/setup-dialogue.md](references/setup-dialogue.md).
-  Ask about allocation policy, never about model rankings — ranking models is your job.
+  Ask about allocation policy, never about model rankings — ranking models is your job. Put a whole
+  round of questions through **one** medium: all prose or all in one form, never both in a turn — a
+  submitted form ends the turn and the prose questions beside it are never seen.
 - **Usage scan** → `node "<skill-dir>/scripts/discover.mjs" --usage`. Tell the user it is metadata
   only before running it. Each discovered CLI gains `usage: { sessions, lastUsed }`; `null` means no
   probe is wired — unknown, not unused.
 - **Both** → run the scan first, then ask only what the numbers cannot answer.
 - Inside a git repo, repo signals (languages, test weight, frontend share) are a fourth source of
   evidence. They do not change the menu; they feed the proposal and the `repo` basis.
+
+**That menu is also the consent surface** — the option chosen sets how much of the map is yours to
+decide:
+
+- **Quick defaults** — the user hired your opinion. A full map is legitimate, dials included; label
+  every lane `my opinion` and keep it cheap to revise.
+- **Interview / usage scan** — evidence modes, so dials are evidence-gated. Set `model`, `effort` or
+  `variant` **only** from the user’s answer, or where the schema requires it (opencode lanes require
+  `model`). Otherwise omit the dial: every CLI then applies its own configured default, which is the
+  user’s standing choice and better model-evidence than your priors. Choosing which installed
+  implementer gets a lane is still yours — Basis `my opinion` — but a dial that raises spend is not.
+  Offer your dial picks as a short addendum *after* the proposal (“say the word and I’ll add the
+  model and effort settings I’d pick”); never pre-insert them into the JSON awaiting approval.
+- **An unanswered question shrinks the map; it never licenses a substitution.** Propose fewer, more
+  conservative lanes, name the axis you are blind on (no quota answer → say the map is quota-blind),
+  and invite the answer anytime. Re-ask once at most; never backfill silence with priors.
 
 Then propose the lanes. Name them after the work the user described; fall back to `feature`, `tests`,
 `ui`, `fast`, `complex`. Installed implementers only.
@@ -100,13 +119,16 @@ Show:
 
 | Lane | Implementer | Model | Effort / variant | Basis | Source (if updating) |
 | --- | --- | --- | --- | --- | --- |
-| feature | opencode | opencode/grok | variant: high | your answer | — |
-| tests | codex | — | effort: medium | usage data | — |
-| ui | claude | sonnet | — | my opinion | — |
+| feature | opencode | opencode/grok | variant: high | your answer; opencode requires a model | — |
+| tests | codex | — | — | usage data | — |
+| ui | claude | — | — | my opinion (implementer) | — |
 
 **Basis** is mandatory on every lane: `your answer` / `usage data` / `repo` / `my opinion`. A lane you
 picked from model-quality priors is `my opinion` — never present it as something the tooling
-determined. “Installed and authenticated” is capability, not evidence of fit.
+determined. “Installed and authenticated” is capability, not evidence of fit. When a lane’s
+implementer and its dials come from different places, say both (`usage + my opinion (model)`) — a
+label you only need in quick defaults, or when the user asked you for a dial: usage counts and repo
+signals are evidence about *work*, never about which model or effort level to buy.
 
 Then the **complete** JSON (`version`: `delegate-fleet.v1`). One line of why per lane; flag auth or
 model uncertainty.

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -119,11 +119,12 @@ Show:
 
 | Lane | Implementer | Model | Effort / variant | Basis | Source (if updating) |
 | --- | --- | --- | --- | --- | --- |
-| feature | opencode | opencode/grok | variant: high | your answer; opencode requires a model | — |
+| feature | opencode | opencode/grok | variant: high | your answer + schema requirement | — |
 | tests | codex | — | — | usage data | — |
 | ui | claude | — | — | my opinion (implementer) | — |
 
-**Basis** is mandatory on every lane: `your answer` / `usage data` / `repo` / `my opinion`. A lane you
+**Basis** is mandatory on every lane: `your answer` / `usage data` / `repo` / `my opinion` /
+`schema requirement` (a dial the schema forces is neither evidence nor opinion — say so). A lane you
 picked from model-quality priors is `my opinion` — never present it as something the tooling
 determined. “Installed and authenticated” is capability, not evidence of fit. When a lane’s
 implementer and its dials come from different places, say both (`usage + my opinion (model)`) — a

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires Node 18+. No implementer CLIs are required — the skill discovers what is available.
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Delegate Setup
@@ -38,7 +38,7 @@ Example lane: **feature** → implementer `opencode`, model `opencode/grok`, var
 4. Write **only** after an explicit approval (“yes”, “approve”, “write it”).
 5. Ask scope unless already clear: **global** (all projects) vs **this repo only**. Never create a project file just because cwd is a git repo. If there is no git repo, default to global and say so.
 6. Do not invent model identifiers.
-7. In interview or usage-scan mode, never write a `model`, `effort`, `variant` or `provider` the user did not give you and the schema does not require — omit it, so that CLI’s own configured default applies.
+7. In interview or usage-scan mode, never write **any** dial the user did not give you and the schema does not require — omit it, so the CLI’s or relay’s own default applies.
 8. Prefer 3–5 useful lanes over a kitchen-sink map.
 9. Never edit `AGENTS.md`, `CLAUDE.md`, or other user agent-instruction files.
 10. Never run a `*-delegate` relay from this skill.
@@ -71,8 +71,6 @@ node "<skill-dir>/scripts/config.mjs" load --cwd "$PWD"
 - If `projectPresent` is true and `projectTrusted` is false, label the project lanes **untrusted**.
   They cannot dispatch until the user reviews and approves a project write.
 
-Details: [references/setup-dialogue.md](references/setup-dialogue.md).
-
 ### 3. Propose
 
 Discovery reports capability, never task fit. So ask **one** grounding question before proposing
@@ -83,12 +81,10 @@ anything — one question, three options, not a wizard:
 > **(3) Usage scan** — I re-read your CLIs’ local session folders (counts and dates only, never the
 > conversations) and let the numbers pick your main lanes. Happy to do 2 and 3 together.
 
-- **Quick defaults** → propose immediately, and say plainly that the map is your opinion and cheap to
-  revise.
-- **Interview** → the four questions live in [references/setup-dialogue.md](references/setup-dialogue.md).
-  Ask about allocation policy, never about model rankings — ranking models is your job. Put a whole
-  round of questions through **one** medium: all prose or all in one form, never both in a turn — a
-  submitted form ends the turn and the prose questions beside it are never seen.
+- **Quick defaults** → propose immediately.
+- **Interview** → the four questions (allocation policy, never model rankings) and how to ask them
+  (one medium per round) live in [references/setup-dialogue.md](references/setup-dialogue.md) — read
+  it before you ask.
 - **Usage scan** → `node "<skill-dir>/scripts/discover.mjs" --usage`. Tell the user it is metadata
   only before running it. Each discovered CLI gains `usage: { sessions, lastUsed }`; `null` means no
   probe is wired — unknown, not unused.
@@ -100,14 +96,14 @@ anything — one question, three options, not a wizard:
 decide:
 
 - **Quick defaults** — the user hired your opinion. A full map is legitimate, dials included; label
-  every lane `my opinion` and keep it cheap to revise.
-- **Interview / usage scan** — evidence modes, so dials are evidence-gated. Set `model`, `effort`,
-  `variant` or `provider` **only** from the user’s answer, or where the schema requires it (opencode
-  lanes require `model`). Otherwise omit the dial: every CLI then applies its own configured default, which is the
-  user’s standing choice and better model-evidence than your priors. Choosing which installed
-  implementer gets a lane is still yours — Basis `my opinion` — but a dial that raises spend is not.
-  Offer your dial picks as a short addendum *after* the proposal (“say the word and I’ll add the
-  model and effort settings I’d pick”); never pre-insert them into the JSON awaiting approval.
+  every lane `my opinion`, say plainly that the map is your opinion, and keep it cheap to revise.
+- **Interview / usage scan** — evidence modes, so **every** dial is gated (rule 7): set one only from
+  the user’s answer, or where the schema requires it (opencode lanes require `model`). Omitting is
+  always safe — every dial has a default the user already lives with, and a CLI’s configured default
+  is their standing choice, better evidence than your priors. Choosing which installed implementer
+  gets a lane is still yours — Basis `my opinion` — but a dial that raises spend is not: offer your
+  dial picks only as an addendum after the proposal, see
+  [references/setup-dialogue.md](references/setup-dialogue.md).
 - **An unanswered question shrinks the map; it never licenses a substitution.** Propose fewer, more
   conservative lanes, name the axis you are blind on (no quota answer → say the map is quota-blind),
   and invite the answer anytime. Re-ask once at most; never backfill silence with priors.
@@ -126,10 +122,9 @@ Show:
 **Basis** is mandatory on every lane: `your answer` / `usage data` / `repo` / `my opinion` /
 `schema requirement` (a dial the schema forces is neither evidence nor opinion — say so). A lane you
 picked from model-quality priors is `my opinion` — never present it as something the tooling
-determined. “Installed and authenticated” is capability, not evidence of fit. When a lane’s
-implementer and its dials come from different places, say both (`usage + my opinion (model)`) — a
-label you only need in quick defaults, or when the user asked you for a dial: usage counts and repo
-signals are evidence about *work*, never about which model or effort level to buy.
+determined, and “installed and authenticated” is capability, not evidence of fit. When a lane’s
+implementer and its dials come from different places, split the label — see
+[references/setup-dialogue.md](references/setup-dialogue.md).
 
 Then the **complete** JSON (`version`: `delegate-fleet.v1`). One line of why per lane; flag auth or
 model uncertainty.
@@ -149,9 +144,10 @@ scope’s raw file (or an empty `lanes` object if new) — not from the effectiv
 or a project write will shadow global-only lanes and a global write will promote project-only ones.
 
 Create a uniquely named file under the platform temporary directory (`$TMPDIR`, `%TEMP%`, or Node
-`os.tmpdir()`), write the **exact approved JSON** into it with the orchestrator's file-writing tool,
-and use that populated path as `<lanes-json>` below. Never validate an empty temp file. Remove the
-temp file after the validation/write attempt, whether it succeeds or fails.
+`os.tmpdir()`; never hard-code `/tmp`, which breaks on native Windows), write the **exact approved
+JSON** into it with the orchestrator's file-writing tool, and use that populated path as
+`<lanes-json>` below. Never validate an empty temp file. Remove the temp file after the
+validation/write attempt, whether it succeeds or fails.
 
 ```bash
 node "<skill-dir>/scripts/config.mjs" validate "<lanes-json>"
@@ -159,8 +155,9 @@ node "<skill-dir>/scripts/config.mjs" write --scope global "<lanes-json>"
 # or:  write --scope project --cwd /path/to/repo "<lanes-json>"
 ```
 
-Confirm the path written and the active lane names. Project writes bind approval to the exact config
-content; later changes fail closed until re-approved. On update, a short before/after is enough.
+Re-read with `load`, then confirm the path written and the active lane names. Project writes bind
+approval to the exact config content; later changes fail closed until re-approved. On update, a short
+before/after is enough.
 
 ### 6. Ready to delegate
 

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -38,7 +38,7 @@ Example lane: **feature** → implementer `opencode`, model `opencode/grok`, var
 4. Write **only** after an explicit approval (“yes”, “approve”, “write it”).
 5. Ask scope unless already clear: **global** (all projects) vs **this repo only**. Never create a project file just because cwd is a git repo. If there is no git repo, default to global and say so.
 6. Do not invent model identifiers.
-7. In interview or usage-scan mode, never write a `model`, `effort` or `variant` the user did not give you and the schema does not require — omit it, so that CLI’s own configured default applies.
+7. In interview or usage-scan mode, never write a `model`, `effort`, `variant` or `provider` the user did not give you and the schema does not require — omit it, so that CLI’s own configured default applies.
 8. Prefer 3–5 useful lanes over a kitchen-sink map.
 9. Never edit `AGENTS.md`, `CLAUDE.md`, or other user agent-instruction files.
 10. Never run a `*-delegate` relay from this skill.
@@ -101,9 +101,9 @@ decide:
 
 - **Quick defaults** — the user hired your opinion. A full map is legitimate, dials included; label
   every lane `my opinion` and keep it cheap to revise.
-- **Interview / usage scan** — evidence modes, so dials are evidence-gated. Set `model`, `effort` or
-  `variant` **only** from the user’s answer, or where the schema requires it (opencode lanes require
-  `model`). Otherwise omit the dial: every CLI then applies its own configured default, which is the
+- **Interview / usage scan** — evidence modes, so dials are evidence-gated. Set `model`, `effort`,
+  `variant` or `provider` **only** from the user’s answer, or where the schema requires it (opencode
+  lanes require `model`). Otherwise omit the dial: every CLI then applies its own configured default, which is the
   user’s standing choice and better model-evidence than your priors. Choosing which installed
   implementer gets a lane is still yours — Basis `my opinion` — but a dial that raises spend is not.
   Offer your dial picks as a short addendum *after* the proposal (“say the word and I’ll add the

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -86,10 +86,12 @@ say where the user works, not which model or effort level to buy for them. That 
 quick-defaults mode, or when the user asked you for a dial: in the evidence modes you write no
 opinion-dials, so there are none to label (see the consent-scope rules in `SKILL.md`).
 
-Opinions about dials travel as an **addendum**, never as a pre-filled field. Show the table and the
-JSON first, then, in a separate paragraph after it: “If you want my picks for models and effort
-levels, say the word and I’ll add them.” Then wait. A dial the user asked for is theirs; the same
-dial sitting inside the JSON they are about to approve spent their quota on your say-so.
+In the evidence modes, unsolicited opinions about dials travel as an **addendum**, never as a
+pre-filled field (quick-defaults proposals may include opinion-labeled dials — the user hired that
+opinion). Show the table and the JSON first, then, in a separate paragraph after it: “If you want my
+picks for models and effort levels, say the word and I’ll add them.” Then wait. A dial the user
+asked for is theirs; the same dial sitting inside the JSON they are about to approve spent their
+quota on your say-so.
 
 ## Scope
 

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -36,6 +36,9 @@ Stop at four. Skip any the usage scan already answered.
 The questions are conversation, not a survey — cramming all four into one cold multiple-choice
 form loses exactly what they exist to collect.
 
+- **One medium per round.** Every question you ask in a turn goes through the same channel: all
+  prose, or all in one form. Never mix the two — submitting a form ends the turn, so any prose
+  question asked beside it is simply lost, and the silence that follows is not an answer to it.
 - **Question 1 is open-ended.** You want the user's words — they become lane names. If your harness
   forces options, derive them from evidence (repo, usage scan, what the user has said), keep them one
   genre (kinds of work — never a mix of domains and task types, which overlap), and treat a selection
@@ -47,6 +50,11 @@ form loses exactly what they exist to collect.
   belong in the proposal, after the answers.
 - **Lead with question 1.** Its answer usually reshapes or removes the others. Stop at four also
   means fewer is better.
+- **Silence shrinks the map; it never gets substituted.** An unanswered question means a smaller,
+  more conservative proposal: fewer lanes, and no dial on the axis it would have settled. Say what
+  you are blind on in one line — “nobody told me which subscriptions to spare, so I set no effort
+  dials; each CLI will use the default you configured” — and add that the answer is welcome anytime.
+  Re-ask once if it matters. Never close the gap with your own preference.
 
 ### Reading a usage scan
 
@@ -71,6 +79,17 @@ form loses exactly what they exist to collect.
 Give every proposed lane a Basis: `your answer`, `usage data`, `repo`, or `my opinion`. Use
 `my opinion` whenever the choice came from your own sense of which model is better at the work —
 including when discovery confirmed the CLI is installed and authenticated.
+
+Label the parts separately when they differ. A lane whose implementer came from the usage scan but
+whose model you chose is `usage + my opinion (model)`, never a flat `usage data` — session counts
+say where the user works, not which model or effort level to buy for them. That split only exists in
+quick-defaults mode, or when the user asked you for a dial: in the evidence modes you write no
+opinion-dials, so there are none to label (see the consent-scope rules in `SKILL.md`).
+
+Opinions about dials travel as an **addendum**, never as a pre-filled field. Show the table and the
+JSON first, then, in a separate paragraph after it: “If you want my picks for models and effort
+levels, say the word and I’ll add them.” Then wait. A dial the user asked for is theirs; the same
+dial sitting inside the JSON they are about to approve spent their quota on your say-so.
 
 ## Scope
 

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -1,22 +1,12 @@
 # Setup dialogue details
 
-Load this when running a configure / reconfigure session. The `SKILL.md` flow is authoritative; this page expands edge cases.
-
-## Effective map (do not dump both files)
-
-When loading existing config:
-
-1. Run `node <skill-dir>/scripts/config.mjs load --cwd <dir>` (use the user’s cwd, or omit `--cwd`).
-2. If `globalPresent` and `projectPresent` are both false → say “No lanes configured yet.”
-3. Otherwise show a **table of effective lanes** from the `lanes` object. Include a Source column (`global` / `project`).
-4. If `projectPresent` is true and `projectTrusted` is false, mark project lanes untrusted and explain
-   that they cannot dispatch until the user approves a project write.
-5. Paste both raw JSON files only if the user asks.
+Load this when running a configure / reconfigure session. `SKILL.md` is authoritative and states each
+rule once; this page expands the dialogue itself — the interview, how to ask it, how to read a usage
+scan, and how to label what you propose.
 
 ## Grounding the lane map
 
-Ask the grounding menu as **one** question with three options (quick defaults / interview / usage
-scan), then act on the answer. One question — never a wizard.
+The grounding menu is `SKILL.md` step 3. When the user picks the interview:
 
 ### The four interview questions
 
@@ -29,7 +19,7 @@ Allocation policy only. Users cannot rank model IDs — that is your job, not th
 | 3 | Any CLI you already trust, or one that has burned you? | Lived experience outranks your priors about the underlying models |
 | 4 | Default to fast and cheap, or slow and thorough? | Effort / variant dials, and who gets the `complex` lane |
 
-Stop at four. Skip any the usage scan already answered.
+Stop at four.
 
 ### How to ask them
 
@@ -48,23 +38,20 @@ form loses exactly what they exist to collect.
   trust *and* burned-by. Multi-select if the harness has it; otherwise ask in prose.
 - **Question 4 may be a closed choice.** Do not pre-mark an option as recommended — recommendations
   belong in the proposal, after the answers.
-- **Lead with question 1.** Its answer usually reshapes or removes the others. Stop at four also
-  means fewer is better.
-- **Silence shrinks the map; it never gets substituted.** An unanswered question means a smaller,
-  more conservative proposal: fewer lanes, and no dial on the axis it would have settled. Say what
-  you are blind on in one line — “nobody told me which subscriptions to spare, so I set no effort
+- **Lead with question 1.** Its answer usually reshapes or removes the others — fewer than four is
+  better.
+- **Silence shrinks the map** — the consent rule is in `SKILL.md` step 3; here is the phrasing for
+  it. Name the axis in one line — “nobody told me which subscriptions to spare, so I set no effort
   dials; each CLI will use the default you configured” — and add that the answer is welcome anytime.
-  Re-ask once if it matters. Never close the gap with your own preference.
 
 ### Reading a usage scan
 
 `node <skill-dir>/scripts/discover.mjs --usage` adds `usage` to each discovered CLI:
 `{ "sessions": <int>, "lastUsed": <ISO-8601 | null> }`, or `null`.
 
-- Say what it does **before** running it: it counts session files and reads their timestamps. It never
-  opens one, so no conversation content is read.
-- `usage: null` = no probe wired for that CLI, or no local state directory. Unknown, not unused —
-  never report it as zero.
+- What to tell the user before running it: it counts session files and reads their timestamps. It
+  never opens one, so no conversation content is read.
+- `usage: null` also covers a CLI with no local state directory — never report it as zero.
 - Large disparities are honest evidence: 1600 codex sessions against 20 pi sessions tells you where
   the user actually works. That earns the main lane.
 - Small differences are noise. 97 against 61 decides nothing — fall back to the interview or to your
@@ -76,15 +63,14 @@ form loses exactly what they exist to collect.
 
 ### Labelling the basis
 
-Give every proposed lane a Basis: `your answer`, `usage data`, `repo`, or `my opinion`. Use
-`my opinion` whenever the choice came from your own sense of which model is better at the work —
-including when discovery confirmed the CLI is installed and authenticated.
+The Basis values, and the rule that every lane carries one, are in `SKILL.md`. What lives here is the
+split label and the addendum.
 
 Label the parts separately when they differ. A lane whose implementer came from the usage scan but
 whose model you chose is `usage + my opinion (model)`, never a flat `usage data` — session counts
 say where the user works, not which model or effort level to buy for them. That split only exists in
-quick-defaults mode, or when the user asked you for a dial: in the evidence modes you write no
-opinion-dials, so there are none to label (see the consent-scope rules in `SKILL.md`).
+quick-defaults mode, or when the user asked you for a dial: the evidence modes gate every dial
+(`SKILL.md` rule 7), so there is no opinion-dial left to label.
 
 In the evidence modes, unsolicited opinions about dials travel as an **addendum**, never as a
 pre-filled field (quick-defaults proposals may include opinion-labeled dials — the user hired that
@@ -93,52 +79,11 @@ picks for models and effort levels, say the word and I’ll add them.” Then wa
 asked for is theirs; the same dial sitting inside the JSON they are about to approve spent their
 quota on your say-so.
 
-## Scope
-
-| User said / situation | Scope |
-| --- | --- |
-| “global”, “all projects”, “outside the repo/project” | `global` — do not re-ask |
-| Not inside a git repository | Default `global` and say so |
-| Inside a git repo, scope unspecified | Ask once: global vs this repo only |
-| “this repo only” / “project” | `project` |
-
-Never create `.delegate/config.json` merely because cwd is a git repo.
-
-## Writing
-
-1. Build the JSON document for **one scope only**. Start from that scope’s raw file
-   (`config.mjs` paths: global or project), or `{ "version": "delegate-fleet.v1", "lanes": {} }`
-   if it does not exist yet. Apply the approved edits there.
-2. Do **not** write the effective merged map (stripping `source` from `load`). That would copy
-   lanes across scopes: a project write would shadow global-only names, and a global write would
-   promote project-only lanes everywhere. `write` replaces the chosen file wholesale.
-3. Validate dials against [schema.md](schema.md) (or `config.mjs validate`).
-4. Show table + full JSON again after every tweak.
-5. On explicit approval, write via:
-
-```bash
-# Write the approved JSON to a uniquely named platform temp file first, then:
-# global
-node <skill-dir>/scripts/config.mjs write --scope global "$LANES_JSON"
-
-# project
-node <skill-dir>/scripts/config.mjs write --scope project --cwd <repo> "$LANES_JSON"
-```
-
-Use the `config.mjs write` command above so project approval is recorded correctly. Re-read with
-`load` and confirm the path. A project write stores an approval hash under the worktree's
-Git metadata; any later content change invalidates it and project lane dispatch fails closed until
-re-approved. Remove the temp file after the write attempt, whether it succeeds or fails. Do not
-hard-code `/tmp` (breaks on native Windows).
-
 ## Auth and models
 
-- `authenticated: null` means unknown, not “logged out.” Usually it means no auth probe is wired for
-  that CLI (currently `agy` and `pi`, which expose no status command) — say that rather than implying
-  the login failed.
+- `authenticated: null` (unknown) usually means no auth probe is wired for that CLI — currently `agy`
+  and `pi`, which expose no status command. Say that, rather than implying the login failed.
 - Prefer not binding a lane to a CLI discover reports as `authenticated: false`.
-- Do not invent model ids. Use `models.values` when `status` is `reported`, or ask the user, or omit `model` when the CLI has a safe default (OpenCode does **not** — require a model for opencode lanes).
-
-## After write
-
-Tell the user the path and active lane names. Remind them: later, pick the `*-delegate` skill matching the lane’s `implementer` and dispatch with `--lane <name>` (explicit `--model` / `--effort` / `--variant` still win). Do not start a delegate task unless they ask.
+- Never invent model ids (rule 6): use `models.values` when `status` is `reported`, or ask the user,
+  or omit `model` when the CLI has a safe default (OpenCode does **not** — require a model for
+  opencode lanes).

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 compatibility: Requires the `grok` CLI (Grok Build) installed and authenticated (`grok login`, or `XAI_API_KEY`; beta access needs an eligible xAI subscription), Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Grok Delegate

--- a/skills/kimi-delegate/SKILL.md
+++ b/skills/kimi-delegate/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   written directly without delegating.
 license: MIT
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Kimi Delegate

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `opencode` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # OpenCode Delegate

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   directly without delegating.
 license: MIT
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Pi Delegate

--- a/skills/qoder-delegate/SKILL.md
+++ b/skills/qoder-delegate/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   small enough to do inline, or when the user wants code written directly without delegation.
 license: MIT
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Qoder Delegate

--- a/skills/vibe-delegate/SKILL.md
+++ b/skills/vibe-delegate/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   directly without delegating.
 license: MIT
 metadata:
-  version: 0.2.0
+  version: 0.4.0
 ---
 
 # Vibe Delegate


### PR DESCRIPTION
Redesign of the propose step, driven by two live test runs where the agent's model-quality opinions filled `model`/`effort` dials, hid under evidence labels ("usage data", "your answer"), silently overrode CLI defaults the user had configured themselves, and escalated effort — the user's paid quota — on pure priors. This skill writes spending policy; uninvited opinion must not spend.

## The principle

**Opinion may place, but only evidence may spend — and the grounding menu is the consent surface.** The user's grounding choice already answers "how much of this decision does the agent own"; the propose step now honors it:

- **Quick defaults** — the user hired the opinion. Full map, dials included, every lane labeled `my opinion`. Consent was the selection itself.
- **Interview / usage scan (evidence modes)** — dials are evidence-gated: set only from the user's answer or schema necessity (opencode requires `model`). Otherwise **omit the dial** — the CLI then applies its own configured default, which is the user's standing choice and better model-evidence than any prior. Opinion may still choose which installed implementer gets a lane (labeled), but never a dial that raises spend. Dial preferences travel as an opt-in addendum after the proposal, never pre-inserted into the JSON awaiting approval.
- **Silence shrinks, never substitutes.** An unanswered question means a smaller, more conservative map with the blind axis named — not priors wearing the user's name. Re-ask once at most.
- **One medium per question round.** A submitted form ends the turn and orphans prose questions beside it — mixing the two is how answers get "totally missed".

## Changes

- `SKILL.md`: new hard rule 7 (the dial gate), consent-scope rules bound to the grounding menu, one-medium rule, example table updated (evidence-mode rows carry no dials), Basis split-provenance labels.
- `references/setup-dialogue.md`: one-medium and silence-shrinks rules in "How to ask them"; split-label and addendum patterns in "Labelling the basis".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified setup guidance for evidence-based model, effort, and variant recommendations.
  - Defined focused lane selection and prohibited delegate relays.
  - Standardized dialogue rounds to use prose or a single form.
  - Added conservative handling for unanswered questions, including limited re-asking of important gaps.
  - Clarified that menus act as consent surfaces and that model or effort opinions appear only after approval.
  - Improved labeling of evidence sources versus implementer or model opinions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->