### PR TITLE
fix(relay): scan streamed events incrementally

### DIFF
--- a/skills/claude-delegate/scripts/relay.mjs
+++ b/skills/claude-delegate/scripts/relay.mjs
@@ -133,6 +133,7 @@ const IMPLEMENTER_KEY = "claude";
 
 function makeEventScanner(onObject) {
   let buf = "";
+  let index = 0;
   let depth = 0;
   let start = -1;
   let inString = false;
@@ -140,52 +141,55 @@ function makeEventScanner(onObject) {
   return (chunk) => {
     if (!chunk) return;
     buf += chunk;
-    for (let i = 0; i < buf.length; i += 1) {
-      const ch = buf[i];
-      // Only track strings inside an object (depth > 0). At depth 0 we are
-      // skipping a junk prefix, and an unmatched `"` there must not swallow the
-      // real `{...}` that follows in the same chunk.
-      if (inString) {
-        if (escaped) escaped = false;
-        else if (ch === "\\") escaped = true;
-        else if (ch === '"') inString = false;
-      } else if (ch === '"') {
-        if (depth > 0) inString = true;
-      } else if (ch === "{") {
-        if (depth === 0) start = i;
-        depth += 1;
-      } else if (ch === "}") {
-        if (depth > 0) {
-          depth -= 1;
-          if (depth === 0 && start !== -1) {
-            const slice = buf.slice(start, i + 1);
-            try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
-            start = -1;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
           }
         }
+        index += 1;
       }
-      if (i === buf.length - 1 && depth > 0 && start !== -1 && buf.length - start > MAX_BUFFERED_CHARS) {
-        // A complete object may exceed the retained-input cap within this
-        // chunk. Drop only an oversized partial, then rescan its suffix so a
-        // later concatenated event is not lost.
-        buf = buf.slice(start + MAX_BUFFERED_CHARS);
-        start = -1;
-        depth = 0;
-        inString = false;
-        escaped = false;
-        i = -1;
-      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
     }
-    // Retain only an in-progress object (if any) so the buffer cannot grow
-    // without bound; everything already emitted or skipped is dropped.  Reset
-    // the scanner state: the next call re-derives depth/string/escape by
-    // scanning the retained prefix (which always begins at an object's `{`)
-    // from scratch.
-    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
-    start = -1;
-    depth = 0;
-    inString = false;
-    escaped = false;
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
   };
 }
 

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -92,6 +92,7 @@ const IMPLEMENTER_KEY = "cursor";
 
 function makeEventScanner(onObject) {
   let buf = "";
+  let index = 0;
   let depth = 0;
   let start = -1;
   let inString = false;
@@ -99,52 +100,55 @@ function makeEventScanner(onObject) {
   return (chunk) => {
     if (!chunk) return;
     buf += chunk;
-    for (let i = 0; i < buf.length; i += 1) {
-      const ch = buf[i];
-      // Only track strings inside an object (depth > 0). At depth 0 we are
-      // skipping a junk prefix, and an unmatched `"` there must not swallow the
-      // real `{...}` that follows in the same chunk.
-      if (inString) {
-        if (escaped) escaped = false;
-        else if (ch === "\\") escaped = true;
-        else if (ch === '"') inString = false;
-      } else if (ch === '"') {
-        if (depth > 0) inString = true;
-      } else if (ch === "{") {
-        if (depth === 0) start = i;
-        depth += 1;
-      } else if (ch === "}") {
-        if (depth > 0) {
-          depth -= 1;
-          if (depth === 0 && start !== -1) {
-            const slice = buf.slice(start, i + 1);
-            try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
-            start = -1;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
           }
         }
+        index += 1;
       }
-      if (i === buf.length - 1 && depth > 0 && start !== -1 && buf.length - start > MAX_BUFFERED_CHARS) {
-        // A complete object may exceed the retained-input cap within this
-        // chunk. Drop only an oversized partial, then rescan its suffix so a
-        // later concatenated event is not lost.
-        buf = buf.slice(start + MAX_BUFFERED_CHARS);
-        start = -1;
-        depth = 0;
-        inString = false;
-        escaped = false;
-        i = -1;
-      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
     }
-    // Retain only an in-progress object (if any) so the buffer cannot grow
-    // without bound; everything already emitted or skipped is dropped.  Reset
-    // the scanner state: the next call re-derives depth/string/escape by
-    // scanning the retained prefix (which always begins at an object's `{`)
-    // from scratch.
-    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
-    start = -1;
-    depth = 0;
-    inString = false;
-    escaped = false;
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
   };
 }
 

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -100,6 +100,7 @@ const IMPLEMENTER_KEY = "grok";
 
 function makeEventScanner(onObject) {
   let buf = "";
+  let index = 0;
   let depth = 0;
   let start = -1;
   let inString = false;
@@ -107,52 +108,55 @@ function makeEventScanner(onObject) {
   return (chunk) => {
     if (!chunk) return;
     buf += chunk;
-    for (let i = 0; i < buf.length; i += 1) {
-      const ch = buf[i];
-      // Only track strings inside an object (depth > 0). At depth 0 we are
-      // skipping a junk prefix, and an unmatched `"` there must not swallow the
-      // real `{...}` that follows in the same chunk.
-      if (inString) {
-        if (escaped) escaped = false;
-        else if (ch === "\\") escaped = true;
-        else if (ch === '"') inString = false;
-      } else if (ch === '"') {
-        if (depth > 0) inString = true;
-      } else if (ch === "{") {
-        if (depth === 0) start = i;
-        depth += 1;
-      } else if (ch === "}") {
-        if (depth > 0) {
-          depth -= 1;
-          if (depth === 0 && start !== -1) {
-            const slice = buf.slice(start, i + 1);
-            try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
-            start = -1;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
           }
         }
+        index += 1;
       }
-      if (i === buf.length - 1 && depth > 0 && start !== -1 && buf.length - start > MAX_BUFFERED_CHARS) {
-        // A complete object may exceed the retained-input cap within this
-        // chunk. Drop only an oversized partial, then rescan its suffix so a
-        // later concatenated event is not lost.
-        buf = buf.slice(start + MAX_BUFFERED_CHARS);
-        start = -1;
-        depth = 0;
-        inString = false;
-        escaped = false;
-        i = -1;
-      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
     }
-    // Retain only an in-progress object (if any) so the buffer cannot grow
-    // without bound; everything already emitted or skipped is dropped.  Reset
-    // the scanner state: the next call re-derives depth/string/escape by
-    // scanning the retained prefix (which always begins at an object's `{`)
-    // from scratch.
-    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
-    start = -1;
-    depth = 0;
-    inString = false;
-    escaped = false;
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
   };
 }
 

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -81,6 +81,7 @@ const IMPLEMENTER_KEY = "kimi";
 
 function makeEventScanner(onObject) {
   let buf = "";
+  let index = 0;
   let depth = 0;
   let start = -1;
   let inString = false;
@@ -88,52 +89,55 @@ function makeEventScanner(onObject) {
   return (chunk) => {
     if (!chunk) return;
     buf += chunk;
-    for (let i = 0; i < buf.length; i += 1) {
-      const ch = buf[i];
-      // Only track strings inside an object (depth > 0). At depth 0 we are
-      // skipping a junk prefix, and an unmatched `"` there must not swallow the
-      // real `{...}` that follows in the same chunk.
-      if (inString) {
-        if (escaped) escaped = false;
-        else if (ch === "\\") escaped = true;
-        else if (ch === '"') inString = false;
-      } else if (ch === '"') {
-        if (depth > 0) inString = true;
-      } else if (ch === "{") {
-        if (depth === 0) start = i;
-        depth += 1;
-      } else if (ch === "}") {
-        if (depth > 0) {
-          depth -= 1;
-          if (depth === 0 && start !== -1) {
-            const slice = buf.slice(start, i + 1);
-            try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
-            start = -1;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
           }
         }
+        index += 1;
       }
-      if (i === buf.length - 1 && depth > 0 && start !== -1 && buf.length - start > MAX_BUFFERED_CHARS) {
-        // A complete object may exceed the retained-input cap within this
-        // chunk. Drop only an oversized partial, then rescan its suffix so a
-        // later concatenated event is not lost.
-        buf = buf.slice(start + MAX_BUFFERED_CHARS);
-        start = -1;
-        depth = 0;
-        inString = false;
-        escaped = false;
-        i = -1;
-      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
     }
-    // Retain only an in-progress object (if any) so the buffer cannot grow
-    // without bound; everything already emitted or skipped is dropped.  Reset
-    // the scanner state: the next call re-derives depth/string/escape by
-    // scanning the retained prefix (which always begins at an object's `{`)
-    // from scratch.
-    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
-    start = -1;
-    depth = 0;
-    inString = false;
-    escaped = false;
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
   };
 }
 

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -85,6 +85,7 @@ const IMPLEMENTER_KEY = "opencode";
 
 function makeEventScanner(onObject) {
   let buf = "";
+  let index = 0;
   let depth = 0;
   let start = -1;
   let inString = false;
@@ -92,52 +93,55 @@ function makeEventScanner(onObject) {
   return (chunk) => {
     if (!chunk) return;
     buf += chunk;
-    for (let i = 0; i < buf.length; i += 1) {
-      const ch = buf[i];
-      // Only track strings inside an object (depth > 0). At depth 0 we are
-      // skipping a junk prefix, and an unmatched `"` there must not swallow the
-      // real `{...}` that follows in the same chunk.
-      if (inString) {
-        if (escaped) escaped = false;
-        else if (ch === "\\") escaped = true;
-        else if (ch === '"') inString = false;
-      } else if (ch === '"') {
-        if (depth > 0) inString = true;
-      } else if (ch === "{") {
-        if (depth === 0) start = i;
-        depth += 1;
-      } else if (ch === "}") {
-        if (depth > 0) {
-          depth -= 1;
-          if (depth === 0 && start !== -1) {
-            const slice = buf.slice(start, i + 1);
-            try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
-            start = -1;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
           }
         }
+        index += 1;
       }
-      if (i === buf.length - 1 && depth > 0 && start !== -1 && buf.length - start > MAX_BUFFERED_CHARS) {
-        // A complete object may exceed the retained-input cap within this
-        // chunk. Drop only an oversized partial, then rescan its suffix so a
-        // later concatenated event is not lost.
-        buf = buf.slice(start + MAX_BUFFERED_CHARS);
-        start = -1;
-        depth = 0;
-        inString = false;
-        escaped = false;
-        i = -1;
-      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
     }
-    // Retain only an in-progress object (if any) so the buffer cannot grow
-    // without bound; everything already emitted or skipped is dropped.  Reset
-    // the scanner state: the next call re-derives depth/string/escape by
-    // scanning the retained prefix (which always begins at an object's `{`)
-    // from scratch.
-    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
-    start = -1;
-    depth = 0;
-    inString = false;
-    escaped = false;
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
   };
 }
 

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -103,6 +103,7 @@ const IMPLEMENTER_KEY = "pi";
 
 function makeEventScanner(onObject) {
   let buf = "";
+  let index = 0;
   let depth = 0;
   let start = -1;
   let inString = false;
@@ -110,52 +111,55 @@ function makeEventScanner(onObject) {
   return (chunk) => {
     if (!chunk) return;
     buf += chunk;
-    for (let i = 0; i < buf.length; i += 1) {
-      const ch = buf[i];
-      // Only track strings inside an object (depth > 0). At depth 0 we are
-      // skipping a junk prefix, and an unmatched `"` there must not swallow the
-      // real `{...}` that follows in the same chunk.
-      if (inString) {
-        if (escaped) escaped = false;
-        else if (ch === "\\") escaped = true;
-        else if (ch === '"') inString = false;
-      } else if (ch === '"') {
-        if (depth > 0) inString = true;
-      } else if (ch === "{") {
-        if (depth === 0) start = i;
-        depth += 1;
-      } else if (ch === "}") {
-        if (depth > 0) {
-          depth -= 1;
-          if (depth === 0 && start !== -1) {
-            const slice = buf.slice(start, i + 1);
-            try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
-            start = -1;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
           }
         }
+        index += 1;
       }
-      if (i === buf.length - 1 && depth > 0 && start !== -1 && buf.length - start > MAX_BUFFERED_CHARS) {
-        // A complete object may exceed the retained-input cap within this
-        // chunk. Drop only an oversized partial, then rescan its suffix so a
-        // later concatenated event is not lost.
-        buf = buf.slice(start + MAX_BUFFERED_CHARS);
-        start = -1;
-        depth = 0;
-        inString = false;
-        escaped = false;
-        i = -1;
-      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
     }
-    // Retain only an in-progress object (if any) so the buffer cannot grow
-    // without bound; everything already emitted or skipped is dropped.  Reset
-    // the scanner state: the next call re-derives depth/string/escape by
-    // scanning the retained prefix (which always begins at an object's `{`)
-    // from scratch.
-    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
-    start = -1;
-    depth = 0;
-    inString = false;
-    escaped = false;
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
   };
 }
 

--- a/skills/qoder-delegate/scripts/relay.mjs
+++ b/skills/qoder-delegate/scripts/relay.mjs
@@ -73,6 +73,7 @@ const IMPLEMENTER_KEY = "qoder";
 
 function makeEventScanner(onObject) {
   let buf = "";
+  let index = 0;
   let depth = 0;
   let start = -1;
   let inString = false;
@@ -80,52 +81,55 @@ function makeEventScanner(onObject) {
   return (chunk) => {
     if (!chunk) return;
     buf += chunk;
-    for (let i = 0; i < buf.length; i += 1) {
-      const ch = buf[i];
-      // Only track strings inside an object (depth > 0). At depth 0 we are
-      // skipping a junk prefix, and an unmatched `"` there must not swallow the
-      // real `{...}` that follows in the same chunk.
-      if (inString) {
-        if (escaped) escaped = false;
-        else if (ch === "\\") escaped = true;
-        else if (ch === '"') inString = false;
-      } else if (ch === '"') {
-        if (depth > 0) inString = true;
-      } else if (ch === "{") {
-        if (depth === 0) start = i;
-        depth += 1;
-      } else if (ch === "}") {
-        if (depth > 0) {
-          depth -= 1;
-          if (depth === 0 && start !== -1) {
-            const slice = buf.slice(start, i + 1);
-            try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
-            start = -1;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
           }
         }
+        index += 1;
       }
-      if (i === buf.length - 1 && depth > 0 && start !== -1 && buf.length - start > MAX_BUFFERED_CHARS) {
-        // A complete object may exceed the retained-input cap within this
-        // chunk. Drop only an oversized partial, then rescan its suffix so a
-        // later concatenated event is not lost.
-        buf = buf.slice(start + MAX_BUFFERED_CHARS);
-        start = -1;
-        depth = 0;
-        inString = false;
-        escaped = false;
-        i = -1;
-      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
     }
-    // Retain only an in-progress object (if any) so the buffer cannot grow
-    // without bound; everything already emitted or skipped is dropped.  Reset
-    // the scanner state: the next call re-derives depth/string/escape by
-    // scanning the retained prefix (which always begins at an object's `{`)
-    // from scratch.
-    buf = depth > 0 && start !== -1 ? buf.slice(start) : "";
-    start = -1;
-    depth = 0;
-    inString = false;
-    escaped = false;
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
   };
 }
 

--- a/skills/vibe-delegate/scripts/relay.mjs
+++ b/skills/vibe-delegate/scripts/relay.mjs
@@ -99,14 +99,19 @@ function makeLineScanner(onObject) {
   let buf = "";
   return (chunk) => {
     if (!chunk) return;
-    buf += chunk;
-    const lines = buf.split("\n");
-    buf = lines.pop() ?? "";
-    for (const line of lines) {
+    let start = 0;
+    for (;;) {
+      const end = chunk.indexOf("\n", start);
+      if (end === -1) break;
+      const line = buf + chunk.slice(start, end);
+      buf = "";
       const trimmed = line.trim();
-      if (!trimmed) continue;
-      try { onObject(JSON.parse(trimmed)); } catch { /* skip non-JSON lines */ }
+      if (trimmed) {
+        try { onObject(JSON.parse(trimmed)); } catch { /* skip non-JSON lines */ }
+      }
+      start = end + 1;
     }
+    buf += chunk.slice(start);
     if (buf.length > MAX_BUFFERED_CHARS) buf = "";
   };
 }

--- a/test/event-scanner.mjs
+++ b/test/event-scanner.mjs
@@ -26,11 +26,30 @@ function extract(source, symbol, kind, relay) {
   return source.slice(start, end);
 }
 
-function loadScanner(relay, symbol) {
+function loadScanner(relay, symbol, onVisit) {
   const source = readFileSync(join(here, "..", "skills", `${relay}-delegate`, "scripts", "relay.mjs"), "utf8");
   const maxBufferedChars = extract(source, "MAX_BUFFERED_CHARS", "const", relay);
-  const scanner = extract(source, symbol, "function", relay);
-  return new Function(`${maxBufferedChars}\n${scanner}\nreturn ${symbol};`)();
+  let scanner = extract(source, symbol, "function", relay);
+  if (onVisit) {
+    // Issue #51 needs a deterministic work bound; source instrumentation avoids a wall-clock assertion.
+    const instrumented = symbol === "makeEventScanner"
+      ? scanner.replace(
+        /(\s+)(const ch = buf\[[^\]]+\];)/,
+        "$1onVisit();$1$2",
+      )
+      : scanner.includes('const lines = buf.split("\\n");')
+        ? scanner.replace(
+          /(\s+)(const lines = buf\.split\("\\n"\);)/,
+          "$1onVisit(buf.length);$1$2",
+        )
+        : scanner.replace(
+          /(\s+)(const end = chunk\.indexOf\("\\n", start\);)/,
+          "$1onVisit(chunk.length - start);$1$2",
+        );
+    if (instrumented === scanner) throw new Error(`${relay}: could not instrument ${symbol}`);
+    scanner = instrumented;
+  }
+  return new Function("onVisit", `${maxBufferedChars}\n${scanner}\nreturn ${symbol};`)(onVisit);
 }
 
 // Parity covers every makeEventScanner copy; Vibe's makeLineScanner is tested directly.
@@ -82,6 +101,16 @@ test("event scanner: object split across chunk boundaries", () => {
   assert.deepEqual(events, []);
   scan('"y"]}');
   assert.deepEqual(events, [{ a: 1, b: ["x", "y"] }]);
+});
+
+test("event scanner: many small chunks examine each character once", () => {
+  let visits = 0;
+  const factory = loadScanner("claude", "makeEventScanner", () => { visits += 1; });
+  const { events, scan } = collectScanner(factory);
+  const event = JSON.stringify({ result: "x".repeat(4096) });
+  for (let i = 0; i < event.length; i += 16) scan(event.slice(i, i + 16));
+  assert.equal(visits, event.length);
+  assert.deepEqual(events, [{ result: "x".repeat(4096) }]);
 });
 
 test("event scanner: braces inside string values do not close the object", () => {
@@ -181,6 +210,16 @@ test("line scanner: split line parses once the newline arrives", () => {
   assert.deepEqual(events, []);
   scan('"x"]}\n{"c":2}\n');
   assert.deepEqual(events, [{ a: 1, b: ["x"] }, { c: 2 }]);
+});
+
+test("line scanner: many small chunks search only newly appended data", () => {
+  let searched = 0;
+  const factory = loadScanner("vibe", "makeLineScanner", (length) => { searched += length; });
+  const { events, scan } = collectScanner(factory);
+  const partial = "x".repeat(4096);
+  for (let i = 0; i < partial.length; i += 16) scan(partial.slice(i, i + 16));
+  assert.equal(searched, partial.length);
+  assert.deepEqual(events, []);
 });
 
 test("line scanner: oversized unterminated line is dropped, later line parses", () => {


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- preserve parser cursor and JSON state across stdout chunks in the seven parity-gated event scanners
- make Vibe search only newly appended chunk data while retaining an incomplete line
- add deterministic scanner-work regressions without wall-clock thresholds

Relates to #51. This PR does not close the issue automatically.

## Root cause

The event scanners reset parser state after every chunk and rescanned the retained incomplete object from its opening brace. Vibe appended each chunk to its retained partial line and split the full accumulated string again. Both paths therefore performed quadratic aggregate work for long input delivered in many small chunks.

## Behavior preserved

The existing 1 MiB retained-input cap, malformed and junk-prefix recovery, complete oversized events, suffix recovery after a cap reset, final Vibe line flushing, StringDecoder handling, and byte-identical event-scanner parity remain unchanged.

## Validation

- `node test/event-scanner.mjs` — 23/23
- `node test/relay-parity.mjs`
- changed relay smoke — green
- `node test/relay-isolated.mjs` — 10/10
- full `node test/relay-smoke.mjs`
- changed-file `node --check`
- `git diff --check`
- `npx skills add . --list` — 11 skills

A repeatable 1,000,000-character unterminated object benchmark in 1,024-character calls improved from a 1,518.9 ms median on master to 60.6 ms on this branch (25.1×).