### PR TITLE
docs: correct delegation economics in delegate-setup

### DIFF
--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `agy` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows). Windows launch is not yet verified for this relay.
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Antigravity Delegate

--- a/skills/claude-delegate/SKILL.md
+++ b/skills/claude-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `claude` CLI (Claude Code) installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Claude's shell sandbox requires macOS, Linux, or WSL2; native Windows launch is pending verification.
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Claude Delegate

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 compatibility: Requires the `codex` CLI (OpenAI Codex) installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Codex Delegate

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `cursor-agent` CLI installed and authenticated, Node 18+, and git. The optional `--add-dir` flag requires cursor-agent 2026.07.23 or newer. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Cursor Delegate

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires Node 18+. No implementer CLIs are required — the skill discovers what is available.
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Delegate Setup
@@ -107,6 +107,30 @@ decide:
 - **An unanswered question shrinks the map; it never licenses a substitution.** Propose fewer, more
   conservative lanes, name the axis you are blind on (no quota answer → say the map is quota-blind),
   and invite the answer anytime. Re-ask once at most; never backfill silence with priors.
+
+**Delegation economics.** The orchestrator reviews and lands every result — the review is the
+quality gate, so optimize total cost, not implementer prestige:
+
+- Prefer capable, authenticated, **low-usage** CLIs for bounded, objectively gated work (tests,
+  mechanical refactors, straightforward fixes) when their reliability keeps review and rework
+  economical. Lanes push token burn away from the subscriptions the user is protecting, toward
+  surplus capacity.
+- Avoid binding a lane to a CLI the user is protecting or orchestrates from, by default; bind it
+  only when the user asks for it or no acceptable alternative exists. Lanes are
+  **orchestrator-blind**: the same lane fires from every seat the user drives from, and from that
+  CLI's own seat it dispatches the CLI to itself.
+- Surplus placement breaks down when rework and review cost exceed the savings; when the
+  implementer is flaky; when correctness rides on security, concurrency, migrations, or unstated
+  domain knowledge; and when the output **is** the product (debate, architecture, research) —
+  review limits damage, it does not manufacture a good first attempt. Bind those lanes to stronger
+  implementers.
+- An explicit "spare X" answer removes X from proposed lanes by default, and overrides blanket
+  posture answers on any lane the user explicitly retains for X — ask whether the posture applies
+  there; omit the dial if unanswered. Never silently stretch one answer across an axis it
+  conflicts with.
+
+Question phrasings for the burn/spare and trust interview live in
+[references/setup-dialogue.md](references/setup-dialogue.md).
 
 Then propose the lanes. Name them after the work the user described; fall back to `feature`, `tests`,
 `ui`, `fast`, `complex`. Installed implementers only.

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -79,7 +79,8 @@ anything — one question, three options, not a wizard:
 > How should I pick the lanes? **(1) Quick defaults** — I decide, no questions.
 > **(2) Interview** — about four questions on how you want work allocated.
 > **(3) Usage scan** — I re-read your CLIs’ local session folders (counts and dates only, never the
-> conversations) and let the numbers pick your main lanes. Happy to do 2 and 3 together.
+> conversations) and let the numbers place your lanes — if one CLI dominates, expect one question
+> about its role. Happy to do 2 and 3 together.
 
 - **Quick defaults** → propose immediately.
 - **Interview** → the four questions (allocation policy, never model rankings) and how to ask them
@@ -111,10 +112,12 @@ decide:
 **Delegation economics.** The orchestrator reviews and lands every result — the review is the
 quality gate, so optimize total cost, not implementer prestige:
 
