### PR TITLE
Add Cloud Agent development environment (Node 22 gate parity)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "delegate-skills",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -33,18 +33,33 @@ nvm alias default "$NODE_MAJOR" >/dev/null
 
 NODE_BIN_DIR="$(dirname "$(nvm which "$NODE_MAJOR")")"
 
-if [ -d "$SHIM_DIR" ] && [ -w "$SHIM_DIR" ]; then
-  for bin in node npm npx corepack; do
-    if [ -x "$NODE_BIN_DIR/$bin" ]; then
-      ln -sf "$NODE_BIN_DIR/$bin" "$SHIM_DIR/$bin"
-    fi
-  done
-else
-  echo "install: $SHIM_DIR is not writable; leaving PATH to nvm's default node" >&2
+if [ ! -d "$SHIM_DIR" ] || [ ! -w "$SHIM_DIR" ]; then
+  echo "install: $SHIM_DIR is missing or not writable; cannot install Node shims" >&2
+  exit 1
 fi
 
-echo "install: node $(node --version) resolved from $(command -v node)"
-node --version | grep -q "^v${NODE_MAJOR}\." || {
-  echo "install: expected Node ${NODE_MAJOR}.x on PATH but found $(node --version)" >&2
+for bin in node npm npx corepack; do
+  if [ ! -x "$NODE_BIN_DIR/$bin" ]; then
+    echo "install: required executable $NODE_BIN_DIR/$bin is missing or not executable" >&2
+    exit 1
+  fi
+  if [ -e "$SHIM_DIR/$bin" ] && [ ! -L "$SHIM_DIR/$bin" ]; then
+    echo "install: refusing to overwrite non-symlink $SHIM_DIR/$bin" >&2
+    exit 1
+  fi
+done
+
+for bin in node npm npx corepack; do
+  ln -sfn "$NODE_BIN_DIR/$bin" "$SHIM_DIR/$bin"
+  if [ ! -L "$SHIM_DIR/$bin" ] || [ "$(readlink "$SHIM_DIR/$bin")" != "$NODE_BIN_DIR/$bin" ]; then
+    echo "install: failed to link $SHIM_DIR/$bin to $NODE_BIN_DIR/$bin" >&2
+    exit 1
+  fi
+done
+
+SHIM_NODE_VERSION="$("$SHIM_DIR/node" --version)"
+echo "install: node $SHIM_NODE_VERSION resolved from $SHIM_DIR/node"
+printf '%s\n' "$SHIM_NODE_VERSION" | grep -q "^v${NODE_MAJOR}\." || {
+  echo "install: expected Node ${NODE_MAJOR}.x at $SHIM_DIR/node but found $SHIM_NODE_VERSION" >&2
   exit 1
 }

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install for delegate-skills.
+#
+# This package is Node built-ins only — no package.json, no dependencies, so
+# there is nothing to `npm install`. The one thing that matters is the Node
+# version the project gates run under: CI pins `actions/setup-node@v7` with
+# `node-version: 22` (the latest 22.x), and two timeout/abort smoke checks are
+# sensitive to a signal-delivery fix that landed in a later 22.x patch. Older
+# 22.x (e.g. 22.14) drops a SIGTERM delivered during the relays' synchronous
+# `--version` preflight and mis-reports "timeout" instead of "aborted".
+#
+# The Cloud Agent VM injects its own `node` early on PATH, ahead of nvm, so a
+# bare `node` can resolve to that older build. The only PATH entry ahead of the
+# injected one is /usr/local/cargo/bin, so we install the pinned Node with nvm
+# and expose it there. The script is idempotent: re-running it re-points the
+# same symlinks at whatever `nvm install 22` resolves to.
+set -euo pipefail
+
+NODE_MAJOR=22
+SHIM_DIR="/usr/local/cargo/bin"
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+  echo "install: nvm not found at $NVM_DIR; cannot provision Node ${NODE_MAJOR}" >&2
+  exit 1
+fi
+# shellcheck disable=SC1091
+. "$NVM_DIR/nvm.sh"
+
+nvm install "$NODE_MAJOR"
+nvm alias default "$NODE_MAJOR" >/dev/null
+
+NODE_BIN_DIR="$(dirname "$(nvm which "$NODE_MAJOR")")"
+
+if [ -d "$SHIM_DIR" ] && [ -w "$SHIM_DIR" ]; then
+  for bin in node npm npx corepack; do
+    if [ -x "$NODE_BIN_DIR/$bin" ]; then
+      ln -sf "$NODE_BIN_DIR/$bin" "$SHIM_DIR/$bin"
+    fi
+  done
+else
+  echo "install: $SHIM_DIR is not writable; leaving PATH to nvm's default node" >&2
+fi
+
+echo "install: node $(node --version) resolved from $(command -v node)"
+node --version | grep -q "^v${NODE_MAJOR}\." || {
+  echo "install: expected Node ${NODE_MAJOR}.x on PATH but found $(node --version)" >&2
+  exit 1
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Claim:** n/a — repository tooling, not a delegate skill.

**What ran:** Ubuntu x86_64 Cloud Agent VM, Node `v22.23.2` (nvm), `skills` CLI via `npx skills add . --list`. Adds a `.cursor/` development environment so Cloud Agents working on this repo boot with the Node version CI uses, then ran the full project gate suite green — both locally and in a fresh Cloud Agent booted from a validated build.

### Why

The gates are Node built-in scripts — there is no `package.json` to install, so the only environment variable that matters is the Node version. CI runs them under `actions/setup-node@v7` with `node-version: 22` (the latest 22.x). Two timeout/abort smoke checks (`cursor preflight abort` and `vibe preflight abort`) depend on a signal-delivery fix that landed in a later 22.x patch: on older 22.x (e.g. `v22.14.0`, which the VM injects by default at `/exec-daemon/node`), a `SIGTERM` delivered while the relay is blocked in its synchronous `--version` preflight is dropped, so the relay reports `timeout` instead of `aborted` and the two checks fail. Under `v22.22.2`+ they pass. A minimal repro confirmed `v22.14.0` → `timeout` and `v22.22.2`/`v22.23.2` → `aborted`.

The VM injects its own `node` ahead of nvm on `PATH`, so a bare `node` resolves to the older build. The only `PATH` entry ahead of the injected one is `/usr/local/cargo/bin`, so `install` installs Node 22 with nvm and exposes it there.

### Changes

- `.cursor/environment.json` — repo-managed config: default base image, `install: bash .cursor/install.sh`. No `start`/`terminals`: this repo has no services or dev server.
- `.cursor/install.sh` — installs Node 22 via nvm, aliases it default, and symlinks `node`/`npm`/`npx`/`corepack` into `/usr/local/cargo/bin`. Idempotent, dependency-free, and fails loudly if nvm is absent or Node 22 doesn't end up on `PATH`.

### Validation — local VM (Node v22.23.2)

| Check | Result |
| --- | --- |
| `node test/relay-parity.mjs` | Passed |
| `node test/relay-isolated.mjs` | Passed |
| `node test/event-scanner.mjs` | Passed (23 checks) |
| `node test/relay-smoke.mjs` | all green (both preflight-abort checks now pass) |
| `npx skills add . --list` | Found 11 skills |
| `install.sh` idempotence | Passed twice |

### Validation — fresh Cloud Agent booted from the tested build

Booted a fresh Cloud Agent from build `bld-20260812-cde081f0-c20d-4b66-84ec-c0b95f59848b` on this branch. `which node` → `/usr/local/cargo/bin/node`, `node --version` → `v22.23.2`. All five gates exited `0`; smoke printed `relay smoke: all green` with zero `FAIL` lines, and `cursor preflight abort` / `vibe preflight abort` both reported `ok`.

Because this is a repo-managed `.cursor/environment.json`, merging this PR activates it for future Cloud Agents on this repository (no dashboard Save needed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3de97e0a-bab6-4651-89f2-3a876de574d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3de97e0a-bab6-4651-89f2-3a876de574d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development environment configuration for consistent setup.
  * Added automated installation and validation of Node.js 22 tooling.
  * Improved setup reliability with safe reruns and checks for required executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->