### PR TITLE
Relay dedup: reconcile drifted helpers + CI parity gate

### DIFF
--- a/.github/workflows/relays.yml
+++ b/.github/workflows/relays.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+      - run: node test/relay-parity.mjs
+      - run: node test/relay-isolated.mjs
       - run: node test/relay-smoke.mjs
       - name: validate the skills package
         if: runner.os == 'Linux'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,11 @@ Fixes to a relay, a reference, or the README need no claim. Keep the diff to one
 A changed relay also wants a direct run — `--help` plus a read-only or no-write run against a
 throwaway repo. The full pre-publish list is in [AGENTS.md](AGENTS.md).
 
+## Shared relay helpers
+
+Shared relay helpers are byte-identical by CI contract. Edit one relay, run
+`node test/relay-parity.mjs`, then paste its helper into the copies the test names.
+
 ## Review
 
 One maintainer reviews these and reads the relay line by line. Expect questions about anything the

--- a/docs/plans/relay-core-dedup.md
+++ b/docs/plans/relay-core-dedup.md
@@ -1,6 +1,6 @@
 # Plan: relay dedup — drift reconciliation + parity gate
 
-> **Status:** ADOPTED (v2), not yet implemented. Date: 2026-08-05.
+> **Status:** IMPLEMENTED (PR #50). Adopted 2026-08-04.
 > Supersedes the v1 build-time code-gen plan (condensed in the appendix — kept so the
 > analysis isn't lost). v1 was fact-checked against the tree, then both plans were
 > debated via a read-only Codex adjudication; v2 won on all five contested points.
@@ -14,7 +14,7 @@ shrink (see packaging constraint below), so the real problem is drift, not dupli
 fix the divergences once, then make drift impossible to land. No generator, no shared
 source dir — the relays themselves stay the source; a fast CI parity test proves they agree.
 
-## Verified drift facts (byte-checked 2026-08-05, branch `feat/consent-scope`)
+## Verified drift facts (byte-checked 2026-08-04, branch `feat/consent-scope`)
 
 v1's evidence came from diffing claude vs codex only and assumed the other 8 matched
 claude. They match codex. Corrected picture:
@@ -22,7 +22,7 @@ claude. They match codex. Corrected picture:
 | Symbol | Reality |
 |---|---|
 | `killChild(child, signal)` | null-guard `if (!child \|\| !child.pid) return;` exists **only in claude**; 9/10 lack it. Bodies otherwise semantically identical (formatting/comments differ). |
-| `gitTouchedFiles(cwd)` | `stdio: ["ignore","pipe","ignore"]` **only in claude**; 9/10 omit it. |
+| `gitTouchedFiles(cwd)` | `stdio: ["ignore","pipe","ignore"]` **only in claude**; 9/10 omit it. Found in PR #50 review: **only vibe** bounded the probe (`timeout` + `killSignal: "SIGKILL"`); the canonical body now bounds it for all 10. |
 | `parseDuration(duration)` | BigInt variant with in-function `MAX_TIMER_MS` ceiling in **8/10**; agy and pi use the Number variant with call-site-only guards. |
 | `MAX_TIMER_MS` | defined in 9/10; pi inlines `2_147_483_647` instead. |
 | `writeJsonAtomic` | named helper **only in claude** (`${path}.tmp-${pid}`); 9/10 inline temp+rename (`${path}.${pid}.tmp`). |

--- a/docs/plans/relay-core-dedup.md
+++ b/docs/plans/relay-core-dedup.md
@@ -1,0 +1,123 @@
+# Plan: relay dedup — drift reconciliation + parity gate
+
+> **Status:** ADOPTED (v2), not yet implemented. Date: 2026-08-05.
+> Supersedes the v1 build-time code-gen plan (condensed in the appendix — kept so the
+> analysis isn't lost). v1 was fact-checked against the tree, then both plans were
+> debated via a read-only Codex adjudication; v2 won on all five contested points.
+> Related: issue #42 (split the 2,191-line smoke suite).
+
+## Goal
+
+Ten `skills/<name>-delegate/scripts/relay.mjs` (~7,249 lines total) share ~80–90%
+near-verbatim boilerplate, and the shared helpers have drifted. Shipped relays cannot
+shrink (see packaging constraint below), so the real problem is drift, not duplication:
+fix the divergences once, then make drift impossible to land. No generator, no shared
+source dir — the relays themselves stay the source; a fast CI parity test proves they agree.
+
+## Verified drift facts (byte-checked 2026-08-05, branch `feat/consent-scope`)
+
+v1's evidence came from diffing claude vs codex only and assumed the other 8 matched
+claude. They match codex. Corrected picture:
+
+| Symbol | Reality |
+|---|---|
+| `killChild(child, signal)` | null-guard `if (!child \|\| !child.pid) return;` exists **only in claude**; 9/10 lack it. Bodies otherwise semantically identical (formatting/comments differ). |
+| `gitTouchedFiles(cwd)` | `stdio: ["ignore","pipe","ignore"]` **only in claude**; 9/10 omit it. |
+| `parseDuration(duration)` | BigInt variant with in-function `MAX_TIMER_MS` ceiling in **8/10**; agy and pi use the Number variant with call-site-only guards. |
+| `MAX_TIMER_MS` | defined in 9/10; pi inlines `2_147_483_647` instead. |
+| `writeJsonAtomic` | named helper **only in claude** (`${path}.tmp-${pid}`); 9/10 inline temp+rename (`${path}.${pid}.tmp`). |
+| `makeEventScanner(onObject)` | present in 7/10 (claude, cursor, grok, kimi, opencode, pi, qoder); the 7 copies **not yet mutually diffed**. |
+
+## The plan — two commits
+
+### Commit 1 — reconcile (all behavior changes, smoke-gated once)
+
+Paste claude's version byte-identical (comments included) into the others:
+
+- `killChild` with the null-guard → 9 relays (strict bugfix: others throw on a null child).
+- `gitTouchedFiles` with the stdio option → 9 relays (silences git stderr noise).
+- BigInt `parseDuration` → agy + pi; add `MAX_TIMER_MS` const to pi (adds the overflow
+  guard both lack in-function).
+- `makeEventScanner`: mutually diff the 7 copies **first**; if identical modulo
+  formatting, normalize to one implementation; otherwise leave it out of parity and note why.
+
+Gate: full `node test/relay-smoke.mjs` on the complete change (one slow run, not five).
+
+### Commit 2 — parity gate + packaging check (fast, mechanical)
+
+New `test/relay-parity.mjs` (~60 lines, Node built-ins, runs in milliseconds):
+
+- For each symbol — `MAX_TIMER_MS`, `parseDuration`, `killChild`, `gitTouchedFiles`,
+  plus `makeEventScanner` iff normalized in commit 1 — extract its source from every
+  relay and assert all copies byte-equal.
+- **Extractor (hardened per adjudication):** anchor at the top-level declaration
+  (`function name(` / `const name =` at column 0) and slice to the *next* top-level
+  function declaration or EOF; require exactly one match per symbol per relay, else fail.
+  Never "slice to the next `\n}`" — nested braces/strings/the closure-returning scanner
+  would mis-slice. Deliberately format-sensitive: byte parity is the contract.
+- **Isolated-install check (new — neither plan had it):** for each delegate skill, copy
+  its directory alone to a temp dir and run `relay.mjs --help` there. `node --check`
+  doesn't resolve imports and full-repo smoke masks accidental cross-directory imports,
+  so the repo's central constraint (single-skill install loads standalone) is otherwise
+  never continuously proven.
+- Wire into `.github/workflows/relays.yml` **before** the smoke job.
+- CONTRIBUTING.md: editing a shared helper = edit one relay, let parity name the stale
+  copies, paste. Acceptable because these helpers have near-zero edit traffic.
+
+## Deliberately not doing (and when to revisit)
+
+- **No generator / `shared/` fragments / markers** — permanent build machinery for
+  helpers that essentially never change. Revisit only if parity failures become frequent
+  enough that the N-file paste genuinely hurts; nothing here is thrown away in that case
+  (reconciliation + gate are prerequisites of the generator anyway).
+- **`writeJsonAtomic` stays inlined** — one call site per relay, no bug, no active
+  drift; consolidating just enlarges the behavior batch. Revisit on a second write site
+  or a semantics change.
+- **No helper unit tests / no eval-extracted-source harness** — smoke already exercises
+  timeout/kill/parsing paths; add a targeted black-box regression only when a real
+  defect shows a gap.
+- **No `runRelay(config)` skeleton, no signal-loop extraction** — closes over ~10
+  locals, shipped files can't shrink anyway; duplication that can't drift is just disk.
+
+## Verification (acceptance criteria)
+
+- `node test/relay-parity.mjs` exits 0; deleting the guard from any one relay makes it exit 1.
+- `node test/relay-smoke.mjs` green after commit 1 (incl. agy `--print-timeout`, pi
+  timeout validation, codex timeout/abort paths).
+- Isolated-install `--help` check green for all 10 delegate skills.
+- `node --check` on every relay.mjs; relays.yml green on ubuntu + windows (the
+  reconciled `killChild`/`gitTouchedFiles` touch the win32 path).
+- `npx skills add . --list` still shows 11 skills.
+
+## Packaging constraint (verified — why relays stay self-contained)
+
+A skill installs one directory at a time (`npx skills add <repo> --skill codex-delegate`
+copies only `skills/codex-delegate/`). No node_modules, no bundling, no dependency
+frontmatter. A plain cross-directory `import` hard-crashes a single-skill install. The
+one existing cross-dir dependency (`*-delegate` → `delegate-setup/scripts/lane.mjs`) is
+an `existsSync`-gated `spawnSync` on the optional `--lane` path; the watchdog/`killChild`
+run every invocation and can't degrade that way. Commit 2's isolated-install check turns
+this constraint from prose into CI.
+
+---
+
+## Appendix — superseded v1: build-time code-gen (mechanism A)
+
+Proposed: canonical fragments in `shared/core/*.mjs` + a generator (`gen-relay.mjs
+--write|--check`) inlining them into marker blocks in each relay; 5 staged smoke-gated
+commits; unit tests on the fragments. Alternatives it rejected still stand rejected:
+B (per-skill `_core.mjs` copy), C (bundler — violates no-deps), D (runtime shared skill —
+breaks single-skill install), E (data-only, ~10% win).
+
+Why v2 superseded it:
+
+1. **Evidence sampling error.** Byte-diffed claude vs codex only; assumed the other 8
+   matched claude when they match codex. Its "low-risk, no behavior change" batch was
+   false (9 relays receive behavior changes, not just codex) and its counts were off
+   (claimed 9/10 BigInt; reality 8/10 — pi is also Number-variant).
+2. **Cost/benefit.** Generator + fragment dir + marker convention + dep map + "never
+   edit the relay" rule, purchased for edit-once ergonomics on helpers with no edit
+   traffic. The CI gate — the part that actually prevents drift — exists in v2 at ~60 lines.
+3. **Latent defect (found in adjudication).** Fragments were specced as standalone
+   testable modules, but the generator only strips `export` — fragment imports would
+   collide with relay imports when inlined.

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -298,6 +298,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -235,20 +235,26 @@ function readBrief(opts) {
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // The kill must reach the whole process family, not just the CLI — a tool subprocess left
-  // running would keep editing after the relay reports timeout/aborted. On Windows Node can't
-  // kill a process family without a Job Object, so kill the tree by pid with the OS tool
-  // (/t includes descendants, /f forces it — the tree-kill/npm idiom).
+  if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
-    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
-    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
-    catch { /* already gone — nothing left to kill */ }
-  } else {
-    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
-    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
-    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
   }
 }
 
@@ -274,16 +280,28 @@ function agyVersion(timeoutMs) {
 function parseDuration(duration) {
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
-  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
 }
 
 function gitTouchedFiles(cwd) {
-  // null (not []) when git can't report - git missing, or a non-repo run - so the
-  // caller can tell "git unavailable" apart from "Antigravity changed nothing."
-  // [] means git ran and the working tree is clean.
   try {
-    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
   } catch {
     return null;
   }

--- a/skills/claude-delegate/scripts/relay.mjs
+++ b/skills/claude-delegate/scripts/relay.mjs
@@ -633,6 +633,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -199,7 +199,6 @@ function parseArgs(argv) {
 }
 
 function parseDuration(duration) {
-  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
   try {
@@ -216,22 +215,26 @@ function parseDuration(duration) {
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // The kill must reach the whole process family, not just the immediate child — a tool
-  // subprocess left running would keep editing after the relay reports timeout/aborted.
-  // On Windows the child is the .cmd shim (the shell:true launch above), Windows has no
-  // process-group signals, and Node can't kill a process family without a Job Object, so
-  // kill the tree by pid with the OS tool: /t includes descendants, /f forces it — the
-  // same idiom tree-kill and npm/pnpm use.
+  if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
-    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
-    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
-    catch { /* already gone — nothing left to kill */ }
-  } else {
-    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
-    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
-    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
   }
 }
 
@@ -298,12 +301,14 @@ function codexVersion(probeTimeoutMs) {
 }
 
 function gitTouchedFiles(cwd) {
-  // null (not []) when git can't report — git missing, or a non-repo run under
-  // --skip-git-repo-check — so the caller can tell "git unavailable" apart from
-  // "Codex changed nothing." [] means git ran and the working tree is clean.
   try {
-    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
   } catch {
     return null;
   }

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -305,6 +305,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -223,22 +223,26 @@ function readBrief(opts) {
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // The kill must reach the whole process family, not just the immediate child — a tool
-  // subprocess left running would keep editing after the relay reports timeout/aborted.
-  // On Windows the child is the cursor-agent.cmd shim (the shell:true launch below), Windows
-  // has no process-group signals, and Node can't kill a process family without a Job Object,
-  // so kill the tree by pid with the OS tool (/t includes descendants, /f forces it — the
-  // tree-kill/npm idiom).
+  if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
-    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
-    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
-    catch { /* already gone — nothing left to kill */ }
-  } else {
-    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
-    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
-    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
   }
 }
 
@@ -269,7 +273,6 @@ function cursorAgentVersion(timeoutMs) {
 }
 
 function parseDuration(duration) {
-  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
   try {
@@ -286,12 +289,14 @@ function parseDuration(duration) {
 }
 
 function gitTouchedFiles(cwd) {
-  // null (not []) when git cannot report — git missing, or a non-repo run — so
-  // the caller can tell "git unavailable" apart from "Cursor changed nothing."
-  // [] means git ran and the working tree is clean.
   try {
-    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
   } catch {
     return null;
   }

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -293,6 +293,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -321,6 +321,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -204,7 +204,6 @@ function parseArgs(argv) {
 }
 
 function parseDuration(duration) {
-  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
   try {
@@ -221,22 +220,26 @@ function parseDuration(duration) {
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // The kill must reach the whole process family, not just the immediate child — a tool
-  // subprocess left running would keep editing after the relay reports timeout/aborted.
-  // On Windows the child is the .cmd shim (the shell:true launch above), Windows has no
-  // process-group signals, and Node can't kill a process family without a Job Object, so
-  // kill the tree by pid with the OS tool: /t includes descendants, /f forces it — the
-  // same idiom tree-kill and npm/pnpm use.
+  if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
-    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
-    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
-    catch { /* already gone — nothing left to kill */ }
-  } else {
-    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
-    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
-    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
   }
 }
 
@@ -314,12 +317,14 @@ function grokVersion(probeTimeoutMs) {
 }
 
 function gitTouchedFiles(cwd) {
-  // null (not []) when git can't report — git missing, or a non-repo run —
-  // so the caller can tell "git unavailable" apart from "Grok changed nothing."
-  // [] means git ran and the working tree is clean.
   try {
-    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
   } catch {
     return null;
   }

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -202,20 +202,26 @@ function readBrief(opts) {
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // The kill must reach the whole process family, not just the CLI — a tool subprocess left
-  // running would keep editing after the relay reports timeout/aborted. On Windows Node can't
-  // kill a process family without a Job Object, so kill the tree by pid with the OS tool
-  // (/t includes descendants, /f forces it — the tree-kill/npm idiom).
+  if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
-    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
-    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
-    catch { /* already gone — nothing left to kill */ }
-  } else {
-    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
-    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
-    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
   }
 }
 
@@ -245,7 +251,6 @@ function kimiVersion(probeTimeoutMs) {
 }
 
 function parseDuration(duration) {
-  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
   try {
@@ -262,12 +267,14 @@ function parseDuration(duration) {
 }
 
 function gitTouchedFiles(cwd) {
-  // null (not []) when git cannot report - git missing, or a non-repo run - so
-  // the caller can tell "git unavailable" apart from "Kimi changed nothing."
-  // [] means git ran and the working tree is clean.
   try {
-    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
   } catch {
     return null;
   }

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -271,6 +271,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -294,6 +294,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -188,7 +188,6 @@ function parseArgs(argv) {
 }
 
 function parseDuration(duration) {
-  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
   try {
@@ -205,22 +204,26 @@ function parseDuration(duration) {
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // The kill must reach the whole process family, not just the immediate child — a tool
-  // subprocess left running would keep editing after the relay reports timeout/aborted.
-  // On Windows the child is the .cmd shim (the shell:true launch above), Windows has no
-  // process-group signals, and Node can't kill a process family without a Job Object, so
-  // kill the tree by pid with the OS tool: /t includes descendants, /f forces it — the
-  // same idiom tree-kill and npm/pnpm use.
+  if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
-    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
-    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
-    catch { /* already gone — nothing left to kill */ }
-  } else {
-    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
-    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
-    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
   }
 }
 
@@ -287,12 +290,14 @@ function opencodeVersion(probeTimeoutMs) {
 }
 
 function gitTouchedFiles(cwd) {
-  // null (not []) when git can't report — git missing, or a non-repo run — so the
-  // caller can tell "git unavailable" apart from "OpenCode changed nothing."
-  // [] means git ran and the working tree is clean.
   try {
-    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
   } catch {
     return null;
   }

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -91,6 +91,7 @@ import { constants, tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
 const VERSION_TIMEOUT_MS = 10_000;
 const READ_ONLY_TOOLS = "read,grep,find,ls";
 // --model, --provider, and --session values reach a shell on win32 (shell:true for the
@@ -141,10 +142,19 @@ function fail(message, code = 2) {
 }
 
 function parseDuration(duration) {
-  // Whole-string match: "1mtypo" must be rejected, not read as one minute.
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
   if (!match || (!match[1] && !match[2] && !match[3])) return null;
-  return (Number(match[1] || 0) * 3600 + Number(match[2] || 0) * 60 + Number(match[3] || 0)) * 1000;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
 }
 
 function parseArgs(argv) {
@@ -240,20 +250,26 @@ function readBrief(opts) {
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // The kill must reach the whole process family, not just the CLI — a tool subprocess left
-  // running would keep editing after the relay reports timeout/aborted. On Windows Node can't
-  // kill a process family without a Job Object, so kill the tree by pid with the OS tool
-  // (/t includes descendants, /f forces it — the tree-kill/npm idiom).
+  if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return; // the first taskkill /f already felled the whole tree
-    // stderr is inherited so a real taskkill failure (e.g. access denied) is visible to the operator;
-    // its non-zero exit when the tree is already gone is the expected race and carries nothing to do.
-    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: ["ignore", "ignore", "inherit"] }); }
-    catch { /* already gone — nothing left to kill */ }
-  } else {
-    // On POSIX the child leads its own process group (the detached launch), so the negative-pid
-    // signal reaches every descendant; fall back to the lone pid if the group is already gone.
-    try { process.kill(-child.pid, signal); } catch { try { child.kill(signal); } catch { /* already gone */ } }
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
   }
 }
 
@@ -314,12 +330,14 @@ async function piVersion(timeoutMs, onChild) {
 }
 
 function gitTouchedFiles(cwd) {
-  // null (not []) when git cannot report — git missing, or a non-repo run — so
-  // the caller can tell "git unavailable" apart from "pi changed nothing."
-  // [] means git ran and the working tree is clean.
   try {
-    const out = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
   } catch {
     return null;
   }

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -334,6 +334,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/qoder-delegate/scripts/relay.mjs
+++ b/skills/qoder-delegate/scripts/relay.mjs
@@ -264,6 +264,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/qoder-delegate/scripts/relay.mjs
+++ b/skills/qoder-delegate/scripts/relay.mjs
@@ -219,20 +219,25 @@ function readBrief(opts) {
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // A timeout/abort must stop Qoder's tools too, or a descendant could keep
-  // editing after the relay reports that the run ended.
+  if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return; // taskkill /f already felled the tree
+    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],
       });
-    } catch { /* The tree already exited. */ }
-  } else {
-    try {
-      process.kill(-child.pid, signal);
     } catch {
-      try { child.kill(signal); } catch { /* The tree already exited. */ }
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
     }
   }
 }
@@ -259,6 +264,7 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });
     return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);

--- a/skills/vibe-delegate/scripts/relay.mjs
+++ b/skills/vibe-delegate/scripts/relay.mjs
@@ -317,6 +317,8 @@ function gitTouchedFiles(cwd) {
     const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });

--- a/skills/vibe-delegate/scripts/relay.mjs
+++ b/skills/vibe-delegate/scripts/relay.mjs
@@ -313,38 +313,39 @@ function parseDuration(duration) {
 }
 
 function gitTouchedFiles(cwd) {
-  // null (not []) when git cannot report — git missing, or a non-repo run — so
-  // the caller can tell "git unavailable" apart from "Vibe changed nothing."
-  // [] means git ran and the working tree is clean.
   try {
-    const out = execFileSync("git", ["status", "--porcelain"], {
+    const output = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
-      timeout: PROBE_TIMEOUT_MS,
-      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: 64 * 1024 * 1024,
     });
-    return out.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
   } catch {
     return null;
   }
 }
 
 function killChild(child, signal = "SIGTERM") {
-  // A timeout/abort must stop Vibe's tools too, or a descendant could keep
-  // editing after the relay reports that the run ended.
+  if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return; // taskkill /f already felled the tree
+    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],
       });
-    } catch { /* The tree already exited. */ }
-  } else {
-    try {
-      process.kill(-child.pid, signal);
     } catch {
-      try { child.kill(signal); } catch { /* The tree already exited. */ }
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
     }
   }
 }