-- Prefer capable, authenticated, **low-usage** CLIs for bounded, objectively gated work (tests,
-  mechanical refactors, straightforward fixes) when their reliability keeps review and rework
-  economical. Lanes push token burn away from the subscriptions the user is protecting, toward
-  surplus capacity.
+- Prefer capable, authenticated, burnable, **low-usage** CLIs for bounded, objectively gated work
+  (tests, mechanical refactors, straightforward fixes) when their reliability keeps review and
+  rework economical — lanes push token burn away from the subscriptions the user is protecting.
+  Low usage alone does not establish burnable: discovery cannot see plans, limits, or per-run
+  cost, and a rarely-used CLI may be metered or deliberately avoided. Burnable comes from the
+  user's quota answer — or, in quick defaults, from your labeled opinion.
 - Avoid binding a lane to a CLI the user is protecting or orchestrates from, by default; bind it
   only when the user asks for it or no acceptable alternative exists. Lanes are
   **orchestrator-blind**: the same lane fires from every seat the user drives from, and from that

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -16,7 +16,7 @@ Allocation policy only. Users cannot rank model IDs — that is your job, not th
 | --- | --- | --- |
 | 1 | What kind of work do you delegate most? | The main lane — and its **name**. “migrations”, “bug triage”, “release-prep” beat the canned `feature`/`tests`/`ui`/`fast`/`complex` five |
 | 2 | Which paid subscriptions should I burn, and which should I spare? | Quota economics. Discovery cannot see plans, limits, or what a run costs — only the user knows |
-| 3 | Any CLI you already trust, or one that has burned you? | Lived experience outranks your priors about the underlying models. A trust answer qualifies a CLI for high-stakes lanes and for orchestrating — it is not an order to assign it work: "trusted + spared" means qualified but normally excluded (the spare rule is in `SKILL.md` step 3) |
+| 3 | Any CLI you already trust — and for what kind of work? Any that has burned you? | Lived experience outranks your priors about the underlying models. Trust is scoped: an answer qualifies the CLI for work like the work that earned it — follow up on the scope before it qualifies a high-stakes lane. It is never an order to assign work: "trusted + spared" means qualified but normally excluded (the spare rule is in `SKILL.md` step 3) |
 | 4 | Default to fast and cheap, or slow and thorough? | Effort / variant dials, and who gets the `complex` lane |
 
 Stop at four.

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -57,8 +57,9 @@ form loses exactly what they exist to collect.
   orchestrate from it) or sends delegated work to it. Treat a meaningful disparity as a signal to
   **ask**, never to assign: "codex has the most local sessions, but the scan cannot tell whether
   you work inside it or delegate work to it — should I protect its quota, burn it as an
-  implementer, or treat it as mixed?" Combine the answer with the burn/spare interview answer
-  before proposing anything.
+  implementer, or treat it as mixed?" Combine the answer with the burn/spare interview answer when
+  the interview also ran; in a scan-only session the role answer is your only quota evidence —
+  propose conservatively and name the map quota-blind (the shrink rule in `SKILL.md` step 3).
 - Low usage alone is not evidence of task fit. A surplus CLI still needs to be installed,
   authenticated, and reliable to earn a lane.
 - Small differences are noise. 97 against 61 decides nothing — fall back to the interview or to your

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -16,7 +16,7 @@ Allocation policy only. Users cannot rank model IDs — that is your job, not th
 | --- | --- | --- |
 | 1 | What kind of work do you delegate most? | The main lane — and its **name**. “migrations”, “bug triage”, “release-prep” beat the canned `feature`/`tests`/`ui`/`fast`/`complex` five |
 | 2 | Which paid subscriptions should I burn, and which should I spare? | Quota economics. Discovery cannot see plans, limits, or what a run costs — only the user knows |
-| 3 | Any CLI you already trust, or one that has burned you? | Lived experience outranks your priors about the underlying models |
+| 3 | Any CLI you already trust, or one that has burned you? | Lived experience outranks your priors about the underlying models. A trust answer qualifies a CLI for high-stakes lanes and for orchestrating — it is not an order to assign it work: "trusted + spared" means qualified but normally excluded (the spare rule is in `SKILL.md` step 3) |
 | 4 | Default to fast and cheap, or slow and thorough? | Effort / variant dials, and who gets the `complex` lane |
 
 Stop at four.
@@ -52,8 +52,15 @@ form loses exactly what they exist to collect.
 - What to tell the user before running it: it counts session files and reads their timestamps. It
   never opens one, so no conversation content is read.
 - `usage: null` also covers a CLI with no local state directory — never report it as zero.
