### PR TITLE
docs: warn that sandboxed orchestrators can read claude auth as false

### DIFF
--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `agy` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows). Windows launch is not yet verified for this relay.
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Antigravity Delegate

--- a/skills/claude-delegate/SKILL.md
+++ b/skills/claude-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `claude` CLI (Claude Code) installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Claude's shell sandbox requires macOS, Linux, or WSL2; native Windows launch is pending verification.
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Claude Delegate
@@ -33,7 +33,11 @@ explicitly asks for delegation to another Claude Code process or session.
 ## Prerequisites
 
 1. `claude --version` succeeds.
-2. `claude auth status` reports an authenticated session.
+2. `claude auth status` reports an authenticated session. On macOS the live credentials sit in the
+   login Keychain; when the orchestrator's own sandbox blocks Keychain access (Codex's sandbox
+   does), `claude` falls back to a possibly stale credentials file and reports `loggedIn: false`
+   even though the login is valid. Re-run the check — and the dispatch itself — with that sandbox
+   escalated or outside it before concluding the CLI is unauthenticated.
 3. The target repository is the directory passed with `--cd`.
 4. On Linux/WSL2, Claude's sandbox dependencies are installed. The normal relay profile is
    configured to fail when the sandbox is unavailable instead of silently running shell commands

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 compatibility: Requires the `codex` CLI (OpenAI Codex) installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Codex Delegate

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `cursor-agent` CLI installed and authenticated, Node 18+, and git. The optional `--add-dir` flag requires cursor-agent 2026.07.23 or newer. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Cursor Delegate

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires Node 18+. No implementer CLIs are required — the skill discovers what is available.
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Delegate Setup

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -84,6 +84,10 @@ quota on your say-so.
 - `authenticated: null` (unknown) usually means no auth probe is wired for that CLI — currently `agy`
   and `pi`, which expose no status command. Say that, rather than implying the login failed.
 - Prefer not binding a lane to a CLI discover reports as `authenticated: false`.
+- For claude specifically, `authenticated: false` can be a Keychain artifact when discovery itself
+  ran inside a sandbox: on macOS the live credentials sit in the login Keychain, and a sandbox that
+  blocks Keychain access makes the probe fall back to a possibly stale credentials file. Verify with
+  `claude auth status` outside the sandbox before treating the CLI as unauthenticated.
 - Never invent model ids (rule 6): use `models.values` when `status` is `reported`, or ask the user,
   or omit `model` when the CLI has a safe default (OpenCode does **not** — require a model for
   opencode lanes).

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 compatibility: Requires the `grok` CLI (Grok Build) installed and authenticated (`grok login`, or `XAI_API_KEY`; beta access needs an eligible xAI subscription), Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Grok Delegate

--- a/skills/kimi-delegate/SKILL.md
+++ b/skills/kimi-delegate/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   written directly without delegating.
 license: MIT
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Kimi Delegate

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `opencode` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # OpenCode Delegate

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   directly without delegating.
 license: MIT
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Pi Delegate

--- a/skills/qoder-delegate/SKILL.md
+++ b/skills/qoder-delegate/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   small enough to do inline, or when the user wants code written directly without delegation.
 license: MIT
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Qoder Delegate

--- a/skills/vibe-delegate/SKILL.md
+++ b/skills/vibe-delegate/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   directly without delegating.
 license: MIT
 metadata:
-  version: 0.4.0
+  version: 0.4.1
 ---
 
 # Vibe Delegate


### PR DESCRIPTION
## What

A real-world dispatch failure: an orchestrator running inside its own sandbox (observed with Codex) ran the `claude auth status` prerequisite check, got `loggedIn: false` despite a valid login, and correctly-but-wrongly refused to delegate.

Root cause: on macOS, Claude Code keeps its live OAuth credentials in the login Keychain. A sandbox that blocks Keychain access makes `claude` fall back to `~/.claude/.credentials.json`, which can hold a long-expired token — so the CLI honestly reports logged out. Re-running the check with sandbox escalation returns `loggedIn: true` and the dispatch proceeds. claude is the only implementer in the registry with Keychain-backed credentials; every other CLI stores auth in plain files, so the caveat is claude-specific.

## Changes

- `skills/claude-delegate/SKILL.md` — extend prerequisite 2 with the caveat and the remedy (escalate the sandbox for the check **and** the dispatch itself, which needs Keychain access equally).
- `skills/delegate-setup/references/setup-dialogue.md` — matching bullet under "Auth and models" for interpreting `authenticated: false` on claude when discovery ran sandboxed.
- All skills bumped to `0.4.1` per the AGENTS.md lockstep versioning rule (tag `v0.4.1` after merge).

Docs-only; no script changes. `npx skills add . --list` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)