### PR TITLE
fix: reject agy permission-denied no-ops

### DIFF
--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -38,6 +38,10 @@ Code; treat other orchestrators as designed-for, not yet proven.
 2. `agy models` succeeds. That proves the CLI can authenticate and list the available model labels.
 3. You are in (or will point `--cd` at) the target git repository.
 
+These checks do not prove that a headless write will be approved. In `--print` mode, Antigravity
+cannot prompt for a write permission and may auto-deny it. The relay detects that denial instead of
+reporting completion.
+
 ## Choose the implementer model
 
 `agy` has a configured default model, so `--model` is optional. Use it when the human has a preferred
@@ -116,6 +120,9 @@ auto-approve tool permission requests. Use `--sandbox` when you want Antigravity
 enabled for the run. Antigravity's own help says `--dangerously-skip-permissions` auto-approves all
 tool permission requests without prompting, including a request to act outside the sandbox. Do not
 treat `--sandbox` as an enforced boundary when the flags are combined; treat the run as full access.
+If headless `--print` auto-denies a write, the relay reports `status: "failed"` and exits non-zero.
+Settings allow-rules are not documented here as a fix because they have not been demonstrated to
+apply to this headless path. Do not add the bypass flag without explicit human approval.
 
 ## Authorization model
 

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -13,7 +13,8 @@ agy models
 ```
 
 `agy models` proves the CLI can authenticate and list available model labels. The relay records the
-version it can infer from `agy changelog` into `result.json`.
+version it can infer from `agy changelog` into `result.json`. Neither command proves that a headless
+write will be approved.
 
 ## Dispatching
 
@@ -64,11 +65,12 @@ touched-files report shows only Antigravity's edits and nothing of the helper's 
 - `workdir`, `model`, `project` (the `--project` you passed, vs `projectId` parsed from the log),
   `sandbox`, `dangerouslySkipPermissions`, `resumed` (true for a `--resume-last` or `--conversation`
   run), `startedAt`, `finishedAt`
-- `stderrTail` - last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`
-- `error` - present on a launch failure, and on `timeout` and `aborted` runs
+- `stderrTail` - last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`; also present when `finalMessage` is empty so diagnostics are not discarded
+- `error` - present on a launch failure, `timeout`, `aborted`, headless permission denial, or silent no-op
 
-The helper also prints a summary to stdout and exits with Antigravity's exit code, so a wrapping script
-can branch on success/failure directly.
+The helper also prints a summary to stdout and normally exits with Antigravity's exit code. It forces
+exit 1 when Antigravity exits 0 after a detected headless permission denial or with neither a final
+message nor observable working-tree changes, so a wrapping script can branch on success/failure directly.
 
 ## Waiting for completion
 
@@ -102,12 +104,15 @@ process has exited and `result.json` is written.
   smaller briefs, then re-dispatch.
 - **`status: failed`:** read `result.json`'s `stderrTail`, `stderrPath`, and `logPath` for the cause.
   Common causes: auth lapse, an unknown model label, timeout, or a permission the run needed.
-- **A run stalls on permissions:** either configure Antigravity permissions for the actions the task
-  needs, or ask the human whether to re-run with `--dangerously-skip-permissions`. Pair risky runs with
-  `--sandbox` when terminal restrictions are appropriate.
-- **Empty `finalMessage`:** Antigravity finished without emitting a closing text summary. The edits may
-  still be correct - check `touchedFiles` and the diff. To get a report next time, add a
-  `<structured_output_contract>` block (see [writing-the-brief.md](writing-the-brief.md)).
+- **Headless write permission denied:** the relay detects Antigravity's `no output produced ...
+  auto-denied` stderr sentinel, reports `status: failed`, preserves `stderrTail`, and exits 1. Settings
+  allow-rules are not recommended here because they have not been demonstrated to apply in
+  `--print` mode. Ask the human before re-dispatching with `--dangerously-skip-permissions`; that flag
+  auto-approves every tool permission request and the run must be treated as full access.
+- **Empty `finalMessage`:** a run with edits may still be correct - check `touchedFiles`, the diff, and
+  the preserved `stderrTail`. With no observable edits, the relay reports `status: failed` rather than
+  claiming completion. To get a report next time, add a `<structured_output_contract>` block (see
+  [writing-the-brief.md](writing-the-brief.md)).
 
 ## What the helper is doing
 

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -60,7 +60,8 @@
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `agy` binary exits 127;
- * otherwise the exit code mirrors Antigravity's own (0 success, non-zero failure).
+ * otherwise the exit code mirrors Antigravity's own, except that an exit-zero
+ * permission denial or silent write-dispatch no-op is forced to exit 1.
  * If the child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome -
@@ -556,24 +557,35 @@ function dispatchToAgy(opts, brief, run, writeResult, watchdogMs) {
     if (watchdogFired) killChild(child, "SIGKILL");
     const finalMessage = stdout.trim();
     if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
+    const touchedFiles = gitTouchedFiles(opts.cd);
+    const stderr = readFileSync(run.stderrPath, "utf8");
+    const diagnostics = stderr.split("\n").map((line) => line.trimEnd()).filter(Boolean).slice(-20);
+    const permissionDenied = /no output produced\s+[—-]\s+a tool required the "([^"]+)" permission that headless\s+mode cannot prompt for, so it was auto-denied/i.exec(stderr);
+    // agy-delegate has no read-only dispatch mode: a report-only analysis can complete
+    // with a clean tree, but a write-capable coding dispatch with neither evidence is a no-op.
+    const silentNoop = code === 0 && !finalMessage && (!Array.isArray(touchedFiles) || touchedFiles.length === 0);
     // A timed-out run is failed even if agy handles SIGTERM by exiting 0 -
     // orchestrators key off status and the relay exit code.
-    const succeeded = code === 0 && !watchdogFired;
+    const succeeded = code === 0 && !watchdogFired && !permissionDenied && !silentNoop;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const result = writeResult({
       status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
       exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
       signal: signal ?? null,
       finalMessage,
-      touchedFiles: gitTouchedFiles(opts.cd),
-      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      touchedFiles,
+      ...(!succeeded || !finalMessage ? { stderrTail: diagnostics } : {}),
       ...(watchdogFired
         ? {
             error: opts.timeout !== null
               ? `agy did not finish within --timeout ${opts.timeout}; killed by the relay watchdog`
               : `agy did not exit within --print-timeout ${opts.printTimeout} plus 60s grace; killed by the relay watchdog`,
           }
-        : {}),
+        : permissionDenied
+          ? { error: `Antigravity auto-denied the ${permissionDenied[1]} permission because headless --print cannot prompt; ask the human whether to re-dispatch with --dangerously-skip-permissions and treat that run as full access` }
+          : silentNoop
+            ? { error: "agy exited 0 without a final message or observable working-tree changes; the relay cannot confirm this write dispatch completed" }
+            : {}),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -340,7 +340,11 @@ function gitWorktreeFingerprint(cwd) {
       fingerprint.update(String(stat.mode)).update("\0");
       if (stat.isSymbolicLink()) fingerprint.update(readlinkSync(fullPath));
       else if (stat.isFile()) fingerprint.update(git(["hash-object", "--no-filters", "--", path]));
-      else return null;
+      else if (stat.isDirectory()) {
+        const nestedState = gitWorktreeFingerprint(fullPath);
+        if (nestedState === null) return null;
+        fingerprint.update("submodule\0").update(git(["-C", fullPath, "rev-parse", "--verify", "HEAD"])).update(nestedState);
+      } else return null;
     }
     return fingerprint.digest("hex");
   } catch {

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -448,6 +448,7 @@ function reportVersionTimeout(writeResult, run, timeoutMs, error) {
 }
 
 function dispatchToAgy(opts, brief, run, writeResult, watchdogMs) {
+  const beforeTree = gitTouchedFiles(opts.cd);
   const argv = buildArgv(opts, brief, run);
   // Antigravity's installer provides a native `agy` binary. Launch directly so
   // multi-line briefs and paths with spaces are passed as argv, not shell text.
@@ -562,8 +563,9 @@ function dispatchToAgy(opts, brief, run, writeResult, watchdogMs) {
     const diagnostics = stderr.split("\n").map((line) => line.trimEnd()).filter(Boolean).slice(-20);
     const permissionDenied = /no output produced\s+[—-]\s+a tool required the "([^"]+)" permission that headless\s+mode cannot prompt for, so it was auto-denied/i.exec(stderr);
     // agy-delegate has no read-only dispatch mode: a report-only analysis can complete
-    // with a clean tree, but a write-capable coding dispatch with neither evidence is a no-op.
-    const silentNoop = code === 0 && !finalMessage && (!Array.isArray(touchedFiles) || touchedFiles.length === 0);
+    // without edits, but a write-capable coding dispatch with neither evidence is a no-op.
+    const treeChanged = beforeTree !== null && touchedFiles !== null && JSON.stringify(beforeTree) !== JSON.stringify(touchedFiles);
+    const silentNoop = code === 0 && !finalMessage && !treeChanged;
     // A timed-out run is failed even if agy handles SIGTERM by exiting 0 -
     // orchestrators key off status and the relay exit code.
     const succeeded = code === 0 && !watchdogFired && !permissionDenied && !silentNoop;

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -343,7 +343,16 @@ function gitWorktreeFingerprint(cwd) {
       else if (stat.isDirectory()) {
         const nestedState = gitWorktreeFingerprint(fullPath);
         if (nestedState === null) return null;
-        fingerprint.update("submodule\0").update(git(["-C", fullPath, "rev-parse", "--verify", "HEAD"])).update(nestedState);
+        let headState;
+        try {
+          headState = git(["-C", fullPath, "rev-parse", "--verify", "HEAD"]);
+        } catch {
+          const symbolicHead = git(["-C", fullPath, "symbolic-ref", "--quiet", "HEAD"]).toString("utf8").trim();
+          const target = spawnSync("git", ["-C", fullPath, "show-ref", "--verify", "--quiet", symbolicHead], { cwd, timeout: 10_000, killSignal: "SIGKILL", stdio: "ignore" });
+          if (target.status !== 1) return null;
+          headState = Buffer.from(`unborn\0${symbolicHead}`);
+        }
+        fingerprint.update("submodule\0").update(headState).update(nestedState);
       } else return null;
     }
     return fingerprint.digest("hex");

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -72,7 +72,8 @@
  */
 
 import {spawn, execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, readlinkSync, lstatSync, existsSync, appendFileSync } from "node:fs";
 import {join, resolve, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir } from "node:os";
@@ -310,6 +311,43 @@ function gitTouchedFiles(cwd) {
   }
 }
 
+function gitWorktreeFingerprint(cwd) {
+  try {
+    const git = (args) => execFileSync("git", args, {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const status = git(["status", "--porcelain=v1", "-z", "--untracked-files=all", "--no-renames"]);
+    const fingerprint = createHash("sha256").update("status\0").update(status);
+    fingerprint.update("\0index\0").update(git(["diff", "--cached", "--raw", "--full-index", "--no-renames", "-z", "--"]));
+    fingerprint.update("\0worktree\0").update(git(["diff", "--raw", "--full-index", "--no-renames", "-z", "--"]));
+
+    const paths = [...new Set(status.toString("utf8").split("\0").filter(Boolean).map((entry) => entry.slice(3)))].sort();
+    for (const path of paths) {
+      const fullPath = join(cwd, path);
+      fingerprint.update("\0path\0").update(path).update("\0");
+      let stat;
+      try {
+        stat = lstatSync(fullPath);
+      } catch (error) {
+        if (error?.code !== "ENOENT") throw error;
+        fingerprint.update("missing");
+        continue;
+      }
+      fingerprint.update(String(stat.mode)).update("\0");
+      if (stat.isSymbolicLink()) fingerprint.update(readlinkSync(fullPath));
+      else if (stat.isFile()) fingerprint.update(git(["hash-object", "--no-filters", "--", path]));
+      else return null;
+    }
+    return fingerprint.digest("hex");
+  } catch {
+    return null;
+  }
+}
+
 function timestamp() {
   return new Date().toISOString().replace(/[:.]/g, "-");
 }
@@ -448,7 +486,7 @@ function reportVersionTimeout(writeResult, run, timeoutMs, error) {
 }
 
 function dispatchToAgy(opts, brief, run, writeResult, watchdogMs) {
-  const beforeTree = gitTouchedFiles(opts.cd);
+  const beforeState = gitWorktreeFingerprint(opts.cd);
   const argv = buildArgv(opts, brief, run);
   // Antigravity's installer provides a native `agy` binary. Launch directly so
   // multi-line briefs and paths with spaces are passed as argv, not shell text.
@@ -564,8 +602,9 @@ function dispatchToAgy(opts, brief, run, writeResult, watchdogMs) {
     const permissionDenied = /no output produced\s+[—-]\s+a tool required the "([^"]+)" permission that headless\s+mode cannot prompt for, so it was auto-denied/i.exec(stderr);
     // agy-delegate has no read-only dispatch mode: a report-only analysis can complete
     // without edits, but a write-capable coding dispatch with neither evidence is a no-op.
-    const treeChanged = beforeTree !== null && touchedFiles !== null && JSON.stringify(beforeTree) !== JSON.stringify(touchedFiles);
-    const silentNoop = code === 0 && !finalMessage && !treeChanged;
+    const afterState = gitWorktreeFingerprint(opts.cd);
+    const worktreeChanged = beforeState !== null && afterState !== null && beforeState !== afterState;
+    const silentNoop = code === 0 && !finalMessage && !worktreeChanged;
     // A timed-out run is failed even if agy handles SIGTERM by exiting 0 -
     // orchestrators key off status and the relay exit code.
     const succeeded = code === 0 && !watchdogFired && !permissionDenied && !silentNoop;

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -34,6 +34,10 @@ if (process.env.SMOKE_MODE === "agy-analysis") {
   console.log("fake agy analysis completed");
   process.exit(0);
 }
+if (process.env.SMOKE_MODE === "agy-silent-edit") {
+  fs.appendFileSync(process.env.SMOKE_EDIT_FILE, "dispatch edit\n");
+  process.exit(0);
+}
 if (process.env.SMOKE_MODE === "agy-silent-noop") process.exit(0);
 if (process.env.SMOKE_MODE === "qoder-success") {
   fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -26,6 +26,15 @@ if (process.env.SMOKE_MODE === "capture") {
   fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
   process.exit(0);
 }
+if (process.env.SMOKE_MODE === "agy-permission-denied") {
+  console.error('jetski: no output produced — a tool required the "write_file" permission that headless\nmode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow\nin settings.json (e.g. write_file(<target>)). Alternatively, re-run with\n--dangerously-skip-permissions to auto-approve all tools.');
+  process.exit(0);
+}
+if (process.env.SMOKE_MODE === "agy-analysis") {
+  console.log("fake agy analysis completed");
+  process.exit(0);
+}
+if (process.env.SMOKE_MODE === "agy-silent-noop") process.exit(0);
 if (process.env.SMOKE_MODE === "qoder-success") {
   fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
   console.log(JSON.stringify({

--- a/test/fixtures/fake-cli.cs
+++ b/test/fixtures/fake-cli.cs
@@ -36,6 +36,10 @@ class FakeCli {
       Console.WriteLine("fake agy analysis completed");
       return 0;
     }
+    if (mode == "agy-silent-edit") {
+      File.AppendAllText(Environment.GetEnvironmentVariable("SMOKE_EDIT_FILE"), "dispatch edit\n");
+      return 0;
+    }
     if (mode == "agy-silent-noop") return 0;
     if (Environment.GetEnvironmentVariable("SMOKE_MODE") == "qoder-success") {
       File.WriteAllLines(Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE"), args);

--- a/test/fixtures/fake-cli.cs
+++ b/test/fixtures/fake-cli.cs
@@ -28,6 +28,15 @@ class FakeCli {
       File.WriteAllLines(Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE"), args);
       return 0;
     }
+    if (mode == "agy-permission-denied") {
+      Console.Error.WriteLine("jetski: no output produced — a tool required the \"write_file\" permission that headless\nmode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow\nin settings.json (e.g. write_file(<target>)). Alternatively, re-run with\n--dangerously-skip-permissions to auto-approve all tools.");
+      return 0;
+    }
+    if (mode == "agy-analysis") {
+      Console.WriteLine("fake agy analysis completed");
+      return 0;
+    }
+    if (mode == "agy-silent-noop") return 0;
     if (Environment.GetEnvironmentVariable("SMOKE_MODE") == "qoder-success") {
       File.WriteAllLines(Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE"), args);
       Console.WriteLine("{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"qoder-session-1\",\"model\":\"performance\",\"permissionMode\":\"auto\"}");

--- a/test/relay/agy.mjs
+++ b/test/relay/agy.mjs
@@ -37,8 +37,10 @@ export async function runAgy(h) {
 
   const dirtySilent = run("dirty-silent-noop", "agy-silent-noop", "pre-existing.txt");
   h.check("agy PR #56 regression: pre-existing dirt is not dispatch evidence",
-    dirtySilent.result.status !== 0 &&
+    dirtySilent.result.status === 1 &&
     dirtySilent.value.status === "failed" &&
+    dirtySilent.value.exitCode === 1 &&
+    dirtySilent.value.error?.includes("without a final message") &&
     dirtySilent.value.touchedFiles?.some((line) => line.endsWith("pre-existing.txt")));
 
   const dirtyEdited = run("dirty-silent-edit", "agy-silent-edit", "pre-existing.txt");
@@ -53,5 +55,6 @@ export async function runAgy(h) {
   h.check("agy analysis: a report without edits remains completed",
     analysis.result.status === 0 &&
     analysis.value.status === "completed" &&
+    analysis.value.exitCode === 0 &&
     analysis.value.finalMessage === "fake agy analysis completed");
 }

--- a/test/relay/agy.mjs
+++ b/test/relay/agy.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export async function runAgy(h) {
@@ -17,6 +17,13 @@ export async function runAgy(h) {
     runGit(workDir, ["-c", "protocol.file.allow=always", "submodule", "add", "-q", sourceDir, "nested"]);
     runGit(workDir, ["-c", "user.name=Relay Smoke", "-c", "user.email=relay-smoke@example.invalid", "commit", "-qm", "fixture"]);
     writeFileSync(join(workDir, "nested", "tracked.txt"), "pre-existing submodule dirt\n");
+    return workDir;
+  };
+  const unbornNestedRepo = (name) => {
+    const workDir = h.freshRepo(`work-${name}-agy`);
+    const nestedDir = join(workDir, "nested");
+    mkdirSync(nestedDir);
+    runGit(nestedDir, ["init", "-q"]);
     return workDir;
   };
   const run = (name, mode, preexistingFile = null, workDir = h.freshRepo(`work-${name}-agy`)) => {
@@ -81,6 +88,15 @@ export async function runAgy(h) {
     dirtySubmoduleEdited.value.exitCode === 0 &&
     dirtySubmoduleEdited.value.finalMessage === "" &&
     dirtySubmoduleEdited.value.touchedFiles?.some((line) => line.endsWith("nested")));
+
+  const unbornNestedEdited = run("unborn-nested-edit", "agy-silent-edit", "pre-existing.txt", unbornNestedRepo("unborn-nested-edit"));
+  h.check("agy PR #56 regression: an unborn nested repo does not erase dispatch evidence",
+    unbornNestedEdited.result.status === 0 &&
+    unbornNestedEdited.value.status === "completed" &&
+    unbornNestedEdited.value.exitCode === 0 &&
+    unbornNestedEdited.value.finalMessage === "" &&
+    unbornNestedEdited.value.touchedFiles?.some((line) => line.endsWith("nested/")) &&
+    unbornNestedEdited.value.touchedFiles?.some((line) => line.endsWith("pre-existing.txt")));
 
   const analysis = run("analysis", "agy-analysis");
   h.check("agy analysis: a report without edits remains completed",

--- a/test/relay/agy.mjs
+++ b/test/relay/agy.mjs
@@ -12,26 +12,42 @@ export async function runAgy(h) {
       "--brief", h.briefPath,
       "--cd", workDir,
       "--out-dir", outDir,
-    ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 15_000 });
+    ], {
+      env: { ...h.baseEnv, SMOKE_MODE: mode, ...(preexistingFile ? { SMOKE_EDIT_FILE: preexistingFile } : {}) },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
     return { result, value: existsSync(join(outDir, "result.json")) ? h.result(outDir) : {} };
   };
 
   const denied = run("permission-denied", "agy-permission-denied");
   h.check("agy permission denial: exit-zero no-op is reported as failed with diagnostics",
-    denied.result.status !== 0 &&
+    denied.result.status === 1 &&
     denied.value.status === "failed" &&
+    denied.value.exitCode === 1 &&
     denied.value.error?.includes("headless --print") &&
     denied.value.stderrTail?.some((line) => line.includes("auto-denied")));
 
   const silent = run("silent-noop", "agy-silent-noop");
   h.check("agy silent no-op: no final message or edits cannot report completed",
-    silent.result.status !== 0 && silent.value.status === "failed");
+    silent.result.status === 1 &&
+    silent.value.status === "failed" &&
+    silent.value.exitCode === 1 &&
+    silent.value.error?.includes("without a final message"));
 
   const dirtySilent = run("dirty-silent-noop", "agy-silent-noop", "pre-existing.txt");
   h.check("agy PR #56 regression: pre-existing dirt is not dispatch evidence",
     dirtySilent.result.status !== 0 &&
     dirtySilent.value.status === "failed" &&
     dirtySilent.value.touchedFiles?.some((line) => line.endsWith("pre-existing.txt")));
+
+  const dirtyEdited = run("dirty-silent-edit", "agy-silent-edit", "pre-existing.txt");
+  h.check("agy PR #56 regression: editing pre-existing dirt is dispatch evidence",
+    dirtyEdited.result.status === 0 &&
+    dirtyEdited.value.status === "completed" &&
+    dirtyEdited.value.exitCode === 0 &&
+    dirtyEdited.value.finalMessage === "" &&
+    dirtyEdited.value.touchedFiles?.some((line) => line.endsWith("pre-existing.txt")));
 
   const analysis = run("analysis", "agy-analysis");
   h.check("agy analysis: a report without edits remains completed",

--- a/test/relay/agy.mjs
+++ b/test/relay/agy.mjs
@@ -1,14 +1,16 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export async function runAgy(h) {
-  const run = (name, mode) => {
+  const run = (name, mode, preexistingFile = null) => {
     const outDir = join(h.scratch, `out-${name}-agy`);
+    const workDir = h.freshRepo(`work-${name}-agy`);
+    if (preexistingFile) writeFileSync(join(workDir, preexistingFile), "pre-existing change\n");
     const result = spawnSync(process.execPath, [
       h.relayPath("agy"),
       "--brief", h.briefPath,
-      "--cd", h.freshRepo(`work-${name}-agy`),
+      "--cd", workDir,
       "--out-dir", outDir,
     ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 15_000 });
     return { result, value: existsSync(join(outDir, "result.json")) ? h.result(outDir) : {} };
@@ -24,6 +26,12 @@ export async function runAgy(h) {
   const silent = run("silent-noop", "agy-silent-noop");
   h.check("agy silent no-op: no final message or edits cannot report completed",
     silent.result.status !== 0 && silent.value.status === "failed");
+
+  const dirtySilent = run("dirty-silent-noop", "agy-silent-noop", "pre-existing.txt");
+  h.check("agy PR #56 regression: pre-existing dirt is not dispatch evidence",
+    dirtySilent.result.status !== 0 &&
+    dirtySilent.value.status === "failed" &&
+    dirtySilent.value.touchedFiles?.some((line) => line.endsWith("pre-existing.txt")));
 
   const analysis = run("analysis", "agy-analysis");
   h.check("agy analysis: a report without edits remains completed",

--- a/test/relay/agy.mjs
+++ b/test/relay/agy.mjs
@@ -1,0 +1,33 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export async function runAgy(h) {
+  const run = (name, mode) => {
+    const outDir = join(h.scratch, `out-${name}-agy`);
+    const result = spawnSync(process.execPath, [
+      h.relayPath("agy"),
+      "--brief", h.briefPath,
+      "--cd", h.freshRepo(`work-${name}-agy`),
+      "--out-dir", outDir,
+    ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 15_000 });
+    return { result, value: existsSync(join(outDir, "result.json")) ? h.result(outDir) : {} };
+  };
+
+  const denied = run("permission-denied", "agy-permission-denied");
+  h.check("agy permission denial: exit-zero no-op is reported as failed with diagnostics",
+    denied.result.status !== 0 &&
+    denied.value.status === "failed" &&
+    denied.value.error?.includes("headless --print") &&
+    denied.value.stderrTail?.some((line) => line.includes("auto-denied")));
+
+  const silent = run("silent-noop", "agy-silent-noop");
+  h.check("agy silent no-op: no final message or edits cannot report completed",
+    silent.result.status !== 0 && silent.value.status === "failed");
+
+  const analysis = run("analysis", "agy-analysis");
+  h.check("agy analysis: a report without edits remains completed",
+    analysis.result.status === 0 &&
+    analysis.value.status === "completed" &&
+    analysis.value.finalMessage === "fake agy analysis completed");
+}

--- a/test/relay/agy.mjs
+++ b/test/relay/agy.mjs
@@ -3,9 +3,24 @@ import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export async function runAgy(h) {
-  const run = (name, mode, preexistingFile = null) => {
-    const outDir = join(h.scratch, `out-${name}-agy`);
+  const runGit = (cwd, args) => {
+    const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+    if (result.status !== 0) throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  };
+  const dirtySubmoduleRepo = (name) => {
+    const sourceDir = h.freshRepo(`source-${name}-agy`);
+    writeFileSync(join(sourceDir, "tracked.txt"), "committed\n");
+    runGit(sourceDir, ["add", "tracked.txt"]);
+    runGit(sourceDir, ["-c", "user.name=Relay Smoke", "-c", "user.email=relay-smoke@example.invalid", "commit", "-qm", "fixture"]);
+
     const workDir = h.freshRepo(`work-${name}-agy`);
+    runGit(workDir, ["-c", "protocol.file.allow=always", "submodule", "add", "-q", sourceDir, "nested"]);
+    runGit(workDir, ["-c", "user.name=Relay Smoke", "-c", "user.email=relay-smoke@example.invalid", "commit", "-qm", "fixture"]);
+    writeFileSync(join(workDir, "nested", "tracked.txt"), "pre-existing submodule dirt\n");
+    return workDir;
+  };
+  const run = (name, mode, preexistingFile = null, workDir = h.freshRepo(`work-${name}-agy`)) => {
+    const outDir = join(h.scratch, `out-${name}-agy`);
     if (preexistingFile) writeFileSync(join(workDir, preexistingFile), "pre-existing change\n");
     const result = spawnSync(process.execPath, [
       h.relayPath("agy"),
@@ -50,6 +65,22 @@ export async function runAgy(h) {
     dirtyEdited.value.exitCode === 0 &&
     dirtyEdited.value.finalMessage === "" &&
     dirtyEdited.value.touchedFiles?.some((line) => line.endsWith("pre-existing.txt")));
+
+  const dirtySubmoduleNoop = run("dirty-submodule-noop", "agy-silent-noop", null, dirtySubmoduleRepo("dirty-submodule-noop"));
+  h.check("agy PR #56 regression: unchanged dirty submodule is not dispatch evidence",
+    dirtySubmoduleNoop.result.status === 1 &&
+    dirtySubmoduleNoop.value.status === "failed" &&
+    dirtySubmoduleNoop.value.exitCode === 1 &&
+    dirtySubmoduleNoop.value.error?.includes("without a final message") &&
+    dirtySubmoduleNoop.value.touchedFiles?.some((line) => line.endsWith("nested")));
+
+  const dirtySubmoduleEdited = run("dirty-submodule-edit", "agy-silent-edit", join("nested", "tracked.txt"), dirtySubmoduleRepo("dirty-submodule-edit"));
+  h.check("agy PR #56 regression: editing an already-dirty submodule is dispatch evidence",
+    dirtySubmoduleEdited.result.status === 0 &&
+    dirtySubmoduleEdited.value.status === "completed" &&
+    dirtySubmoduleEdited.value.exitCode === 0 &&
+    dirtySubmoduleEdited.value.finalMessage === "" &&
+    dirtySubmoduleEdited.value.touchedFiles?.some((line) => line.endsWith("nested")));
 
   const analysis = run("analysis", "agy-analysis");
   h.check("agy analysis: a report without edits remains completed",

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -1,6 +1,7 @@
 import { runPackageShape } from "./package-shape.mjs";
 import { runSyntax } from "./syntax.mjs";
 import { runCodex } from "./codex.mjs";
+import { runAgy } from "./agy.mjs";
 import { runCursor } from "./cursor.mjs";
 import { runVibe } from "./vibe.mjs";
 import { runAtomic } from "./atomic.mjs";
@@ -17,6 +18,7 @@ export const runners = [
   ["package-shape", runPackageShape],
   ["syntax", runSyntax],
   ["codex", runCodex],
+  ["agy", runAgy],
   ["cursor", runCursor],
   ["vibe", runVibe],
   ["atomic", runAtomic],


### PR DESCRIPTION
## Summary

- classify Antigravity's exit-zero headless permission-denial sentinel as `failed`, preserve its stderr diagnostics, and force relay exit 1
- reject a silent write-dispatch no-op while keeping report-only analysis runs successful
- document the verified headless permission behavior without claiming settings allow-rules work in `--print` mode

The existing `delegate-relay.result.v1` `failed` status expresses both failures, so this does not change the wire schema.

## Validation

- `node test/relay-smoke.mjs --only agy`
- `node --check skills/agy-delegate/scripts/relay.mjs`
- `node --check test/relay/agy.mjs`
- `node --check test/fixtures/fake-cli.cjs`
- `node --check test/relay/index.mjs`
- `git diff --check`
- `node test/relay-parity.mjs`
- `node test/relay-isolated.mjs`
- `node test/relay-smoke.mjs`
- `npx -y skills add . --list`

The native Windows fake-CLI branch is covered by the repository's Windows CI matrix; it was not run locally on macOS.

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Headless runs encountering denied permissions now report failure and exit with a nonzero status.
  * Silent write-capable runs without output or file changes now provide clear failure diagnostics.
  * Failure results preserve recent diagnostic information and detect changes across files, directories, symlinks, and submodules.

* **Documentation**
  * Clarified permission requirements, failure conditions, diagnostics, and troubleshooting guidance for headless runs.

* **Tests**
  * Added coverage for permission denials, silent no-op runs, successful analysis-only runs, and varied repository states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->