-- Large disparities are honest evidence: 1600 codex sessions against 20 pi sessions tells you where
-  the user actually works. That earns the main lane.
+- Large disparities show where activity occurs — not what role the CLI played in it. 1600 codex
+  sessions against 20 pi sessions cannot tell you whether the user works inside codex (and would
+  orchestrate from it) or sends delegated work to it. Treat a meaningful disparity as a signal to
+  **ask**, never to assign: "codex has the most local sessions, but the scan cannot tell whether
+  you work inside it or delegate work to it — should I protect its quota, burn it as an
+  implementer, or treat it as mixed?" Combine the answer with the burn/spare interview answer
+  before proposing anything.
+- Low usage alone is not evidence of task fit. A surplus CLI still needs to be installed,
+  authenticated, and reliable to earn a lane.
 - Small differences are noise. 97 against 61 decides nothing — fall back to the interview or to your
   opinion, and label it as such.
 - `lastUsed` weighs as much as the count. A big count that stopped months ago is a CLI the user moved

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 compatibility: Requires the `grok` CLI (Grok Build) installed and authenticated (`grok login`, or `XAI_API_KEY`; beta access needs an eligible xAI subscription), Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Grok Delegate

--- a/skills/kimi-delegate/SKILL.md
+++ b/skills/kimi-delegate/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   written directly without delegating.
 license: MIT
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Kimi Delegate

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 compatibility: Requires the `opencode` CLI installed and authenticated, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # OpenCode Delegate

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   directly without delegating.
 license: MIT
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Pi Delegate

--- a/skills/qoder-delegate/SKILL.md
+++ b/skills/qoder-delegate/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   small enough to do inline, or when the user wants code written directly without delegation.
 license: MIT
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Qoder Delegate

--- a/skills/vibe-delegate/SKILL.md
+++ b/skills/vibe-delegate/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   directly without delegating.
 license: MIT
 metadata:
-  version: 0.4.1
+  version: 0.4.2
 ---
 
 # Vibe Delegate


### PR DESCRIPTION
## Problem

Round-three live test: the setup flow read the usage scan's dominant CLI (most sessions) as *earning* the main lanes, and read "trust X" as an order to assign X the work. Both inferences are inverted. The user's dominant CLI is typically the one they orchestrate **from** — the quota under the most pressure, the thing delegation exists to relieve. And the orchestrator reviews and lands every result, so the review is the quality gate: bounded, objectively gated work does not need the best implementer, it needs surplus capacity.

The repo's own docs commanded the inversion: setup-dialogue.md said *"1600 codex sessions against 20 pi sessions tells you where the user actually works. That earns the main lane."*

## Design (debated adversarially with a second implementer before landing)

- A large usage disparity is a **signal to ask, never to assign** — the scan cannot distinguish orchestrating-in from delegating-to. New three-way role question: protect its quota, burn it as an implementer, or mixed?
- **Trust qualifies, it does not assign**: a trust answer qualifies a CLI for high-stakes lanes and for orchestrating; "trusted + spared" = qualified but normally excluded.
- **Avoid-by-default, not never**: don't bind lanes to CLIs the user protects or orchestrates from, unless asked or no acceptable alternative exists. Lanes are orchestrator-blind — from that CLI's own seat, such a lane dispatches the CLI to itself.
- **Explicit "spare X" removes X's lanes by default** and overrides blanket posture answers on any lane the user explicitly retains for X.
- The boundaries where surplus placement breaks down are stated honestly: rework cost, flaky implementers, security/concurrency/migrations, and lanes where the output **is** the product — review limits damage; it does not manufacture a good first attempt.
- Doc-only for v1: an orchestrator-exclusion schema field can't work — relays receive no orchestrator identity at dispatch — so guidance now, mechanism only on demonstrated need.

## Changes

- `skills/delegate-setup/SKILL.md` — "Delegation economics" block in step 3 (the normative home).
- `skills/delegate-setup/references/setup-dialogue.md` — usage-scan interpretation rewritten (the "earns the main lane" sentence is gone); trust-reading rule in the Q3 row, referencing (not restating) the SKILL.md spare rule.
- All skills bumped to `0.4.2` per the lockstep rule (tag after merge).

Gates: package validation passes, no "earns the main lane" survivor, 11/11 versions, no banned vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)