--- a/test/relay-isolated.mjs
+++ b/test/relay-isolated.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { cpSync, mkdtempSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const RELAYS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi"];
+let failed = 0;
+const check = (name, condition) => {
+  console.log(`${condition ? "  ok " : "  FAIL"}  ${name}`);
+  if (!condition) failed += 1;
+};
+
+for (const relay of RELAYS) {
+  const temp = mkdtempSync(join(tmpdir(), `delegate-skills-${relay}-`));
+  try {
+    cpSync(join(here, "..", "skills", `${relay}-delegate`), join(temp, `${relay}-delegate`), { recursive: true });
+    const result = spawnSync(process.execPath, ["scripts/relay.mjs", "--help"], {
+      cwd: join(temp, `${relay}-delegate`),
+      encoding: "utf8",
+    });
+    check(`${relay}: isolated --help`, result.status === 0 && Boolean(result.stdout.trim()));
+    if (result.status !== 0 || !result.stdout.trim()) {
+      console.log(`        exit ${result.status}; ${(result.stderr || result.error?.message || "no output").trim()}`);
+    }
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+if (failed) {
+  console.error(`relay isolated install: ${failed} failure(s)`);
+  process.exit(1);
+}
+console.log("relay isolated install: all checks passed");

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const RELAYS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi"];
+const SYMBOLS = [
+  ["MAX_TIMER_MS", "const"],
+  ["parseDuration", "function"],
+  ["killChild", "function"],
+  ["gitTouchedFiles", "function"],
+];
+let failed = 0;
+const check = (name, condition) => {
+  console.log(`${condition ? "  ok " : "  FAIL"}  ${name}`);
+  if (!condition) failed += 1;
+};
+
+function extract(source, symbol, kind, relay) {
+  const anchor = kind === "const"
+    ? new RegExp(`^const ${symbol} =.*$`, "gm")
+    : new RegExp(`^function ${symbol}\\(`, "gm");
+  const matches = [...source.matchAll(anchor)];
+  if (matches.length !== 1) {
+    throw new Error(`${relay}: expected one top-level ${kind} ${symbol}, found ${matches.length}`);
+  }
+  const start = matches[0].index;
+  if (kind === "const") return source.slice(start, source.indexOf("\n", start));
+  const next = /^(?:async )?function /gm;
+  next.lastIndex = start + 1;
+  const end = next.exec(source)?.index ?? source.length;
+  return source.slice(start, end);
+}
+
+for (const [symbol, kind] of SYMBOLS) {
+  try {
+    const copies = RELAYS.map((relay) => [
+      relay,
+      extract(readFileSync(join(here, "..", "skills", `${relay}-delegate`, "scripts", "relay.mjs"), "utf8"), symbol, kind, relay),
+    ]);
+    const groups = new Map();
+    for (const [relay, source] of copies) groups.set(source, [...(groups.get(source) || []), relay]);
+    const majority = [...groups.values()].sort((a, b) => b.length - a.length)[0];
+    const divergent = copies.filter(([, source]) => source !== copies.find(([relay]) => majority.includes(relay))[1]).map(([relay]) => relay);
+    check(`${symbol}: byte-identical across relays`, divergent.length === 0);
+    if (divergent.length) {
+      console.log(`        diverges from majority (${majority.join(", ")}): ${divergent.join(", ")}`);
+    }
+  } catch (error) {
+    check(`${symbol}: extract shared source`, false);
+    console.log(`        ${error.message}`);
+  }
+}
+
+if (failed) {
+  console.error(`relay parity: ${failed} failure(s)`);
+  process.exit(1);
+}
+console.log("relay parity: all checks passed");


### PR DESCRIPTION
## What

Implements the adopted v2 dedup plan (`docs/plans/relay-core-dedup.md`, committed here): fix the real drift in the shared relay helpers once, then make drift impossible to land — no generator, no `shared/` dir; the relays stay the source and CI proves they agree.

## Commits

- **docs:** the adopted v2 plan (supersedes the code-gen draft; appendix records why).
- **fix — reconcile:** `killChild` gains the null-guard in the 9 relays that lacked it; `gitTouchedFiles` gains `stdio: ["ignore","pipe","ignore"]` in the same 9; agy/pi move to the BigInt `parseDuration` with the in-function `MAX_TIMER_MS` ceiling (new const for pi). All four helper bodies are now byte-identical across the 10 relays.
- **test — gates:** `test/relay-parity.mjs` asserts the four bodies stay byte-equal (anchored top-level extraction, exactly one match per symbol required, divergers named); `test/relay-isolated.mjs` copies each skill directory alone to a temp dir and runs `--help` there, turning the single-skill-install constraint into CI. Both run before smoke on both OSes.

## Not done, deliberately

- `makeEventScanner` excluded from parity: its 7 copies are six genuinely different implementations (different buffer/state algorithms), not drifted duplicates. Unifying it is a design task, not a paste.
- No generator/`shared/` fragments, no `writeJsonAtomic` consolidation — see the plan's "Deliberately not doing" list and revisit triggers.

## Verification

- `node test/relay-parity.mjs` green; self-tested — removing the guard from one relay makes it exit 1 and name the diverger.
- `node test/relay-isolated.mjs` 10/10 green.
- `node test/relay-smoke.mjs` full run: all green, exit 0.
- `node --check` on all 10 relays.

Known trade-off: the canonical (claude) bodies are comment-sparse, so the paste dropped rationale comments the other copies carried; restoring them is a one-relay edit + re-paste via the parity workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay process termination across Windows and POSIX systems.
  * Prevented duration parsing errors caused by oversized timer values.
  * Improved Git status handling and error output.

* **Tests**
  * Added parity checks to detect inconsistencies across relay implementations.
  * Added isolated-install checks to verify each relay runs independently.

* **Documentation**
  * Documented relay helper consistency requirements and the updated deduplication plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->