### PR TITLE
test: enforce skill version lockstep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,15 +76,24 @@ module names — see `test/relay/index.mjs`) skips the rest of the matrix.
 A changed relay also wants a direct run — `--help` plus a read-only or no-write run against a
 throwaway repo. The full pre-publish list is in [AGENTS.md](AGENTS.md).
 
+Before changing completion detection or `touchedFiles`, read the relevant skill's result contract.
+Exercise clean, pre-dirty, same-dirty-path, dirty-submodule, and git-unavailable worktrees, and assert
+the exact `delegate-relay.result.v1` fields instead of generic success or failure.
+
 ## Shared relay helpers
 
-Shared relay helpers are byte-identical by CI contract. Edit one relay, run
-`node test/relay-parity.mjs`, then paste its helper into the copies the test names.
+Shared relay helpers are byte-identical by contract. Before making them identical, inspect every
+divergent sibling and carry the strongest behavior forward, including bounds and timeouts. Then run
+`node test/relay-parity.mjs` and `node test/relay-smoke.mjs`.
 
 ## Review
 
 One maintainer reviews these and reads the relay line by line. Expect questions about anything the
 verification line claims.
+
+Automated reviewers such as CodeRabbit, Codex, and Greptile are advisory. If one is unavailable,
+rate-limited, or silent, record that and continue; do not wait or retry. Required project gates plus
+maintainer review determine readiness.
 
 Where two pull requests cover the same implementer, this checklist decides — the one that satisfies
 more of it merges. Ties break on verification evidence, then on the earlier claim. The other pull

--- a/test/relay/package-shape.mjs
+++ b/test/relay/package-shape.mjs
@@ -35,6 +35,16 @@ export function runPackageShape(h) {
     h.check(`${dir}: listed in skills.sh.json`, registered.has(dir));
     h.check(`${dir}: in the utility carve-out`, onDiskUtility.includes(dir));
   }
+  const metadataVersions = [...onDiskDelegate, ...onDiskUtility].map((dir) => {
+    const skillFile = join(skillsDir, dir, "SKILL.md");
+    return existsSync(skillFile)
+      ? readFileSync(skillFile, "utf8").match(/^metadata:\r?\n  version:\s*(\S+)\s*$/m)?.[1] ?? "(missing)"
+      : "(missing)";
+  });
+  h.check(
+    "all skill metadata.version values are present and in lockstep",
+    !metadataVersions.includes("(missing)") && new Set(metadataVersions).size === 1,
+  );
   h.check("smoke matrix has no entry without a directory", h.SKILLS.every((s) => onDiskDelegate.includes(`${s}-delegate`)));
   h.check(
     "skills.sh.json has no entry without a directory",

--- a/test/relay/package-shape.mjs
+++ b/test/relay/package-shape.mjs
@@ -5,6 +5,22 @@ import { join } from "node:path";
 /** Utility skills: not *-delegate, no relay.mjs / four-reference contract. */
 const UTILITY_SKILLS = ["delegate-setup"];
 
+function metadataVersion(source) {
+  const lines = source.split(/\r?\n/);
+  if (lines[0] !== "---") return "(missing)";
+  const frontmatterEnd = lines.indexOf("---", 1);
+  if (frontmatterEnd === -1) return "(missing)";
+  const frontmatter = lines.slice(1, frontmatterEnd);
+  const metadataAt = frontmatter.findIndex((line) => /^metadata: *$/.test(line));
+  if (metadataAt === -1) return "(missing)";
+  for (const line of frontmatter.slice(metadataAt + 1)) {
+    if (line && !line.startsWith(" ")) break;
+    const match = line.match(/^ +version: *(?:"([^"]+)"|'([^']+)'|(\S+)) *$/);
+    if (match) return match.slice(1).find(Boolean) ?? "(missing)";
+  }
+  return "(missing)";
+}
+
 export function runPackageShape(h) {
   const skillsDir = join(h.testDir, "..", "skills");
   const onDiskDelegate = readdirSync(skillsDir).filter((d) => d.endsWith("-delegate")).sort();
@@ -38,9 +54,20 @@ export function runPackageShape(h) {
   const metadataVersions = [...onDiskDelegate, ...onDiskUtility].map((dir) => {
     const skillFile = join(skillsDir, dir, "SKILL.md");
     return existsSync(skillFile)
-      ? readFileSync(skillFile, "utf8").match(/^metadata:\r?\n  version:\s*(\S+)\s*$/m)?.[1] ?? "(missing)"
+      ? metadataVersion(readFileSync(skillFile, "utf8"))
       : "(missing)";
   });
+  h.check(
+    "metadata.version ignores Markdown body snippets",
+    metadataVersion("---\nname: example\n---\n\nmetadata:\n  version: 9.9.9\n") === "(missing)",
+  );
+  h.check(
+    "metadata.version accepts ordering, indentation, and quoted scalars",
+    [
+      "---\nmetadata:\n owner: package\n version: '0.4.2'\n---\n",
+      "---\nmetadata:\n    owner: package\n    version: \"0.4.2\"\n---\n",
+    ].every((source) => metadataVersion(source) === "0.4.2"),
+  );
   h.check(
     "all skill metadata.version values are present and in lockstep",
     !metadataVersions.includes("(missing)") && new Set(metadataVersions).size === 1,


### PR DESCRIPTION
## Summary

- enforce that every shipped skill has a present, lockstep `metadata.version` in the existing package-shape runner
- document the required worktree state matrix and exact `delegate-relay.result.v1` assertions for completion and `touchedFiles` changes
- require strongest-behavior preservation for shared helpers and make automated reviewers explicitly advisory

## Why

Release metadata can drift without an objective package gate, and the contribution guidance did not fully capture recurring worktree-state, shared-helper, and reviewer-availability failures.

## Validation

- `node test/relay-smoke.mjs --only package-shape` — passed
- `node test/relay-parity.mjs` — passed
- `node test/relay-smoke.mjs` — passed; the existing invalid UTF-8 filename case was skipped because this host filesystem rejects arbitrary filename bytes
- `npx skills add . --list` — passed and found 11 skills; the first sandboxed attempt failed with registry DNS `ENOTFOUND`, then the network-approved rerun passed
- `git diff --check` — passed

Automated reviewer bots were not required, awaited, or retried.