### PR TITLE
Restrict relay push runs to master

### DIFF
--- a/.github/workflows/relays.yml
+++ b/.github/workflows/relays.yml
@@ -2,6 +2,7 @@ name: relays
 
 on:
   push:
+    branches: [master]
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Summary

- restrict the relays workflow's `push` trigger to `master`
- retain unfiltered `pull_request` validation
- leave permissions, the Ubuntu/Windows matrix, Node 22, relay gates, and package validation unchanged

## Why

PR #61 demonstrated the duplicate cost on exact head SHA `1ed42e2c895137fc07fa73064486237329f6d5c8`:

- push run [31294252601](https://github.com/amElnagdy/delegate-skills/actions/runs/31294252601)
- pull_request run [31294266238](https://github.com/amElnagdy/delegate-skills/actions/runs/31294266238)

Both ran the same matrix. The push run needed a second attempt after cancellation, leaving the aggregate unstable until rerun.

## Expected event behavior

- same-repository feature-branch pushes: no `push` workflow run
- PR open/reopen/new-head synchronization: one `pull_request` workflow run with Ubuntu and Windows jobs
- direct or merged pushes to `master`: one `push` workflow run with the existing matrix
- fork PRs: unchanged under `pull_request`
- tag pushes: intentionally excluded; release tags point at commits already validated on `master`

The branch push for head `0d99d53ad3e317af420c58a5240212f9b7ea452d` produced zero workflow runs before this PR was opened.

## Validation

- Ruby YAML parse
- `node test/relay-parity.mjs`
- `node test/relay-isolated.mjs`
- `node test/relay-smoke.mjs`
- `npx -y skills add . --list`
- independent semantics/spec review: PASS
- independent standards/minimality review: PASS

Closes #62