### PR TITLE
ci: pin workflow actions to immutable v7 commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/relays.yml
+++ b/.github/workflows/relays.yml
@@ -16,10 +16,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
       - run: node test/relay-parity.mjs


### PR DESCRIPTION
**Claim:** None (focused workflow maintenance)

## Summary

- Pin the two GitHub Actions used by `relays.yml` to immutable commits currently named by their authoritative `v7` tags.
- Add the minimal Dependabot configuration to update `github-actions` references weekly from `/`.

This keeps the workflow reviewable and prevents mutable tag movement from silently changing the runner supply chain. It does not claim a complete security guarantee.

## Verification

- Baseline: upstream `master` `f9f2528525b820e7fd24724f87d6821c0e272947`.
- Direct tag resolution with `git ls-remote`: `actions/checkout` `v7` → `3d3c42e5aac5ba805825da76410c181273ba90b1`; `actions/setup-node` `v7` → `820762786026740c76f36085b0efc47a31fe5020`.
- Python PyYAML parse passed for both changed YAML files.
- Exact-two-ref and Dependabot schema assertions passed; `git diff --check` passed.
- `node test/relay-parity.mjs` passed.
- `node test/relay-isolated.mjs` passed.
- `node test/event-scanner.mjs` passed (23/23).
- `node test/relay-smoke.mjs` passed (all green).
- `npx -y skills add . --list` ran successfully as the package-list gate.
- Rechecked all currently open PR file lists (#71, #67, #59); none touches `.github/workflows/relays.yml` or `.github/dependabot.yml`.

Codex assisted with the bounded change and verification; no source, relay, npm, or documentation changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured weekly checks for GitHub Actions dependency updates.
  * Improved workflow reliability by pinning checkout and Node.js setup actions to specific versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->