### PR TITLE
fix: share Grok models discovery capture

### DIFF
--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -123,12 +123,14 @@ function captureProbe(binaryPath, args, useShell) {
       stdio: ["pipe", "pipe", "pipe"],
       shell: useShell,
     });
+    const stdout = result.stdout || "";
     return {
       ok: !result.error && result.status === 0,
-      output: stripAnsi(`${result.stdout || ""}${result.stderr || ""}`),
+      stdout,
+      output: stripAnsi(`${stdout}${result.stderr || ""}`),
     };
   } catch {
-    return { ok: false, output: "" };
+    return { ok: false, stdout: "", output: "" };
   }
 }
 
@@ -161,7 +163,7 @@ function readAuthField(raw, jsonField) {
   }
 }
 
-function probeAuth(impl, binaryPath) {
+function probeAuth(impl, binaryPath, captured = null) {
   if (!impl.authProbe) return null;
   const { args, jsonField, successPattern, failPattern, missMeansFalse } = impl.authProbe;
   const useShell = needsWindowsShell(impl, binaryPath);
@@ -179,7 +181,7 @@ function probeAuth(impl, binaryPath) {
     }
   }
 
-  const { ok, output } = captureProbe(binaryPath, args, useShell);
+  const { ok, output } = captured || captureProbe(binaryPath, args, useShell);
   // failPattern first: "not logged in" also contains "logged in".
   if (failPattern && failPattern.test(output)) return false;
   if (successPattern) {
@@ -247,7 +249,7 @@ function modelFilePath(probe) {
   return join(base, probe.file);
 }
 
-function probeModels(impl, binaryPath) {
+function probeModels(impl, binaryPath, captured = null) {
   const probe = impl.modelProbe;
   if (!probe) {
     return { status: "unsupported", values: [], truncated: false };
@@ -262,6 +264,9 @@ function probeModels(impl, binaryPath) {
       // No cache until the CLI has run once; that is not a discovery failure worth throwing on.
       return failedModels();
     }
+  }
+  if (captured) {
+    return captured.ok ? parseModelLines(captured.stdout, probe.format) : failedModels();
   }
   try {
     const raw = runProbe(binaryPath, probe.args, needsWindowsShell(impl, binaryPath));
@@ -356,15 +361,25 @@ function main(argv) {
       missing.push({ key: impl.key, binary: impl.binary, skill: impl.skill });
       continue;
     }
+    const version = probeVersion(impl, binaryPath);
+    const authArgs = impl.authProbe && !impl.authProbe.jsonField ? impl.authProbe.args : null;
+    const modelArgs = impl.modelProbe?.args;
+    const sharedCapture =
+      authArgs &&
+      modelArgs &&
+      authArgs.length === modelArgs.length &&
+      authArgs.every((arg, index) => arg === modelArgs[index])
+        ? captureProbe(binaryPath, authArgs, needsWindowsShell(impl, binaryPath))
+        : null;
     const entry = {
       key: impl.key,
       skill: impl.skill,
       binary: impl.binary,
-      version: probeVersion(impl, binaryPath),
+      version,
       path: binaryPath,
-      authenticated: probeAuth(impl, binaryPath),
+      authenticated: probeAuth(impl, binaryPath, sharedCapture),
       supports: [...impl.supports],
-      models: probeModels(impl, binaryPath),
+      models: probeModels(impl, binaryPath, sharedCapture),
     };
     if (withUsage) entry.usage = probeUsage(impl);
     discovered.push(entry);

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -53,6 +53,77 @@ export function runDelegateSetup(h) {
     agyReport?.discovered.find(({ key }) => key === "agy")?.version === "1.2.3",
   );
 
+  const grokProbeDir = join(h.scratch, "discover-grok");
+  mkdirSync(grokProbeDir);
+  const grokProbeSource = `
+const fs = require("node:fs");
+const [command] = process.argv.slice(2);
+if (command === "version" || command === "--version") {
+  console.log("fake-grok 1.0.0");
+  process.exit(0);
+}
+if (command !== "models") process.exit(2);
+let count = 0;
+try { count = Number(fs.readFileSync(process.env.GROK_PROBE_COUNT, "utf8")) || 0; } catch {}
+count += 1;
+fs.writeFileSync(process.env.GROK_PROBE_COUNT, String(count));
+const first = process.env.GROK_PROBE_FIRST;
+const observation = count === 1
+  ? first
+  : first === "models" ? "unauthenticated" : first === "unauthenticated" ? "models" : "ambiguous";
+if (observation === "models") {
+  console.log("Available models");
+  console.log("* grok-code-fast-1 (default)");
+} else if (observation === "unauthenticated") {
+  console.error("You are not authenticated.");
+  process.exit(1);
+} else {
+  console.error("Temporary service failure.");
+  process.exit(1);
+}
+`;
+  if (h.WIN) {
+    writeFileSync(join(grokProbeDir, "fake-grok.cjs"), grokProbeSource);
+    writeFileSync(
+      join(grokProbeDir, "grok.cmd"),
+      `@"${process.execPath}" "%~dp0fake-grok.cjs" %*\r\n`,
+    );
+  } else {
+    const grokProbePath = join(grokProbeDir, "grok");
+    writeFileSync(grokProbePath, `#!${process.execPath}\n${grokProbeSource}`);
+    chmodSync(grokProbePath, 0o755);
+  }
+  for (const [first, authenticated, modelStatus] of [
+    ["models", true, "reported"],
+    ["unauthenticated", false, "failed"],
+    ["ambiguous", null, "failed"],
+  ]) {
+    const countPath = join(grokProbeDir, `${first}.count`);
+    const grokDiscover = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: grokProbeDir,
+        GROK_PROBE_COUNT: countPath,
+        GROK_PROBE_FIRST: first,
+      },
+    });
+    let grokReport = null;
+    try {
+      if (grokDiscover.status === 0) grokReport = JSON.parse(grokDiscover.stdout);
+    } catch {
+      grokReport = null;
+    }
+    const grok = grokReport?.discovered.find(({ key }) => key === "grok");
+    h.check(
+      `Grok shares one ${first} observation across auth and model discovery`,
+      readFileSync(countPath, "utf8") === "1" &&
+        grok?.authenticated === authenticated &&
+        grok?.models?.status === modelStatus &&
+        (first !== "models" || grok.models.values[0] === "grok-code-fast-1"),
+    );
+  }
+
   // Keep fixtures inside the repo tree so sandboxed CI/dev runs can write; seed a
   // minimal .git without `git init` (hooks/config writes are often blocked).
   const fleetRoot = mkdtempSync(join(h.testDir, "..", ".tmp-fleet-smoke-"));


### PR DESCRIPTION
## Root cause

`delegate-setup` ran `grok models` independently for auth and model discovery. A transient difference between those calls could report Grok as unauthenticated while still reporting models.

## Fix

- Share one captured observation when auth and model probes use the same command.
- Keep auth matching on combined plain stdout/stderr and model parsing on the unchanged raw stdout semantics.
- Cover successful, exact unauthenticated, and ambiguous flapping observations through a fake Grok CLI boundary.

## Gates

- Focused delegate-setup regression
- Node syntax and `git diff --check`
- Full relay parity, isolated, and smoke gates
- Skills package listing
- Workflow-equivalent Node 22 Linux gates in Docker

Closes #54


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic discovery of Grok authentication status and available models.
  * Correctly distinguishes authentication results from model-discovery output, including unauthenticated and ambiguous responses.
  * Preserves existing fallback behavior when discovery results are incomplete.

* **Performance**
  * Reduces redundant Grok checks by reusing a single discovery result when possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->