### PR TITLE
feat(kiro): add kiro-delegate implementer skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,11 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Ten implementer skills ship today: `claude-delegate` (Claude Code),
+and land the result. Eleven implementer skills ship today: `claude-delegate` (Claude Code),
 `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode), `agy-delegate` (Google Antigravity),
 `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code), `qoder-delegate` (Qoder CLI),
-`vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI), and `pi-delegate` (Pi CLI);
+`vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI), `pi-delegate` (Pi CLI), and
+`kiro-delegate` (Kiro CLI);
 siblings like `gemini-delegate` can be added later without renaming the repo. One **utility** skill
 ships alongside them: `delegate-setup` (configure fleet lanes — setup only, never dispatches).
 
@@ -18,7 +19,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the separate agent (Claude, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi) | "worker", "sub-agent", "executor" |
+ | **implementer** | the separate agent (Claude, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Kiro) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -37,6 +38,7 @@ jargon. Use these terms; don't invent synonyms.
 | `session`, `-c`, `--resume`, `permission mode` (`default`/`accept_edits`/`auto`/`bypass_permissions`/`dont_ask`/`plan`), `print mode`, `stream-json`, `model`, `context window` | Qoder CLI's own terms — use verbatim when discussing Qoder | don't paraphrase them |
 | `--prompt`, `--output` (`streaming`/`json`/`text`), `--agent` (`plan`/`accept-edits`/`auto-approve`), `--max-turns`, `--max-price`, `--max-tokens`, `--trust`, `--resume`, `--continue`, `--enabled-tools`, `--disabled-tools` | Mistral Vibe's own terms — use verbatim when discussing `vibe` | don't invent a Vibe sandbox enum; `--trust` is not a permission mode |
 | `session`, `--continue`, `--session`, `print mode`, `--mode json`, `tools`, `context files`, `project trust` | Pi's own terms — use verbatim when discussing `pi` | don't paraphrase them |
+| `chat`, `--no-interactive`, `--trust-tools`, `--trust-all-tools`, `--resume`, `--resume-id`, `--wrap` | Kiro CLI's own terms — use verbatim when discussing `kiro-cli` | don't paraphrase them |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -44,7 +46,7 @@ version-neutral) everywhere except the README's "Verification status" list, wher
 version a run was made against is what makes the claim checkable; and claims that can't be verified
 ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
-`codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi`) and
+`codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi` / `kiro-cli`) and
 the skill's `relay.mjs`.
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`pi-delegate`](skills/pi-delegate/SKILL.md) | [Pi](https://github.com/earendil-works/pi-mono) (`pi`) | full local tools — no sandbox, no permission modes [^none]; project trust opt-in | `--read-only` (`read,grep,find,ls`) | `--resume-last`, `--session <id>` |
 | [`qoder-delegate`](skills/qoder-delegate/SKILL.md) | [Qoder](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` permission mode; bypass opt-in | `--permission-mode plan` | `--resume-last`, `--resume <id>` |
 | [`vibe-delegate`](skills/vibe-delegate/SKILL.md) | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits`; `--full-access` opt-in | `--plan-only` (`plan` agent) | `--resume-last`, `--session <id>` |
+| [`kiro-delegate`](skills/kiro-delegate/SKILL.md) | Kiro CLI (`kiro-cli`) | `--trust-tools`; `--trust-all-tools` opt-in | — [^none] | `--resume`, `--resume-id <UUID>` |
 
 [^none]: No CLI-enforced read-only mode. `touchedFiles` and the diff, not a flag, are the guarantee.
 
@@ -215,6 +216,11 @@ Per skill — platform, CLI version, and what the run exercised:
 - `codex-delegate`, `opencode-delegate`, `vibe-delegate` — contract-tested only: argument validation,
   bounded version preflight, missing binary, result parsing, and whole-process-tree timeout/abort
   cleanup. No end-to-end run is recorded here.
+- `kiro-delegate` — contract-tested on Windows: sanitized environment, Git boundary, capability
+  preflight, result contract, session extraction, timeout tree cleanup, and a real console `CTRL+C`
+  abort harness; authenticated Windows smoke against Kiro CLI 2.16.2 (model `qwen3-coder-next`)
+  completed a minimal write task with an unchanged HEAD and no secret leakage. Authenticated runs on
+  other platforms and CLI versions remain unverified.
 - `delegate-setup` — contract-tested: discover JSON shape, config validate/write/load, whole-lane
   project overlay, global write without creating `.delegate/`, and `--lane` resolve / wrong-skill /
   flag-override against relays. The smoke suite runs live discovery against installed CLIs

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -14,7 +14,8 @@
         "qoder-delegate",
         "vibe-delegate",
         "cursor-delegate",
-        "pi-delegate"
+        "pi-delegate",
+        "kiro-delegate"
       ]
     },
     {

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -237,7 +237,6 @@ function readBrief(opts) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],

--- a/skills/claude-delegate/scripts/relay.mjs
+++ b/skills/claude-delegate/scripts/relay.mjs
@@ -719,7 +719,6 @@ function makeResultWriter(opts, version, run, state, beforeTree) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -217,7 +217,6 @@ function parseDuration(duration) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],
@@ -272,32 +271,70 @@ function versionProbeTimeout(opts) {
   return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
 }
 
-function codexVersion(probeTimeoutMs) {
-  try {
-    // On Windows, npm installs `codex` as a .cmd shim; Node's CreateProcess only
-    // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
-    // ENOENTs on a working install. POSIX is unaffected. (git installs a real
-    // git.exe and must NOT get this flag — see gitTouchedFiles.)
-    const version = execFileSync("codex", ["--version"], {
-      encoding: "utf8",
-      shell: process.platform === "win32",
-      timeout: probeTimeoutMs,
-      killSignal: "SIGKILL",
-    }).trim();
-    return { version: version || "unknown", error: null };
-  } catch (error) {
-    if (error?.code === "ENOENT") return { version: null, error: null };
-    // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
-    // exit rather than ENOENT; that is still "not installed", not a broken install.
-    if (process.platform === "win32" &&
-        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
-      return { version: null, error: null };
-    }
-    // Anything else — a hung probe we killed, or a real non-zero exit — means codex is
-    // installed but not usable. Reporting that as "unavailable" would send the caller
-    // off to reinstall a binary that is already there.
-    return { version: null, error };
+function runVersionProbe(binary, args, timeoutMs, shell = process.platform === "win32") {
+  return new Promise((resolve) => {
+    const child = spawn(binary, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // A shell-backed .cmd launch has a wrapper plus the actual CLI. Kill the
+      // wrapper's whole tree, not just the process Node started directly.
+      killChild(child, "SIGKILL");
+    }, timeoutMs);
+    const finish = (error, status = null, signal = null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        if (Number.isInteger(status)) error.status = status;
+        error.signal = signal;
+        resolve({ version: null, error });
+        return;
+      }
+      resolve({ version: stdout.trim() || "unknown", error: null });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+    child.on("error", (error) => finish(error));
+    child.on("close", (status, signal) => {
+      if (timedOut) {
+        const error = new Error("version probe timed out");
+        error.code = "ETIMEDOUT";
+        finish(error, status, signal);
+      } else if (status === 0) {
+        finish(null, status, signal);
+      } else {
+        const error = new Error(`version probe exited with ${status ?? "unknown"}`);
+        finish(error, status, signal);
+      }
+    });
+  });
+}
+
+async function codexVersion(probeTimeoutMs) {
+  // On Windows, npm installs `codex` as a .cmd shim; shell:true resolves it and
+  // runVersionProbe retains the wrapper PID so timeout cleanup can fell its tree.
+  const probe = await runVersionProbe("codex", ["--version"], probeTimeoutMs);
+  if (probe.error?.code === "ENOENT") return { version: null, error: null };
+  // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+  // exit rather than ENOENT; that is still "not installed", not a broken install.
+  if (process.platform === "win32" &&
+      /not recognized as an internal or external command/i.test(String(probe.error?.stderr || ""))) {
+    return { version: null, error: null };
   }
+  // Anything else — a hung probe we killed, or a real non-zero exit — means codex is
+  // installed but not usable. Reporting that as "unavailable" would send the caller
+  // off to reinstall a binary that is already there.
+  return probe;
 }
 
 function gitTouchedFiles(cwd) {
@@ -588,7 +625,7 @@ function dispatchToCodex(opts, brief, run, writeResult) {
   child.stdin.end();
 }
 
-function main() {
+async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
@@ -597,7 +634,7 @@ function main() {
   // somewhere to publish result.json rather than exiting silently.
   const run = prepareRunDir(opts, brief);
   const probeTimeoutMs = versionProbeTimeout(opts);
-  const probe = codexVersion(probeTimeoutMs);
+  const probe = await codexVersion(probeTimeoutMs);
   const writeResult = makeResultWriter(opts, probe.version, run);
 
   if (!probe.version && !probe.error) {
@@ -643,4 +680,4 @@ function printSummary(result, resultPath) {
   process.stdout.write(`${lines.join("\n")}\n`);
 }
 
-main();
+main().catch((error) => fail(error?.message || String(error)));

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -70,7 +70,7 @@
  * to cursor-agent), or cursor_agent_unavailable.
  */
 
-import {spawn, execSync, execFileSync, spawnSync } from "node:child_process";
+import { spawn, execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync, renameSync, rmSync, readFileSync, existsSync, appendFileSync } from "node:fs";
 import {join, resolve, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -80,6 +80,7 @@ import { StringDecoder } from "node:string_decoder";
 const DEFAULT_TIMEOUT = "30m";
 const MAX_TIMER_MS = 2_147_483_647;
 const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const GRACE_MS = 2_000;
 const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:@/[\],=-]*$/;
 const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 
@@ -225,7 +226,6 @@ function readBrief(opts) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],
@@ -246,31 +246,100 @@ function killChild(child, signal = "SIGTERM") {
   }
 }
 
-function cursorAgentVersion(timeoutMs) {
+function cursorAgentMissingOnWindowsPath() {
+  if (process.platform !== "win32") return false;
+  // Locale-independent missing-binary check. cmd.exe's command-not-found exit
+  // code is not stable across Windows versions/locales, so resolve with
+  // where.exe instead of parsing stderr.
+  const where = join(process.env.SystemRoot || process.env.WINDIR || "C:\\Windows", "System32", "where.exe");
   try {
-    // On Windows, cursor-agent installs as a .cmd shim; Node's CreateProcess only
-    // auto-appends .exe, never .cmd, so launching it needs a shell there or it
-    // ENOENTs on a working install. A pre-joined string (not shell:true + args)
-    // avoids Node's DEP0190 warning. POSIX is unaffected. (git installs a real
-    // git.exe and must NOT go through a shell — see gitTouchedFiles.)
-    const options = {
-      encoding: "utf8",
-      timeout: Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS),
-      killSignal: "SIGKILL",
-    };
-    const out = process.platform === "win32"
-      ? execSync("cursor-agent --version", options).trim()
-      : execFileSync("cursor-agent", ["--version"], options).trim();
-    return { version: out || "unknown", error: null };
-  } catch (error) {
-    if (error?.code === "ENOENT") return { version: null, error: null };
-    if (process.platform === "win32" &&
-        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
-      return { version: null, error: null };
-    }
-    return { version: null, error };
+    execFileSync(where, ["cursor-agent"], { encoding: "utf8", timeout: 2_000, stdio: ["ignore", "pipe", "ignore"] });
+    return false;
+  } catch {
+    return true;
   }
 }
+
+function cursorAgentVersion(timeoutMs) {
+  if (cursorAgentMissingOnWindowsPath()) return Promise.resolve({ version: null, error: null });
+  return new Promise((resolveProbe) => {
+    // On Windows, cursor-agent installs as a .cmd shim; Node's CreateProcess
+    // only auto-appends .exe, never .cmd, so it needs a shell there. The command
+    // string is fixed and contains no user input. POSIX spawns detached so
+    // killChild can fell the whole process group.
+    const child = process.platform === "win32"
+      ? spawn("cursor-agent --version", { shell: true, stdio: ["ignore", "pipe", "pipe"] })
+      : spawn("cursor-agent", ["--version"], { detached: true, stdio: ["ignore", "pipe", "pipe"] });
+    activePreflightChild = child;
+    let settled = false;
+    let timedOut = false;
+    let graceTimer = null;
+    let graceExpired = false;
+    let pendingClose = null;
+    let stdout = "";
+    let stderr = "";
+    const outDecoder = new StringDecoder("utf8");
+    const errDecoder = new StringDecoder("utf8");
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      activePreflightChild = null;
+      clearTimeout(timer);
+      if (graceTimer) clearTimeout(graceTimer);
+      stdout += outDecoder.end();
+      stderr += errDecoder.end();
+      resolveProbe({ version: result.version ?? null, error: result.error ?? null, stdout, stderr });
+    };
+    const finishAfterClose = (result) => {
+      if (timedOut && !graceExpired) pendingClose = result;
+      else finish(result);
+    };
+    const forceStop = () => {
+      killChild(child, "SIGKILL");
+      graceExpired = true;
+      if (pendingClose) {
+        const result = pendingClose;
+        pendingClose = null;
+        finish(result);
+      }
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      killChild(child);
+      graceTimer = setTimeout(forceStop, GRACE_MS);
+    }, Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS));
+    child.stdout.on("data", (chunk) => { stdout += outDecoder.write(chunk); });
+    child.stderr.on("data", (chunk) => { stderr += errDecoder.write(chunk); });
+    child.on("error", (error) => finishAfterClose({
+      version: null,
+      error: error?.code === "ENOENT" ? null : error,
+    }));
+    child.on("close", (code, signal) => {
+      if (timedOut) {
+        const error = new Error("cursor-agent version preflight timed out");
+        error.code = "ETIMEDOUT";
+        finishAfterClose({ version: null, error });
+        return;
+      }
+      if (code === 0) {
+        finishAfterClose({ version: stdout.trim() || "unknown", error: null });
+        return;
+      }
+      // cmd.exe's command-not-found code is unreliable; treat it as missing too.
+      if (code === 9009) {
+        finishAfterClose({ version: null, error: null });
+        return;
+      }
+      const error = new Error(`cursor-agent version preflight exited with code ${code ?? "unknown"}`);
+      error.status = code;
+      error.signal = signal;
+      finishAfterClose({ version: null, error });
+    });
+  });
+}
+
+let activePreflightChild = null;
 
 function parseDuration(duration) {
   const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
@@ -466,6 +535,7 @@ function installPreflightSignalHandlers(opts, run, writeResult) {
     const handler = () => {
       if (!active) return;
       active = false;
+      if (activePreflightChild) killChild(activePreflightChild, "SIGKILL");
       const result = writeResult({
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
@@ -652,10 +722,12 @@ function dispatchToCursor(opts, brief, run, writeResult) {
     // is_error true is failed even on exit 0.
     const succeeded = code === 0 && !watchdogFired && !resultIsError;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
-    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
     const touched = gitTouchedFiles(opts.cd);
+    const gitStatusUnavailable = touched === null;
+    const status = gitStatusUnavailable ? "failed" : succeeded ? "completed" : watchdogFired ? "timeout" : "failed";
+    const exitCode = gitStatusUnavailable ? 1 : succeeded ? 0 : mapped === 0 ? 1 : mapped;
     const result = writeResult({
-      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      status,
       exitCode,
       signal: signal ?? null,
       sessionId,
@@ -664,9 +736,10 @@ function dispatchToCursor(opts, brief, run, writeResult) {
       usage,
       finalMessage: assembleFinal(),
       touchedFiles: touched,
-      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(!succeeded || gitStatusUnavailable ? { stderrTail: stderrTail.slice(-20) } : {}),
       ...(watchdogFired ? { error: `cursor-agent did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
       ...(resultIsError && !watchdogFired ? { error: "cursor-agent reported an error result (is_error: true in its result event)" } : {}),
+      ...(gitStatusUnavailable ? { error: "git status could not be reported; inspect the working tree directly" } : {}),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
@@ -682,10 +755,7 @@ async function main() {
   const run = prepareRunDir(opts, brief);
   let writeResult = makeResultWriter(opts, null, run);
   const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult);
-  const probe = cursorAgentVersion(timeoutMs);
-  // Synchronous child-process calls defer JavaScript signal handlers. Yield once
-  // so a signal received during the bounded probe becomes "aborted" before dispatch.
-  await new Promise((resolve) => setImmediate(resolve));
+  const probe = await cursorAgentVersion(timeoutMs);
   writeResult = makeResultWriter(opts, probe.version, run);
   if (!probe.version && !probe.error) {
     clearPreflightSignals();

--- a/skills/delegate-setup/references/schema.md
+++ b/skills/delegate-setup/references/schema.md
@@ -56,6 +56,7 @@ later-edited project config fails closed until it is reviewed and written again 
 | `vibe` | vibe-delegate | `vibe` | timeout, readOnly |
 | `cursor` | cursor-delegate | `cursor-agent` | model, force, timeout, readOnly |
 | `pi` | pi-delegate | `pi` | provider, model, timeout, readOnly |
+| `kiro` | kiro-delegate | `kiro-cli` | model, timeout |
 
 OpenCode uses `variant` for reasoning intensity, not `effort`. Do not write `effort` on an `opencode` lane.
 OpenCode lanes **require** `model` in `provider/model` form, with a non-empty provider before the first

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -233,6 +233,17 @@ export const IMPLEMENTERS = Object.freeze([
     supports: ["provider", "model", "timeout", "readOnly"],
     winShell: true,
   },
+  {
+    key: "kiro",
+    skill: "kiro-delegate",
+    binary: "kiro-cli",
+    versionArgs: ["--version"],
+    authProbe: null,
+    modelProbe: null,
+    usageProbe: null,
+    supports: ["model", "timeout"],
+    winShell: false,
+  },
 ]);
 
 /** Prototype-free map so names like "toString" cannot pass as implementers. */

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -222,7 +222,6 @@ function parseDuration(duration) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],
@@ -277,39 +276,66 @@ function versionProbeTimeout(opts) {
   return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
 }
 
-function grokVersion(probeTimeoutMs) {
+function runVersionProbe(binary, args, timeoutMs, shell = process.platform === "win32") {
+  return new Promise((resolve) => {
+    const child = spawn(binary, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // A shell-backed .cmd launch has a wrapper plus the actual CLI. Kill the
+      // wrapper's whole tree, not just the process Node started directly.
+      killChild(child, "SIGKILL");
+    }, timeoutMs);
+    const finish = (error, status = null, signal = null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        if (Number.isInteger(status)) error.status = status;
+        error.signal = signal;
+        resolve({ version: null, error });
+        return;
+      }
+      resolve({ version: stdout.trim() || "unknown", error: null });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+    child.on("error", (error) => finish(error));
+    child.on("close", (status, signal) => {
+      if (timedOut) {
+        const error = new Error("version probe timed out");
+        error.code = "ETIMEDOUT";
+        finish(error, status, signal);
+      } else if (status === 0) {
+        finish(null, status, signal);
+      } else {
+        const error = new Error(`version probe exited with ${status ?? "unknown"}`);
+        finish(error, status, signal);
+      }
+    });
+  });
+}
+
+async function grokVersion(probeTimeoutMs) {
   // On Windows, npm installs `grok` as a .cmd shim; Node's CreateProcess only
   // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
   // ENOENTs on a working install. POSIX is unaffected. (git installs a real
   // git.exe and must NOT get this flag — see gitTouchedFiles.)
-  const probe = (argv, timeout = probeTimeoutMs) => {
-    try {
-      const version = execFileSync("grok", argv, {
-        encoding: "utf8",
-        shell: process.platform === "win32",
-        timeout,
-        killSignal: "SIGKILL",
-      }).trim();
-      return { version: version || "unknown", error: null };
-    } catch (error) {
-      if (error?.code === "ENOENT") return { version: null, error: null };
-      // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
-      // exit rather than ENOENT; that is still "not installed", not a broken install.
-      if (process.platform === "win32" &&
-          /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
-        return { version: null, error: null };
-      }
-      // Anything else — a hung probe we killed, or a real non-zero exit — means grok is
-      // installed but not usable. Reporting that as "unavailable" would send the caller
-      // off to reinstall a binary that is already there.
-      return { version: null, error };
-    }
-  };
+  const probe = (argv, timeout = probeTimeoutMs) => runVersionProbe("grok", argv, timeout);
   // Prefer `grok version` (documented subcommand); fall back to `--version` for builds that
   // only answer the flag. A missing binary and a hung probe are both conclusive, though:
   // retrying either would only spend the bound a second time.
   const startedAt = performance.now();
-  const documented = probe(["version"]);
+  const documented = await probe(["version"]);
   if (documented.version || !documented.error || documented.error.code === "ETIMEDOUT") return documented;
   const remainingMs = Math.floor(probeTimeoutMs - (performance.now() - startedAt));
   if (remainingMs <= 0) return { version: null, error: { code: "ETIMEDOUT" } };
@@ -702,7 +728,7 @@ function dispatchToGrok(opts, run, writeResult) {
   });
 }
 
-function main() {
+async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
@@ -711,7 +737,7 @@ function main() {
   // somewhere to publish result.json rather than exiting silently.
   const run = prepareRunDir(opts, brief);
   const probeTimeoutMs = versionProbeTimeout(opts);
-  const probe = grokVersion(probeTimeoutMs);
+  const probe = await grokVersion(probeTimeoutMs);
   const writeResult = makeResultWriter(opts, probe.version, run);
 
   if (!probe.version && !probe.error) {
@@ -764,4 +790,4 @@ function printSummary(result, resultPath) {
   process.stdout.write(`${lines.join("\n")}\n`);
 }
 
-main();
+main().catch((error) => fail(error?.message || String(error)));

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -204,7 +204,6 @@ function readBrief(opts) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],
@@ -232,22 +231,63 @@ function versionProbeTimeout(opts) {
   return Math.min(parseDuration(opts.timeout), VERSION_PROBE_TIMEOUT_MS);
 }
 
-function kimiVersion(probeTimeoutMs) {
-  try {
-    const out = execFileSync("kimi", ["--version"], {
-      encoding: "utf8",
-      timeout: probeTimeoutMs,
-      killSignal: "SIGKILL",
-    }).trim();
-    return { version: out || "unknown", error: null };
-  } catch (err) {
-    // Only a missing binary means "unavailable"; any other version-probe
-    // failure must not masquerade as exit 127.
-    if (err && err.code === "ENOENT") return { version: null, error: null };
-    // A hung probe we killed, or a real non-zero exit, means kimi is installed but not
-    // usable. Dispatching anyway would send the brief to a CLI already known to be broken.
-    return { version: null, error: err };
-  }
+function runVersionProbe(binary, args, timeoutMs, shell = process.platform === "win32") {
+  return new Promise((resolve) => {
+    const child = spawn(binary, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // A shell-backed .cmd launch has a wrapper plus the actual CLI. Kill the
+      // wrapper's whole tree, not just the process Node started directly.
+      killChild(child, "SIGKILL");
+    }, timeoutMs);
+    const finish = (error, status = null, signal = null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        if (Number.isInteger(status)) error.status = status;
+        error.signal = signal;
+        resolve({ version: null, error });
+        return;
+      }
+      resolve({ version: stdout.trim() || "unknown", error: null });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+    child.on("error", (error) => finish(error));
+    child.on("close", (status, signal) => {
+      if (timedOut) {
+        const error = new Error("version probe timed out");
+        error.code = "ETIMEDOUT";
+        finish(error, status, signal);
+      } else if (status === 0) {
+        finish(null, status, signal);
+      } else {
+        const error = new Error(`version probe exited with ${status ?? "unknown"}`);
+        finish(error, status, signal);
+      }
+    });
+  });
+}
+
+async function kimiVersion(probeTimeoutMs) {
+  // Kimi's supported Windows install is native, but retaining the same PID-aware
+  // probe also prevents a future shim install from reintroducing this leak.
+  const probe = await runVersionProbe("kimi", ["--version"], probeTimeoutMs, false);
+  if (probe.error?.code === "ENOENT") return { version: null, error: null };
+  // A hung probe we killed, or a real non-zero exit, means kimi is installed but not
+  // usable. Dispatching anyway would send the brief to a CLI already known to be broken.
+  return probe;
 }
 
 function parseDuration(duration) {
@@ -563,7 +603,7 @@ function dispatchToKimi(opts, brief, run, writeResult) {
   });
 }
 
-function main() {
+async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
@@ -581,7 +621,7 @@ function main() {
   // somewhere to publish result.json rather than exiting silently.
   const run = prepareRunDir(opts, brief);
   const probeTimeoutMs = versionProbeTimeout(opts);
-  const probe = kimiVersion(probeTimeoutMs);
+  const probe = await kimiVersion(probeTimeoutMs);
   const writeResult = makeResultWriter(opts, probe.version, run);
   if (!probe.version && !probe.error) {
     reportUnavailable(writeResult, run.resultPath);
@@ -624,4 +664,4 @@ function printSummary(result, resultPath) {
   process.stdout.write(`${lines.join("\n")}\n`);
 }
 
-main();
+main().catch((error) => fail(error?.message || String(error)));

--- a/skills/kiro-delegate/SKILL.md
+++ b/skills/kiro-delegate/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: kiro-delegate
+description: >-
+  Delegate a bounded coding task to the Kiro CLI as a headless implementer, then review its
+  working-tree diff and land it yourself. Use when the user explicitly asks to delegate work to
+  Kiro, Kiro CLI, or kiro-cli. Do not use for small inline edits, review-only work, or when Kiro
+  authentication and the applicable Kiro/AWS terms have not been accepted.
+license: MIT
+compatibility: Requires Node.js 18+, git, and an authenticated Kiro CLI (`kiro-cli`) whose capabilities pass relay preflight; accepted Kiro/AWS terms are required for headless use.
+metadata:
+  version: 0.1.0
+---
+
+# Kiro CLI Delegate
+
+You are the **orchestrator**. This skill delegates one bounded implementation task to a separate
+Kiro CLI process. Kiro edits the working tree; you own the brief, judgment, verification, and Git
+commit.
+
+Kiro's public guidance may restrict third-party harness use. Confirm that the intended Kiro/AWS
+account terms permit this automated use before dispatching.
+
+## When not to use
+
+- The task is small enough to implement directly or is review-only.
+- `kiro-cli` is unavailable, unauthenticated, or needs interactive clarification.
+- The task is not bounded enough to review as one diff.
+
+## Prerequisites
+
+1. `--cd` is an existing Git worktree with a verifiable, non-unborn `HEAD`.
+2. `kiro-cli --version` and `kiro-cli chat --help` pass relay capability preflight.
+3. Headless authentication is configured, preferably with `KIRO_API_KEY`; never put it in a brief,
+   command argument, repository file, or result artifact.
+
+The child receives a sanitized environment by default. `--inherit-env` is an explicit unsafe opt-in;
+artifact redaction still applies. Redaction covers known environment values, not secrets read from
+files, MCP, or external services.
+
+## Workflow
+
+1. Write one complete brief using [writing-the-brief.md](references/writing-the-brief.md).
+2. Dispatch with the relay, for example:
+
+   ```powershell
+   node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd "C:\path\to\repo" --trust-tools=fs_read,fs_write,execute_bash,grep,glob,code
+   ```
+
+3. Read `result.json`, inspect `git status --short`, `git diff`, and `git diff --cached`, then rerun
+   the gates yourself. The relay never commits, pushes, or creates a PR.
+4. Resume only the same task with `--resume` or `--resume-id <UUID>` and a delta brief.
+
+Use the smallest explicit tool set needed. Do not use `--trust-all-tools` unless the user explicitly
+accepts unrestricted Kiro tool approval.
+
+## Result contract
+
+The relay writes `delegate-relay.result.v1` with `status`, `exitCode`, `signal`, Kiro's final report,
+`touchedFiles` (`null` when Git cannot report, `[]` when clean), and a session id when exposed. It
+also records lane/permission/workspace metadata, preflight results, redaction metadata, and artifact
+paths. A changed HEAD or unknown Git state is a failed boundary requiring inspection.
+
+## References
+
+- [writing-the-brief.md](references/writing-the-brief.md)
+- [dispatch-and-poll.md](references/dispatch-and-poll.md)
+- [review-and-land.md](references/review-and-land.md)
+- [multi-task-queues.md](references/multi-task-queues.md)

--- a/skills/kiro-delegate/references/dispatch-and-poll.md
+++ b/skills/kiro-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,23 @@
+# Dispatch and poll
+
+Run the relay once, then poll its result artifact:
+
+```powershell
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd "C:\path\to\repo"
+```
+
+Useful options include `--lane <name>`, `--agent <name>`, `--model <name>`, `--trust-tools <tools>`,
+`--trust-all-tools`, `--require-mcp-startup`, `--resume`, `--resume-id <UUID>`, `--timeout <h/m/s>`,
+and `--out-dir <dir>`. Explicit options override lane dials; a lane for another implementer fails.
+
+Artifacts are `brief.txt`, `final.txt` when Kiro emitted a report, `stderr.txt`, and atomic
+`result.json`. The result uses `delegate-relay.result.v1`: `touchedFiles` is final Git porcelain for
+the `--cd` tree, `[]` means clean, and `null` means Git could not report the tree — which forces
+`status: failed` with `git_status_unavailable` rather than a completed run. It includes `sessionId`
+when Kiro emits a UUID. A usage error exits 2 without a result; a missing binary exits 127 with one.
+
+The relay performs bounded version/help preflight before dispatch, sanitizes the child environment,
+redacts known secret values, verifies Git before and after the run, and kills the process tree after
+timeout or abort grace. The shared Windows matrix validates timeout cleanup; Kiro also has a
+Windows-only console harness that sends a real `CTRL+C` event. Non-console `child.kill("SIGINT")`
+remains unsupported as a substitute for an interactive console event.

--- a/skills/kiro-delegate/references/multi-task-queues.md
+++ b/skills/kiro-delegate/references/multi-task-queues.md
@@ -1,0 +1,14 @@
+# Multi-task queues
+
+Run queued work sequentially: one bounded brief, one Kiro session, one reviewed diff, and one commit
+per task. Keep the tree clean before each dispatch so `touchedFiles` remains interpretable.
+
+```powershell
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd "C:\path\to\repo"
+```
+
+Use a resumed Kiro session only for corrections to the same task. Start unrelated work in a fresh
+session and carry forward decisions explicitly in its brief. For independent tasks, use separate
+working trees and review them independently. Keep a progress file with queued, dispatched, reviewed,
+and landed states, gate outcomes, and open questions. After the last task, rerun the full gates and
+search for stale references before the orchestrator lands the result.

--- a/skills/kiro-delegate/references/review-and-land.md
+++ b/skills/kiro-delegate/references/review-and-land.md
@@ -1,0 +1,14 @@
+# Review and land
+
+The orchestrator owns judgment. Treat Kiro's `finalMessage` as a report, not proof.
+
+1. Read `result.json`, `git status --short`, `git diff`, and `git diff --cached`.
+2. Open every untracked file and inspect changed tests before trusting a green gate.
+3. Reject scope creep, weakened assertions, commits, changed `HEAD`, unknown Git state, leaked
+   secrets, and unrequested file edits.
+4. Rerun the project's actual tests, lint, type, build, and specialized gates yourself.
+5. Commit only after the diff and gates satisfy the brief. Kiro and the relay never commit.
+
+For rework, use the same workspace and `--resume-id <UUID>` with a delta brief. Review the complete
+tree again; resuming is not a verification shortcut. Preserve interrupted work until it has been
+reviewed rather than resetting or cleaning it.

--- a/skills/kiro-delegate/references/writing-the-brief.md
+++ b/skills/kiro-delegate/references/writing-the-brief.md
@@ -1,0 +1,26 @@
+# Writing the brief
+
+Kiro receives one self-contained brief, not the orchestrator's conversation history. Include the
+goal, repository facts, target files, explicit non-goals, real gates, and the report contract.
+
+```xml
+<task>
+State the bounded change, current behavior, desired behavior, target files, and what stays untouched.
+</task>
+<repo_constraints>
+Copy the applicable AGENTS.md rules, dependency policy, generated-file policy, and commit boundary.
+</repo_constraints>
+<verification_loop>
+Run the exact project gates and report their outcomes. Confirm only intended files changed.
+</verification_loop>
+<action_safety>
+Do not git add, commit, push, or create a PR. Do not invoke another implementer. Leave the worktree
+uncommitted for the orchestrator.
+</action_safety>
+<structured_output_contract>
+Report: what changed and why; files touched; gate outcomes; deviations or open questions.
+</structured_output_contract>
+```
+
+Keep secrets out of the brief. The relay stores a redacted artifact and passes the brief to Kiro;
+put large context in workspace files instead of the brief. A resumed session gets only a delta brief.

--- a/skills/kiro-delegate/scripts/relay.mjs
+++ b/skills/kiro-delegate/scripts/relay.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+/** Dispatch one bounded brief to Kiro CLI without committing or leaking credentials. */
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_TIMEOUT = "30m";
+const DEFAULT_TRUST_TOOLS = "fs_read,grep,glob,code";
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+const MAX_BRIEF_BYTES = 24 * 1024;
+const GRACE_MS = 2_000;
+const SCHEMA = "delegate-relay.result.v1";
+const IMPLEMENTER_KEY = "kiro";
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_SEARCH = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+const REQUIRED_FLAGS = ["--no-interactive", "--trust-tools", "--resume-id", "--wrap"];
+const MANAGED = ["brief.txt", "final.txt", "stderr.txt", "result.json"];
+
+function fail(message, code = 2) { process.stderr.write(`relay: ${message}\n`); process.exit(code); }
+
+function help() { return `kiro-delegate relay\n\nUsage:\n  node relay.mjs --brief <file> [options]\n  type brief.txt | node relay.mjs [options]\n\nOptions:\n  --brief <file>                  Read brief from file instead of stdin\n  --cd <dir>                      Kiro working directory (default: current directory)\n  --lane <name>                   Fleet lane from delegate-setup config\n  --kiro-bin <path>               Kiro executable (default: kiro-cli)\n  --agent <name>                  Kiro custom agent\n  --model <name>                  Kiro model\n  --trust-tools <tools>           Comma-separated tools; default: ${DEFAULT_TRUST_TOOLS}\n  --trust-all-tools               Explicitly trust every Kiro tool\n  --inherit-env                   Pass the complete parent environment (unsafe)\n  --require-mcp-startup           Fail if an MCP server cannot start\n  --resume                        Resume the most recent session in --cd\n  --resume-id <uuid>              Resume a specific Kiro session\n  --timeout <h/m/s>               Relay watchdog (default: ${DEFAULT_TIMEOUT})\n  --out-dir <dir>                 Artifact directory (default: system temp)\n  -h, --help                      Show this help\n\nThe relay never runs git commit, git push, or creates a pull request.\n`; }
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds = BigInt(match[1] || 0) * 3600n + BigInt(match[2] || 0) * 60n + BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch { return null; }
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) fail("--lane requires the delegate-setup skill installed beside this relay");
+  const r = spawnSync(process.execPath, [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY], { encoding: "utf8", env: process.env });
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  let resolved;
+  try { const lines = (r.stdout || "").trim().split("\n").filter(Boolean); resolved = JSON.parse(lines[lines.length - 1]); } catch { fail("lane resolve returned invalid JSON"); }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) if (!flagged.has(field)) opts[field] = value;
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = { lane: null, laneSource: null, brief: null, cd: process.cwd(), kiroBin: process.env.KIRO_CLI_BIN || "kiro-cli", agent: null, model: null, trustTools: DEFAULT_TRUST_TOOLS, trustToolsExplicit: false, trustAllTools: false, inheritEnv: false, requireMcpStartup: false, resume: false, resumeId: null, timeout: DEFAULT_TIMEOUT, outDir: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]; const next = () => { if (argv[i + 1] === undefined) fail(`${arg} requires a value`); return argv[++i]; };
+    if (arg === "-h" || arg === "--help") { process.stdout.write(help()); process.exit(0); }
+    else if (arg === "--brief") opts.brief = next(); else if (arg === "--cd") opts.cd = resolve(next()); else if (arg === "--lane") opts.lane = next(); else if (arg === "--kiro-bin") opts.kiroBin = next();
+    else if (arg === "--agent") { opts.agent = next(); flagged.add("agent"); } else if (arg === "--model") { opts.model = next(); flagged.add("model"); }
+    else if (arg === "--trust-tools") { opts.trustTools = next(); opts.trustToolsExplicit = true; flagged.add("trustTools"); } else if (arg.startsWith("--trust-tools=")) { opts.trustTools = arg.slice(14); opts.trustToolsExplicit = true; flagged.add("trustTools"); }
+    else if (arg === "--trust-all-tools") { opts.trustAllTools = true; flagged.add("trustAllTools"); } else if (arg === "--inherit-env") opts.inheritEnv = true;
+    else if (arg === "--require-mcp-startup") opts.requireMcpStartup = true; else if (arg === "--resume") opts.resume = true; else if (arg === "--resume-id") opts.resumeId = next(); else if (arg === "--timeout") { opts.timeout = next(); flagged.add("timeout"); } else if (arg === "--out-dir") opts.outDir = resolve(next()); else fail(`unknown option: ${arg}`);
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.resume && opts.resumeId) fail("--resume and --resume-id are mutually exclusive");
+  if (parseDuration(opts.timeout) === null) fail(`--timeout "${opts.timeout}" is invalid or too long`);
+  if (!existsSync(opts.cd)) fail(`working directory does not exist: ${opts.cd}`);
+  if (opts.trustAllTools && opts.trustToolsExplicit) fail("--trust-all-tools cannot be combined with explicitly supplied --trust-tools");
+  if (opts.resumeId && !UUID.test(opts.resumeId)) fail("--resume-id must be a complete Kiro session UUID");
+  return opts;
+}
+
+function readBrief(opts) { if (opts.brief) { if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`); return readFileSync(opts.brief, "utf8"); } if (process.stdin.isTTY) fail("no --brief given and stdin is a TTY; pass --brief or pipe stdin"); return readFileSync(0, "utf8"); }
+
+function killChild(child, force = false) {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    // Windows child.kill can remove the root before the later escalation can
+    // address its descendants. taskkill must fell the tree while the root PID exists.
+    try { execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" }); } catch { /* The process tree already exited. */ }
+    return;
+  }
+  try { process.kill(-child.pid, force ? "SIGKILL" : "SIGTERM"); } catch { try { child.kill(force ? "SIGKILL" : "SIGTERM"); } catch { /* The process group already exited. */ } }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", timeout: 10_000, killSignal: "SIGKILL", stdio: ["ignore", "pipe", "ignore"], maxBuffer: 64 * 1024 * 1024 });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch { return null; }
+}
+
+function gitHead(cwd) { try { return execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8", timeout: 10_000 }).trim() || null; } catch { return null; } }
+function gitWorktree(cwd) { try { return execFileSync("git", ["rev-parse", "--is-inside-work-tree"], { cwd, encoding: "utf8", timeout: 10_000 }).trim() === "true"; } catch { return false; } }
+function secretValues(env) { return Object.entries(env).filter(([key, value]) => value && (key === "KIRO_API_KEY" || /(?:KEY|TOKEN|SECRET|PASSWORD|PASS|CREDENTIAL|AUTH|PRIVATE)/i.test(key))).map(([, value]) => value).filter((value) => value.length >= 4).sort((a, b) => b.length - a.length); }
+function makeRedactor(env) { const values = [...new Set(secretValues(env))]; const maxSecretLength = values.reduce((max, value) => Math.max(max, value.length), 0); let replacements = 0; const redact = (input) => { let text = String(input ?? ""); for (const value of values) text = text.replaceAll(value, () => { replacements += 1; return "[REDACTED]"; }); return text; }; return { redact, maxSecretLength, metadata: () => ({ applied: values.length > 0, replacementCount: replacements }) }; }
+function makeStderrStream(redactor) {
+  // A secret split across two stderr chunks must still be redacted. Redact the
+  // whole pending buffer (carryover + incoming decoded text) first, then emit
+  // everything except the last maxSecretLength chars, keeping that redacted
+  // tail as carryover so a partial secret that continues in the next chunk is
+  // re-scanned as part of the full string.
+  const hold = redactor.maxSecretLength;
+  let carry = "";
+  return {
+    write(text) {
+      const redactedPending = redactor.redact(carry + text);
+      const splitAt = Math.max(0, redactedPending.length - hold);
+      const safe = redactedPending.slice(0, splitAt);
+      carry = redactedPending.slice(splitAt);
+      return safe;
+    },
+    flush() {
+      const out = carry;
+      carry = "";
+      return out;
+    },
+  };
+}
+function childEnvironment(opts) { if (opts.inheritEnv) return { ...process.env, PWD: opts.cd, KIRO_LOG_NO_COLOR: "1" }; const env = {}; const allow = /^(PATH|Path|PATHEXT|SystemRoot|TEMP|TMP|HOME|USERPROFILE|LANG|LC_[A-Z_]+|HTTP_PROXY|HTTPS_PROXY|NO_PROXY|http_proxy|https_proxy|no_proxy|KIRO_API_KEY|KIRO_[A-Z0-9_]+)$/; for (const [key, value] of Object.entries(process.env)) if (value !== undefined && allow.test(key) && !(key !== "KIRO_API_KEY" && /(?:KEY|TOKEN|SECRET|PASSWORD|PASS|CREDENTIAL|AUTH|PRIVATE)/i.test(key))) env[key] = value; return { ...env, PWD: opts.cd, KIRO_LOG_NO_COLOR: "1" }; }
+function prepareRun(opts, brief, redactor) { const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${new Date().toISOString().replace(/[:.]/g, "-")}`); mkdirSync(outDir, { recursive: true }); for (const name of MANAGED) rmSync(join(outDir, name), { force: true }); for (const name of readdirSync(outDir)) if (name.startsWith("result.json.")) rmSync(join(outDir, name), { force: true }); const run = { startedAt: new Date().toISOString(), outDir, briefPath: join(outDir, "brief.txt"), finalPath: join(outDir, "final.txt"), stderrPath: join(outDir, "stderr.txt"), resultPath: join(outDir, "result.json") }; writeFileSync(run.briefPath, redactor.redact(brief), "utf8"); writeFileSync(run.stderrPath, "", "utf8"); return run; }
+function command(binary, args) { return binary.toLowerCase().endsWith(".mjs") ? { file: process.execPath, args: [binary, ...args] } : { file: binary, args }; }
+
+function probe(opts, args, redactor) {
+  return new Promise((resolveProbe) => {
+    const c = command(opts.kiroBin, args);
+    let child;
+    try {
+      child = spawn(c.file, c.args, { cwd: opts.cd, env: childEnvironment(opts), detached: process.platform !== "win32", stdio: ["ignore", "pipe", "pipe"] });
+    } catch (error) {
+      resolveProbe({ ok: false, missing: error?.code === "ENOENT", output: "", status: null, error: `exit_${error?.status ?? "unknown"}` });
+      return;
+    }
+    let settled = false;
+    let timedOut = false;
+    let graceTimer = null;
+    let graceExpired = false;
+    let pendingClose = null;
+    let stdout = "";
+    let stderr = "";
+    const outDecoder = new StringDecoder("utf8");
+    const errDecoder = new StringDecoder("utf8");
+    const finishProbe = (closeResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (graceTimer) clearTimeout(graceTimer);
+      stdout += outDecoder.end();
+      stderr += errDecoder.end();
+      const output = redactor.redact(stdout || stderr).trim().slice(0, 20_000);
+      resolveProbe({ ...closeResult, output });
+    };
+    const finishAfterClose = (closeResult) => {
+      if (timedOut && !graceExpired) pendingClose = closeResult;
+      else finishProbe(closeResult);
+    };
+    const forceStop = () => {
+      killChild(child, true);
+      graceExpired = true;
+      if (pendingClose) {
+        const closeResult = pendingClose;
+        pendingClose = null;
+        finishProbe(closeResult);
+      }
+    };
+    const probeTimeout = Math.min(parseDuration(opts.timeout), VERSION_PROBE_TIMEOUT_MS);
+    const timer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      killChild(child);
+      graceTimer = setTimeout(forceStop, GRACE_MS);
+    }, probeTimeout);
+    child.stdout.on("data", (chunk) => { stdout += outDecoder.write(chunk); });
+    child.stderr.on("data", (chunk) => { stderr += errDecoder.write(chunk); });
+    child.on("error", (error) => finishAfterClose({ ok: false, missing: error?.code === "ENOENT", status: null, error: `exit_${error?.status ?? "unknown"}` }));
+    child.on("close", (code) => finishAfterClose(timedOut
+      ? { ok: false, missing: false, status: null, error: "timeout" }
+      : { ok: code === 0 && Boolean((stdout || stderr).trim()), missing: false, status: code, error: code === 0 ? null : `exit_${code ?? "unknown"}` }));
+  });
+}
+
+async function preflight(opts, redactor) {
+  const version = await probe(opts, ["--version"], redactor);
+  if (version.missing) return { ok: false, missing: true, version, help: null };
+  if (!version.ok) return { ok: false, missing: false, version, help: null };
+  const helpResult = await probe(opts, ["chat", "--help"], redactor);
+  const missingFlags = REQUIRED_FLAGS.filter((flag) => !helpResult.output.includes(flag));
+  return { ok: helpResult.ok && missingFlags.length === 0, missing: false, version, help: { ...helpResult, missingFlags } };
+}
+
+function buildArgs(opts, brief) { const args = ["chat", "--no-interactive", "--wrap", "never"]; if (opts.agent) args.push("--agent", opts.agent); if (opts.model) args.push("--model", opts.model); if (opts.trustAllTools) args.push("--trust-all-tools"); else args.push(`--trust-tools=${opts.trustTools}`); if (opts.requireMcpStartup) args.push("--require-mcp-startup"); if (opts.resume) args.push("--resume"); if (opts.resumeId) args.push("--resume-id", opts.resumeId); args.push(brief); return args; }
+function extractSessionId(text) { const match = String(text).match(UUID_SEARCH); return match ? match[0] : null; }
+
+function writeResult(run, opts, extra) { const result = { schema: SCHEMA, lane: opts.lane, laneSource: opts.laneSource, tool: IMPLEMENTER_KEY, workdir: opts.cd, kiroBin: opts.kiroBin, agent: opts.agent, model: opts.model, trustTools: opts.trustAllTools ? null : opts.trustTools.split(",").map((x) => x.trim()).filter(Boolean), trustAllTools: opts.trustAllTools, inheritEnv: opts.inheritEnv, requireMcpStartup: opts.requireMcpStartup, resumed: Boolean(opts.resume || opts.resumeId), resumeId: opts.resumeId, startedAt: run.startedAt, finishedAt: new Date().toISOString(), briefPath: run.briefPath, finalPath: existsSync(run.finalPath) ? run.finalPath : null, stderrPath: run.stderrPath, resultPath: run.resultPath, ...extra }; const temporary = `${run.resultPath}.${process.pid}.tmp`; writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8"); renameSync(temporary, run.resultPath); return result; }
+function printSummary(result) { process.stdout.write(`relay: ${result.status} (exit ${result.exitCode})\nresult: ${result.resultPath}\n`); }
+
+function dispatch(opts, brief, run, baseline, checks, redactor) {
+  const c = command(opts.kiroBin, buildArgs(opts, brief));
+  const child = spawn(c.file, c.args, { cwd: opts.cd, env: childEnvironment(opts), stdio: ["ignore", "pipe", "pipe"], detached: process.platform !== "win32" });
+  let stdout = "";
+  let stderr = "";
+  let settled = false;
+  let timedOut = false;
+  let abortSignal = null;
+  let graceTimer = null;
+  let graceExpired = false;
+  let pendingClose = null;
+  const stderrTail = [];
+  const outDecoder = new StringDecoder("utf8");
+  const errDecoder = new StringDecoder("utf8");
+  const stderrStream = makeStderrStream(redactor);
+  const timer = setTimeout(() => {
+    if (settled) return;
+    timedOut = true;
+    killChild(child);
+    graceTimer = setTimeout(forceStop, GRACE_MS);
+  }, parseDuration(opts.timeout));
+  const finish = (status, exitCode, signal, error = null) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    if (graceTimer) clearTimeout(graceTimer);
+    stdout += outDecoder.end();
+    const stderrRemainder = errDecoder.end();
+    stderr += stderrRemainder;
+    const redactedRemainder = stderrStream.write(stderrRemainder) + stderrStream.flush();
+    if (redactedRemainder) {
+      appendFileSync(run.stderrPath, redactedRemainder, "utf8");
+      for (const line of redactedRemainder.split("\n")) if (line.trim()) {
+        stderrTail.push(line.trimEnd());
+        while (stderrTail.length > 20) stderrTail.shift();
+      }
+    }
+    const final = redactor.redact(stdout).trim();
+    if (final) writeFileSync(run.finalPath, final, "utf8");
+    const finalStatus = gitTouchedFiles(opts.cd);
+    const head = gitHead(opts.cd);
+    const headChanged = baseline.head && head ? baseline.head !== head : null;
+    let effectiveStatus = status;
+    let errorCode = error ? (status === "timeout" ? "timeout" : status === "aborted" ? "aborted" : "kiro_failed") : null;
+    let errorMessage = error ? String(error) : null;
+    if (!gitWorktree(opts.cd)) { effectiveStatus = "failed"; errorCode = "git_worktree_unavailable"; errorMessage = "Git worktree is unavailable"; }
+    else if (!head) { effectiveStatus = "failed"; errorCode = "git_head_unavailable"; errorMessage = "Git HEAD could not be verified"; }
+    else if (headChanged) { effectiveStatus = "failed"; errorCode = "head_changed"; errorMessage = "Git HEAD changed during the run; inspect the working tree"; }
+    else if (finalStatus === null) { effectiveStatus = "failed"; errorCode = "git_status_unavailable"; errorMessage = "git status could not be reported"; }
+    const result = writeResult(run, opts, {
+      status: effectiveStatus,
+      exitCode: effectiveStatus === "completed" ? 0 : (exitCode || 1),
+      signal: signal || null,
+      kiroVersion: checks.version.output,
+      preflight: checks,
+      sessionId: extractSessionId(`${stdout}\n${stderr}`) || opts.resumeId,
+      finalMessage: final,
+      touchedFiles: finalStatus,
+      baselineStatus: baseline.status,
+      finalStatus,
+      baselineHead: baseline.head,
+      finalHead: head,
+      headCheck: head ? "known" : "unavailable",
+      headChanged,
+      errorCode,
+      stderrTail: redactor.redact(stderrTail.slice(-20).join("\n")),
+      error: errorMessage ? redactor.redact(errorMessage) : null,
+      redaction: redactor.metadata(),
+    });
+    printSummary(result);
+    process.exit(result.exitCode);
+  };
+  const finishAfterClose = (closeResult) => {
+    if ((timedOut || abortSignal) && !graceExpired) pendingClose = closeResult;
+    else finish(...closeResult);
+  };
+  function forceStop() {
+    killChild(child, true);
+    graceExpired = true;
+    if (pendingClose) {
+      const closeResult = pendingClose;
+      pendingClose = null;
+      finish(...closeResult);
+    }
+  }
+  child.stdout.on("data", (chunk) => { stdout += outDecoder.write(chunk); });
+  child.stderr.on("data", (chunk) => {
+    const text = errDecoder.write(chunk);
+    stderr += text;
+    const redactedText = stderrStream.write(text);
+    if (!redactedText) return;
+    appendFileSync(run.stderrPath, redactedText, "utf8");
+    for (const line of redactedText.split("\n")) if (line.trim()) {
+      stderrTail.push(line.trimEnd());
+      while (stderrTail.length > 20) stderrTail.shift();
+    }
+  });
+  child.on("error", (error) => finishAfterClose([error?.code === "ENOENT" ? "kiro_unavailable" : "failed", error?.code === "ENOENT" ? 127 : 1, null, error?.message || error]));
+  child.on("close", (code, signal) => {
+    if (timedOut) finishAfterClose(["timeout", 124, signal, `kiro-cli did not finish within --timeout ${opts.timeout}`]);
+    else if (abortSignal) finishAfterClose(["aborted", 128 + (constants.signals[abortSignal] || 15), abortSignal, `relay received ${abortSignal}`]);
+    else finishAfterClose([code === 0 ? "completed" : "failed", code ?? 1, signal, code === 0 ? null : `kiro-cli exited with code ${code ?? "unknown"}`]);
+  });
+  const abortSignals = ["SIGTERM", "SIGINT", "SIGHUP"];
+  if (process.platform === "win32") abortSignals.push("SIGBREAK");
+  for (const signal of abortSignals) process.on(signal, () => {
+    if (!settled && !timedOut && !abortSignal) {
+      abortSignal = signal;
+      killChild(child);
+      graceTimer = setTimeout(forceStop, GRACE_MS);
+    }
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief");
+  if (Buffer.byteLength(brief, "utf8") > MAX_BRIEF_BYTES) fail(`brief exceeds ${MAX_BRIEF_BYTES} bytes`);
+  const redactor = makeRedactor(process.env);
+  const run = prepareRun(opts, brief, redactor);
+  const baseline = { status: gitTouchedFiles(opts.cd), head: gitHead(opts.cd), worktreeAvailable: gitWorktree(opts.cd) };
+  const base = { baselineStatus: baseline.status, finalStatus: baseline.status, baselineHead: baseline.head, finalHead: baseline.head, headCheck: baseline.head ? "known" : "unavailable", headChanged: null, finalMessage: "", touchedFiles: baseline.status, sessionId: null, redaction: redactor.metadata() };
+  if (!baseline.worktreeAvailable) { const result = writeResult(run, opts, { ...base, status: "failed", exitCode: 1, signal: null, kiroVersion: null, errorCode: "git_worktree_unavailable", error: "--cd must be a Git worktree" }); printSummary(result); process.exit(1); }
+  if (!baseline.head) { const result = writeResult(run, opts, { ...base, status: "failed", exitCode: 1, signal: null, kiroVersion: null, errorCode: "git_head_unavailable", error: "Git HEAD could not be verified" }); printSummary(result); process.exit(1); }
+  if (baseline.status === null) { const result = writeResult(run, opts, { ...base, status: "failed", exitCode: 1, signal: null, kiroVersion: null, errorCode: "git_status_unavailable", error: "Git status could not be verified" }); printSummary(result); process.exit(1); }
+  const checks = await preflight(opts, redactor);
+  if (checks.missing) { const result = writeResult(run, opts, { ...base, status: "kiro_unavailable", exitCode: 127, signal: null, kiroVersion: null, errorCode: "kiro_unavailable", preflight: checks, error: `${opts.kiroBin} was not found` }); printSummary(result); process.exit(127); }
+  if (!checks.ok) { const probeTimedOut = checks.version.error === "timeout" || checks.help?.error === "timeout"; const result = writeResult(run, opts, { ...base, status: probeTimedOut ? "timeout" : "failed", exitCode: probeTimedOut ? 124 : 1, signal: null, kiroVersion: checks.version.output || null, errorCode: "kiro_preflight_failed", preflight: checks, error: "Kiro CLI preflight failed; Kiro was not dispatched" }); printSummary(result); process.exit(probeTimedOut ? 124 : 1); }
+  dispatch(opts, brief, run, baseline, checks, redactor);
+}
+
+main().catch((error) => fail(error?.message || String(error), 1));

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -206,7 +206,6 @@ function parseDuration(duration) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],
@@ -261,32 +260,70 @@ function versionProbeTimeout(opts) {
   return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
 }
 
-function opencodeVersion(probeTimeoutMs) {
-  try {
-    // On Windows, npm installs `opencode` as a .cmd shim; Node's CreateProcess only
-    // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
-    // ENOENTs on a working install. POSIX is unaffected. (git installs a real
-    // git.exe and must NOT get this flag — see gitTouchedFiles.)
-    const version = execFileSync("opencode", ["--version"], {
-      encoding: "utf8",
-      shell: process.platform === "win32",
-      timeout: probeTimeoutMs,
-      killSignal: "SIGKILL",
-    }).trim();
-    return { version: version || "unknown", error: null };
-  } catch (error) {
-    if (error?.code === "ENOENT") return { version: null, error: null };
-    // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
-    // exit rather than ENOENT; that is still "not installed", not a broken install.
-    if (process.platform === "win32" &&
-        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
-      return { version: null, error: null };
-    }
-    // Anything else — a hung probe we killed, or a real non-zero exit — means opencode is
-    // installed but not usable. Reporting that as "unavailable" would send the caller
-    // off to reinstall a binary that is already there.
-    return { version: null, error };
+function runVersionProbe(binary, args, timeoutMs, shell = process.platform === "win32") {
+  return new Promise((resolve) => {
+    const child = spawn(binary, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // A shell-backed .cmd launch has a wrapper plus the actual CLI. Kill the
+      // wrapper's whole tree, not just the process Node started directly.
+      killChild(child, "SIGKILL");
+    }, timeoutMs);
+    const finish = (error, status = null, signal = null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        if (Number.isInteger(status)) error.status = status;
+        error.signal = signal;
+        resolve({ version: null, error });
+        return;
+      }
+      resolve({ version: stdout.trim() || "unknown", error: null });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+    child.on("error", (error) => finish(error));
+    child.on("close", (status, signal) => {
+      if (timedOut) {
+        const error = new Error("version probe timed out");
+        error.code = "ETIMEDOUT";
+        finish(error, status, signal);
+      } else if (status === 0) {
+        finish(null, status, signal);
+      } else {
+        const error = new Error(`version probe exited with ${status ?? "unknown"}`);
+        finish(error, status, signal);
+      }
+    });
+  });
+}
+
+async function opencodeVersion(probeTimeoutMs) {
+  // On Windows, npm installs `opencode` as a .cmd shim; shell:true resolves it and
+  // runVersionProbe retains the wrapper PID so timeout cleanup can fell its tree.
+  const probe = await runVersionProbe("opencode", ["--version"], probeTimeoutMs);
+  if (probe.error?.code === "ENOENT") return { version: null, error: null };
+  // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+  // exit rather than ENOENT; that is still "not installed", not a broken install.
+  if (process.platform === "win32" &&
+      /not recognized as an internal or external command/i.test(String(probe.error?.stderr || ""))) {
+    return { version: null, error: null };
   }
+  // Anything else — a hung probe we killed, or a real non-zero exit — means opencode is
+  // installed but not usable. Reporting that as "unavailable" would send the caller
+  // off to reinstall a binary that is already there.
+  return probe;
 }
 
 function gitTouchedFiles(cwd) {
@@ -646,7 +683,7 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
   child.stdin.end();
 }
 
-function main() {
+async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
@@ -665,7 +702,7 @@ function main() {
   // somewhere to publish result.json rather than exiting silently.
   const run = prepareRunDir(opts, brief);
   const probeTimeoutMs = versionProbeTimeout(opts);
-  const probe = opencodeVersion(probeTimeoutMs);
+  const probe = await opencodeVersion(probeTimeoutMs);
   const writeResult = makeResultWriter(opts, probe.version, run);
 
   if (!probe.version && !probe.error) {
@@ -711,4 +748,4 @@ function printSummary(result, resultPath) {
   process.stdout.write(`${lines.join("\n")}\n`);
 }
 
-main();
+main().catch((error) => fail(error?.message || String(error)));

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -252,7 +252,6 @@ function readBrief(opts) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],

--- a/skills/qoder-delegate/scripts/relay.mjs
+++ b/skills/qoder-delegate/scripts/relay.mjs
@@ -221,7 +221,6 @@ function readBrief(opts) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],

--- a/skills/vibe-delegate/scripts/relay.mjs
+++ b/skills/vibe-delegate/scripts/relay.mjs
@@ -331,7 +331,6 @@ function gitTouchedFiles(cwd) {
 function killChild(child, signal = "SIGTERM") {
   if (!child || !child.pid) return;
   if (process.platform === "win32") {
-    if (signal !== "SIGTERM") return;
     try {
       execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
         stdio: ["ignore", "ignore", "inherit"],

--- a/test/fixtures/console-signal-helper.cs
+++ b/test/fixtures/console-signal-helper.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+class ConsoleSignalHelper {
+  private const uint CREATE_NEW_CONSOLE = 0x00000010;
+  private const uint CREATE_UNICODE_ENVIRONMENT = 0x00000400;
+  private const uint CTRL_C_EVENT = 0;
+  private const uint INFINITE = 0xffffffff;
+  private const uint WAIT_OBJECT_0 = 0;
+
+  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+  private struct STARTUPINFO {
+    public int cb;
+    public string lpReserved;
+    public string lpDesktop;
+    public string lpTitle;
+    public int dwX;
+    public int dwY;
+    public int dwXSize;
+    public int dwYSize;
+    public int dwXCountChars;
+    public int dwYCountChars;
+    public int dwFillAttribute;
+    public int dwFlags;
+    public short wShowWindow;
+    public short cbReserved2;
+    public IntPtr lpReserved2;
+    public IntPtr hStdInput;
+    public IntPtr hStdOutput;
+    public IntPtr hStdError;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct PROCESS_INFORMATION {
+    public IntPtr hProcess;
+    public IntPtr hThread;
+    public uint dwProcessId;
+    public uint dwThreadId;
+  }
+
+  [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  private static extern bool CreateProcess(
+    string applicationName,
+    StringBuilder commandLine,
+    IntPtr processAttributes,
+    IntPtr threadAttributes,
+    bool inheritHandles,
+    uint creationFlags,
+    IntPtr environment,
+    string currentDirectory,
+    ref STARTUPINFO startupInfo,
+    out PROCESS_INFORMATION processInformation);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool TerminateProcess(IntPtr process, uint exitCode);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool CloseHandle(IntPtr handle);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool FreeConsole();
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool AttachConsole(uint processId);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool GenerateConsoleCtrlEvent(uint eventType, uint processGroupId);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool SetConsoleCtrlHandler(IntPtr handlerRoutine, bool add);
+
+  private static string Quote(string value) {
+    return "\"" + value.Replace("\"", "\\\"") + "\"";
+  }
+
+  private static void Fail(string message, PROCESS_INFORMATION process) {
+    Console.Error.WriteLine("console-signal-helper: " + message + " (error " + Marshal.GetLastWin32Error() + ")");
+    if (process.hProcess != IntPtr.Zero) TerminateProcess(process.hProcess, 1);
+    Environment.Exit(1);
+  }
+
+  public static int Main(string[] args) {
+    if (args.Length < 7) {
+      Console.Error.WriteLine("usage: helper <node> <relay> <brief> <workdir> <outdir> <kiro-bin> <ready-file>");
+      return 2;
+    }
+
+    var node = args[0];
+    var relay = args[1];
+    var brief = args[2];
+    var workdir = args[3];
+    var outdir = args[4];
+    var kiroBin = args[5];
+    var readyFile = args[6];
+    var commandLine = new StringBuilder(Quote(node) + " " + Quote(relay)
+      + " --brief " + Quote(brief)
+      + " --cd " + Quote(workdir)
+      + " --out-dir " + Quote(outdir)
+      + " --kiro-bin " + Quote(kiroBin));
+    var startup = new STARTUPINFO();
+    startup.cb = Marshal.SizeOf(startup);
+    var process = new PROCESS_INFORMATION();
+    var created = CreateProcess(node, commandLine, IntPtr.Zero, IntPtr.Zero, false,
+      CREATE_NEW_CONSOLE | CREATE_UNICODE_ENVIRONMENT, IntPtr.Zero, workdir,
+      ref startup, out process);
+    if (!created) Fail("CreateProcess failed", process);
+
+    var ready = false;
+    for (var i = 0; i < 150; i++) {
+      if (File.Exists(readyFile)) { ready = true; break; }
+      Thread.Sleep(100);
+    }
+    if (!ready) Fail("relay did not reach the fake implementer", process);
+    Thread.Sleep(300);
+
+    // Ignore the control event in this helper, then attach to the relay's new console.
+    SetConsoleCtrlHandler(IntPtr.Zero, true);
+    FreeConsole();
+    var attached = false;
+    for (var i = 0; i < 20 && !attached; i++) {
+      attached = AttachConsole(process.dwProcessId);
+      if (!attached) Thread.Sleep(100);
+    }
+    if (!attached) Fail("AttachConsole failed", process);
+    if (!GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0)) Fail("GenerateConsoleCtrlEvent failed", process);
+    Thread.Sleep(300);
+    FreeConsole();
+
+    if (WaitForSingleObject(process.hProcess, 30000) != WAIT_OBJECT_0) Fail("relay did not exit", process);
+    uint exitCode;
+    if (!GetExitCodeProcess(process.hProcess, out exitCode)) Fail("GetExitCodeProcess failed", process);
+    CloseHandle(process.hThread);
+    CloseHandle(process.hProcess);
+    return unchecked((int)exitCode);
+  }
+}

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -1,8 +1,28 @@
 const fs = require("node:fs");
+const path = require("node:path");
 const args = process.argv.slice(2);
+const testContext = process.env.SMOKE_MODE || process.cwd();
 // Every probe form one relay or another uses: --version, grok's \`version\` subcommand, and
 // agy's \`changelog\`. Treating them alike lets any relay's hang/fail mode be driven by name.
 const versionProbe = args.includes("--version") || args[0] === "version" || args[0] === "changelog";
+if (versionProbe && process.env.SMOKE_VERSION_PID_FILE) {
+  const versionPidFile = process.env.SMOKE_VERSION_PID_FILE;
+  fs.writeFileSync(versionPidFile, String(process.pid));
+}
+if (versionProbe && /-version-hang-tree$/.test(testContext)) {
+  const grand = require("node:child_process").spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+  const grandPidFile = process.env.SMOKE_VERSION_GRAND_PID_FILE || path.join(process.cwd(), "smoke-version-grand.pid");
+  fs.writeFileSync(grandPidFile, String(grand.pid));
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+}
+if (args[0] === "chat" && args[1] === "--help") {
+  if (/-version-hang$/.test(testContext)) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+  if (/-version-fail(?:-silent)?$/.test(testContext)) process.exit(7);
+  console.log(/-help-missing$/.test(testContext)
+    ? "--no-interactive --trust-tools --resume-id"
+    : "--no-interactive --trust-tools --resume-id --wrap");
+  process.exit(0);
+}
 if (versionProbe && process.env.SMOKE_MODE === "grok-version-fallback-budget") {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 700);
   if (args[0] === "version") {
@@ -11,11 +31,11 @@ if (versionProbe && process.env.SMOKE_MODE === "grok-version-fallback-budget") {
   }
   console.log("fake-cli 0.0.0-smoke");
   process.exit(0);
-} else if (versionProbe && /-version-hang$/.test(process.env.SMOKE_MODE || "")) {
+} else if (versionProbe && /-version-hang$/.test(testContext)) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
-} else if (versionProbe && /-version-fail-silent$/.test(process.env.SMOKE_MODE || "")) {
+} else if (versionProbe && /-version-fail-silent$/.test(testContext)) {
   process.exit(7);
-} else if (versionProbe && /-version-fail$/.test(process.env.SMOKE_MODE || "")) {
+} else if (versionProbe && /-version-fail$/.test(testContext)) {
   console.error("fake version failure");
   process.exit(7);
 } else if (versionProbe) {
@@ -54,6 +74,19 @@ if (process.env.SMOKE_MODE === "vibe-success") {
   fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
   console.log(JSON.stringify({ role: "assistant", content: "working" }));
   console.log(JSON.stringify({ role: "assistant", content: "fake vibe completed" }));
+  process.exit(0);
+}
+if (process.env.KIRO_FAKE_MODE === "split") {
+  console.log("fake kiro completed");
+  process.stderr.write("partial-api-");
+  setTimeout(() => {
+    process.stderr.write("secret-value\n");
+    process.exit(0);
+  }, 200);
+}
+if (args.includes("--resume-id")) {
+  fs.writeFileSync(process.env.SMOKE_ARGS_FILE || "smoke-args.json", JSON.stringify(args));
+  console.log("fake kiro completed\nSession: 11111111-1111-4111-8111-111111111111");
   process.exit(0);
 }
 if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
@@ -150,8 +183,8 @@ if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
     ? "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"
     : "setInterval(() => {}, 1000)";
   const grand = require("node:child_process").spawn(process.execPath, ["-e", grandProgram], { stdio: "ignore" });
-  fs.writeFileSync(process.env.SMOKE_GRAND_PID_FILE, String(grand.pid));
-  fs.writeFileSync(process.env.SMOKE_PID_FILE, String(process.pid)); // written last: its existence means both pid files are readable
+  fs.writeFileSync(process.env.SMOKE_GRAND_PID_FILE || path.join(process.cwd(), "smoke-grand.pid"), String(grand.pid));
+  fs.writeFileSync(process.env.SMOKE_PID_FILE || path.join(process.cwd(), "smoke.pid"), String(process.pid)); // written last: its existence means both pid files are readable
   if (process.env.SMOKE_MODE === "abort") {
     process.on("SIGTERM", () => { fs.writeFileSync(process.env.SMOKE_LATE_FILE, "flushed during shutdown"); process.exit(0); });
   } else if (process.env.SMOKE_MODE === "timeout-yield") {

--- a/test/fixtures/fake-cli.cs
+++ b/test/fixtures/fake-cli.cs
@@ -7,16 +7,45 @@ class FakeCli {
     // Mirrors the .cjs fake: any probe form, and hang/fail selected by the mode's suffix,
     // so a native-binary relay (agy, kimi, qoder, vibe) enters the same preflight matrix.
     var mode = Environment.GetEnvironmentVariable("SMOKE_MODE") ?? "";
+    var testContext = mode.Length > 0 ? mode : Environment.CurrentDirectory;
+    if (args.Length > 1 && args[0] == "chat" && args[1] == "--help") {
+      if (testContext.EndsWith("-version-fail") || testContext.EndsWith("-version-fail-silent")) return 7;
+      Console.WriteLine(testContext.EndsWith("-help-missing")
+        ? "--no-interactive --trust-tools --resume-id"
+        : "--no-interactive --trust-tools --resume-id --wrap");
+      return 0;
+    }
     bool versionProbe = Array.IndexOf(args, "--version") >= 0
       || (args.Length > 0 && (args[0] == "version" || args[0] == "changelog"));
-    if (versionProbe && mode.EndsWith("-version-hang")) {
+    if (versionProbe) {
+      var versionPidFile = Environment.GetEnvironmentVariable("SMOKE_VERSION_PID_FILE");
+      if (String.IsNullOrEmpty(versionPidFile) && Environment.CurrentDirectory.IndexOf("relay-smoke-", StringComparison.OrdinalIgnoreCase) >= 0) {
+        versionPidFile = Path.Combine(Environment.CurrentDirectory, "smoke-version.pid");
+      }
+      if (!String.IsNullOrEmpty(versionPidFile)) File.WriteAllText(versionPidFile, Process.GetCurrentProcess().Id.ToString());
+    }
+    if (versionProbe && testContext.EndsWith("-version-hang-tree")) {
+      var versionGrand = Process.Start(new ProcessStartInfo {
+        FileName = Environment.GetEnvironmentVariable("SMOKE_NODE") ?? "node",
+        Arguments = "-e setInterval(()=>{},1000)",
+        UseShellExecute = false,
+      });
+      var versionGrandPidFile = Environment.GetEnvironmentVariable("SMOKE_VERSION_GRAND_PID_FILE");
+      if (String.IsNullOrEmpty(versionGrandPidFile) && Environment.CurrentDirectory.IndexOf("relay-smoke-", StringComparison.OrdinalIgnoreCase) >= 0) {
+        versionGrandPidFile = Path.Combine(Environment.CurrentDirectory, "smoke-version-grand.pid");
+      }
+      if (!String.IsNullOrEmpty(versionGrandPidFile)) File.WriteAllText(versionGrandPidFile, versionGrand.Id.ToString());
       Thread.Sleep(Timeout.Infinite);
       return 1;
     }
-    if (versionProbe && mode.EndsWith("-version-fail-silent")) {
+    if (versionProbe && testContext.EndsWith("-version-hang")) {
+      Thread.Sleep(Timeout.Infinite);
+      return 1;
+    }
+    if (versionProbe && testContext.EndsWith("-version-fail-silent")) {
       return 7;
     }
-    if (versionProbe && mode.EndsWith("-version-fail")) {
+    if (versionProbe && testContext.EndsWith("-version-fail")) {
       Console.Error.WriteLine("fake version failure");
       return 7;
     }
@@ -40,14 +69,32 @@ class FakeCli {
       Console.WriteLine("{\"role\":\"assistant\",\"content\":\"fake vibe completed\"}");
       return 0;
     }
+    if (Environment.GetEnvironmentVariable("KIRO_FAKE_MODE") == "split") {
+      Console.WriteLine("fake kiro completed");
+      Console.Error.Write("partial-api-");
+      Console.Error.Flush();
+      Thread.Sleep(200);
+      Console.Error.Write("secret-value\n");
+      Console.Error.Flush();
+      return 0;
+    }
+    if (Array.IndexOf(args, "--resume-id") >= 0) {
+      var argsFile = Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE") ?? Path.Combine(Environment.CurrentDirectory, "smoke-args.json");
+      File.WriteAllLines(argsFile, args);
+      Console.WriteLine("fake kiro completed");
+      Console.WriteLine("Session: 11111111-1111-4111-8111-111111111111");
+      return 0;
+    }
     var psi = new ProcessStartInfo {
-      FileName = Environment.GetEnvironmentVariable("SMOKE_NODE"),
+      FileName = Environment.GetEnvironmentVariable("SMOKE_NODE") ?? "node",
       Arguments = "-e setInterval(()=>{},1000)",
       UseShellExecute = false,
     };
     var grand = Process.Start(psi);
-    File.WriteAllText(Environment.GetEnvironmentVariable("SMOKE_GRAND_PID_FILE"), grand.Id.ToString());
-    File.WriteAllText(Environment.GetEnvironmentVariable("SMOKE_PID_FILE"), Process.GetCurrentProcess().Id.ToString());
+    var grandPidFile = Environment.GetEnvironmentVariable("SMOKE_GRAND_PID_FILE") ?? Path.Combine(Environment.CurrentDirectory, "smoke-grand.pid");
+    var pidFile = Environment.GetEnvironmentVariable("SMOKE_PID_FILE") ?? Path.Combine(Environment.CurrentDirectory, "smoke.pid");
+    File.WriteAllText(grandPidFile, grand.Id.ToString());
+    File.WriteAllText(pidFile, Process.GetCurrentProcess().Id.ToString());
     Thread.Sleep(Timeout.Infinite);
     return 0;
   }

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi"];
+export const SKILLS = ["claude", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "kiro"];
 
 export const EXTRA_ARGS = {
   claude: [],
@@ -13,6 +13,7 @@ export const EXTRA_ARGS = {
   vibe: [],
   cursor: [],
   pi: [],
+  kiro: [],
 };
 
 export const WIN = process.platform === "win32";

--- a/test/harness/create-harness.mjs
+++ b/test/harness/create-harness.mjs
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, mkdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, readFileSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { join, delimiter } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
@@ -65,6 +65,9 @@ export function createHarness() {
     baseEnv: null,
     slowWriteNodeOptions: null,
     freshRepo: null,
+    committedRepo: null,
+    gitOnlyPath: null,
+    consoleSignalHelper: null,
     runRelay: null,
     result: null,
     cleanup() {
@@ -78,6 +81,21 @@ export function createHarness() {
     spawnSync("git", ["-C", dir, "init", "-q"], { encoding: "utf8" });
     return dir;
   };
+
+  h.committedRepo = (name) => {
+    const dir = h.freshRepo(name);
+    writeFileSync(join(dir, "seed.txt"), "seed\n");
+    spawnSync("git", ["-C", dir, "config", "user.email", "smoke@example.invalid"], { encoding: "utf8" });
+    spawnSync("git", ["-C", dir, "config", "user.name", "Relay Smoke"], { encoding: "utf8" });
+    spawnSync("git", ["-C", dir, "add", "seed.txt"], { encoding: "utf8" });
+    spawnSync("git", ["-C", dir, "commit", "-qm", "seed"], { encoding: "utf8" });
+    return dir;
+  };
+
+  const gitName = WIN ? "git.exe" : "git";
+  h.gitOnlyPath = (process.env.PATH || "").split(delimiter)
+    .filter((dir) => dir && existsSync(join(dir, gitName)))
+    .join(delimiter);
 
   h.runRelay = (skill, workDir, outDir, extraArgs, extraEnv) =>
     spawn(process.execPath, [h.relayPath(skill), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir, ...extraArgs], {

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -22,7 +22,7 @@ export function installShim(h) {
       join(windir, "Microsoft.NET", "Framework64", "v4.0.30319", "csc.exe"),
       join(windir, "Microsoft.NET", "Framework", "v4.0.30319", "csc.exe"),
     ].find((p) => existsSync(p));
-    h.check("windows: the in-box C# compiler exists (builds the native fake for agy/kimi/qoder/vibe)", Boolean(csc));
+      h.check("windows: the in-box C# compiler exists (builds the native fake for agy/kimi/qoder/vibe/kiro)", Boolean(csc));
     if (csc) {
       const csFile = join(shimDir, "fake-cli.cs");
       copyFileSync(join(fixturesDir, "fake-cli.cs"), csFile);
@@ -32,9 +32,16 @@ export function installShim(h) {
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "agy.exe"));
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "qodercli.exe"));
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "vibe.exe"));
+        copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "kiro-cli.exe"));
       } else {
         console.error(`${compiled.stdout ?? ""}${compiled.stderr ?? ""}`);
       }
+      const signalSource = join(fixturesDir, "console-signal-helper.cs");
+      const signalHelper = join(shimDir, "console-signal-helper.exe");
+      const signalCompiled = spawnSync(csc, ["/nologo", "/target:exe", `/out:${signalHelper}`, signalSource], { encoding: "utf8" });
+      h.check("windows: console signal helper compiled", signalCompiled.status === 0);
+      if (signalCompiled.status !== 0) console.error(`${signalCompiled.stdout ?? ""}${signalCompiled.stderr ?? ""}`);
+      h.consoleSignalHelper = signalCompiled.status === 0 ? signalHelper : null;
     }
   } else {
     for (const skill of SKILLS) {

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -7,7 +7,7 @@
  * not complete:
  *
  *   1. timeout  — the watchdog kills the implementer's WHOLE process tree and
- *                 result.json reports status "timeout". Driven for all ten
+ *                 result.json reports status "timeout". Driven for all eleven
  *                 relays on both platforms. On Windows, claude and cursor
  *                 launch a .cmd shim through a serialized cmd.exe invocation,
  *                 while codex/opencode/grok/pi use shell:true. These are exactly the
@@ -23,15 +23,16 @@
  *   2. aborted  — killing the relay itself still produces result.json with
  *                 status "aborted", and files the implementer flushes during
  *                 the shutdown grace window appear in the refreshed
- *                 touchedFiles. Driven for all ten relays on POSIX; Windows
- *                 delivers no catchable SIGTERM, so the scenario cannot be
- *                 driven there (the skill docs carry the same caveat).
+ *                 touchedFiles. Driven for all eleven relays on POSIX. Kiro
+ *                 additionally has a Windows-only console harness that
+ *                 launches a new console and sends CTRL+C through
+ *                 GenerateConsoleCtrlEvent.
  *
  * Every fake answers each relay's version preflight (--version, `version`,
  * `changelog`), and can be told to hang or fail that probe by mode name, so a
  * relay whose preflight is unbounded — wedging before any result.json exists —
  * or which reports a broken CLI as a missing one is caught here.
- * A shared matrix also drives all ten through the --timeout values no
+ * A shared matrix also drives all eleven through the --timeout values no
  * watchdog can honour — malformed, zero, and past Node's timer ceiling — each of
  * which would otherwise fire on the next tick as a silent instant "timeout".
  * Quick Claude, Cursor, Qoder, Vibe, and Pi success cases verify brief

--- a/test/relay/atomic.mjs
+++ b/test/relay/atomic.mjs
@@ -27,7 +27,7 @@ for (const skill of h.SKILLS) {
   }
   const timedOut = exitCode === undefined;
   if (timedOut) child.kill();
-  await h.until(() => exitCode !== undefined, 5_000);
+  await h.until(() => exitCode !== undefined, 20_000);
   if (exitCode === undefined) child.kill("SIGKILL"); // a relay that ignored SIGTERM would keep its tree alive
   let finalResultValid = false;
   try { finalResultValid = Boolean(h.result(atomicOutDir)); } catch {}

--- a/test/relay/cursor.mjs
+++ b/test/relay/cursor.mjs
@@ -95,22 +95,39 @@ for (const [flag, bad] of [
 }
 for (const [mode, expectedStatus, expectedExit] of [
   ["cursor-version-hang", "timeout", 124],
+  ["cursor-version-hang-tree", "timeout", 124],
   ["cursor-version-fail", "failed", 7],
 ]) {
   const outDir = join(h.scratch, `out-${mode}`);
+  const versionGrandPidFile = join(cursorNegativeWorkDir, `${mode}-grand.pid`);
   const preflight = spawnSync(process.execPath, [
     h.relayPath("cursor"),
     "--brief", h.briefPath,
     "--cd", cursorNegativeWorkDir,
     "--out-dir", outDir,
-    "--timeout", "1s",
-  ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
+    "--timeout", mode === "cursor-version-hang" ? "1s" : "30s",
+  ], {
+    env: {
+      ...h.baseEnv,
+      SMOKE_MODE: mode,
+      ...(mode === "cursor-version-hang-tree" ? {
+        SMOKE_VERSION_PID_FILE: join(cursorNegativeWorkDir, `${mode}.pid`),
+        SMOKE_VERSION_GRAND_PID_FILE: versionGrandPidFile,
+      } : {}),
+    },
+    encoding: "utf8",
+    timeout: 60000,
+  });
   const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
   h.check(`cursor preflight: ${mode} is explicit and prevents dispatch`,
     preflight.status === expectedExit &&
     value.status === expectedStatus &&
     value.error?.includes("version preflight") &&
     value.error?.includes("was not dispatched"));
+  if (mode === "cursor-version-hang-tree") {
+    const grandPid = existsSync(versionGrandPidFile) ? Number(readFileSync(versionGrandPidFile, "utf8")) : null;
+    h.check("cursor preflight: version timeout kills probe grandchild", grandPid !== null && await h.until(() => !h.alive(grandPid), 10000));
+  }
 }
 if (!h.WIN) {
   const outDir = join(h.scratch, "out-abort-preflight-cursor");
@@ -145,10 +162,26 @@ if (!h.WIN) {
     "--brief", h.briefPath,
     "--cd", cursorNegativeWorkDir,
     "--out-dir", outDir,
-  ], { env: { ...process.env, PATH: "" }, encoding: "utf8" });
+  ], { env: { ...process.env, PATH: h.gitOnlyPath, Path: h.gitOnlyPath }, encoding: "utf8", timeout: 60000 });
+  const missingResult = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
   h.check("cursor unavailable: structured result replaces stale artifacts",
     missing.status === 127 &&
-    h.result(outDir).status === "cursor_agent_unavailable" &&
+    missingResult.status === "cursor_agent_unavailable" &&
+    missingResult.exitCode === 127 &&
     !existsSync(join(outDir, "final.txt")));
+}
+{
+  const gitStatusWork = h.committedRepo("work-cursor-git-status-unavailable");
+  writeFileSync(join(gitStatusWork, ".git", "index"), "CORRUPT");
+  const gitStatusOut = join(h.scratch, "out-cursor-git-status-unavailable");
+  const gitStatusRun = spawnSync(process.execPath, [
+    h.relayPath("cursor"),
+    "--brief", h.briefPath,
+    "--cd", gitStatusWork,
+    "--out-dir", gitStatusOut,
+  ], { env: { ...h.baseEnv, SMOKE_MODE: "cursor-success", SMOKE_CAPTURE_FILE: join(h.scratch, "capture-cursor-git-status.json") }, encoding: "utf8", timeout: 60000 });
+  const gitStatusValue = existsSync(join(gitStatusOut, "result.json")) ? h.result(gitStatusOut) : {};
+  h.check("cursor git status unavailable fails closed",
+    gitStatusRun.status === 1 && gitStatusValue.status === "failed" && gitStatusValue.exitCode === 1);
 }
 }

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -27,7 +27,7 @@ export function runDelegateSetup(h) {
   h.check("discover reports version", report?.version === "delegate-discover.v1");
   h.check("discover lists discovered or missing", Array.isArray(report?.discovered) && Array.isArray(report?.missing));
   h.check(
-    "discover covers all ten implementers",
+    "discover covers all eleven implementers",
     Array.isArray(report?.discovered) &&
       Array.isArray(report?.missing) &&
       report.discovered.length + report.missing.length === h.SKILLS.length,

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -12,6 +12,10 @@ import { runClaude } from "./claude.mjs";
 import { runTimeoutTree } from "./timeout-tree.mjs";
 import { runAbort } from "./abort.mjs";
 import { runDelegateSetup } from "./delegate-setup.mjs";
+import { runKiro } from "./kiro.mjs";
+import { runKiroPreflight } from "./kiro-preflight.mjs";
+import { runKiroTimeout } from "./kiro-timeout.mjs";
+import { runKiroConsoleAbort } from "./kiro-console-abort.mjs";
 
 export const runners = [
   ["package-shape", runPackageShape],
@@ -28,4 +32,8 @@ export const runners = [
   ["timeout-tree", runTimeoutTree],
   ["abort", runAbort],
   ["delegate-setup", runDelegateSetup],
+  ["kiro", runKiro],
+  ["kiro-preflight", runKiroPreflight],
+  ["kiro-timeout", runKiroTimeout],
+  ["kiro-console-abort", runKiroConsoleAbort],
 ];

--- a/test/relay/kiro-console-abort.mjs
+++ b/test/relay/kiro-console-abort.mjs
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+export async function runKiroConsoleAbort(h) {
+  if (!h.WIN) {
+    console.log("  skip  kiro console abort: Windows-only console control event");
+    return;
+  }
+  const workDir = h.committedRepo("work-kiro-console-abort");
+  const outDir = join(h.scratch, "out-kiro-console-abort");
+  const pidFile = join(workDir, "smoke.pid");
+  const grandPidFile = join(workDir, "smoke-grand.pid");
+  const lateFile = join(workDir, "late-file.txt");
+  const kiroBin = join(h.scratch, "shim", "kiro-cli.exe");
+  h.check("kiro console abort: helper compiled", Boolean(h.consoleSignalHelper));
+  if (!h.consoleSignalHelper) return;
+  const run = spawnSync(h.consoleSignalHelper, [
+    process.execPath,
+    h.relayPath("kiro"),
+    h.briefPath,
+    workDir,
+    outDir,
+    kiroBin,
+    pidFile,
+  ], {
+    cwd: h.testDir,
+    env: {
+      ...h.baseEnv,
+      SMOKE_MODE: "abort",
+      SMOKE_PID_FILE: pidFile,
+      SMOKE_GRAND_PID_FILE: grandPidFile,
+      SMOKE_LATE_FILE: lateFile,
+    },
+    encoding: "utf8",
+    timeout: 45_000,
+  });
+  const resultPath = join(outDir, "result.json");
+  const result = existsSync(resultPath) ? JSON.parse(readFileSync(resultPath, "utf8")) : {};
+  h.check(`kiro console abort: helper exits with relay abort code (got ${run.status})`, run.status === 130);
+  h.check("kiro console abort: result exists", existsSync(resultPath));
+  h.check("kiro console abort: result records aborted status", result.status === "aborted" && result.errorCode === "aborted");
+  h.check("kiro console abort: signal is a console abort signal", result.signal === "SIGINT" || result.signal === "SIGBREAK");
+  const implementerPid = existsSync(pidFile) ? Number(readFileSync(pidFile, "utf8")) : null;
+  const grandPid = existsSync(grandPidFile) ? Number(readFileSync(grandPidFile, "utf8")) : null;
+  h.check("kiro console abort: implementer is dead", implementerPid !== null && await h.until(() => !h.alive(implementerPid), 10_000));
+  h.check("kiro console abort: implementer's child is dead", grandPid !== null && await h.until(() => !h.alive(grandPid), 10_000));
+  if (run.stderr) console.error(`kiro console abort stderr:\n${run.stderr}`);
+}

--- a/test/relay/kiro-preflight.mjs
+++ b/test/relay/kiro-preflight.mjs
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+export async function runKiroPreflight(h) {
+  for (const [suffix, expectedStatus, expectedExit] of [
+    ["version-hang", "timeout", 124],
+    ["version-hang-tree", "timeout", 124],
+    ["version-fail", "failed", 1],
+    ["version-fail-silent", "failed", 1],
+    ["help-missing", "failed", 1],
+  ]) {
+    const workDir = h.committedRepo(`work-kiro-preflight-${suffix}`);
+    const outDir = join(h.scratch, `out-kiro-preflight-${suffix}`);
+    const versionGrandPidFile = join(workDir, "smoke-version-grand.pid");
+    const run = spawnSync(process.execPath, [
+      h.relayPath("kiro"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", outDir,
+      "--timeout", suffix === "version-hang" ? "1s" : "30s",
+    ], {
+      env: {
+        ...h.baseEnv,
+        PATH: h.baseEnv.PATH,
+        SMOKE_MODE: `kiro-${suffix}`,
+        ...(suffix === "version-hang-tree" ? {
+          SMOKE_VERSION_PID_FILE: join(workDir, "smoke-version.pid"),
+          SMOKE_VERSION_GRAND_PID_FILE: versionGrandPidFile,
+        } : {}),
+      },
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    const resultPath = join(outDir, "result.json");
+    const result = existsSync(resultPath) ? JSON.parse(readFileSync(resultPath, "utf8")) : {};
+    h.check(`kiro preflight: ${suffix} exits with ${expectedExit}`, run.status === expectedExit);
+    h.check(`kiro preflight: ${suffix} fails before dispatch`,
+      result.status === expectedStatus && result.errorCode === "kiro_preflight_failed");
+    h.check(`kiro preflight: ${suffix} records structured probes`,
+      result.preflight?.version && Object.prototype.hasOwnProperty.call(result.preflight, "help"));
+    if (suffix === "version-hang-tree") {
+      const grandPid = existsSync(versionGrandPidFile) ? Number(readFileSync(versionGrandPidFile, "utf8")) : null;
+      h.check("kiro preflight: version timeout kills probe grandchild", grandPid !== null && await h.until(() => !h.alive(grandPid), 10_000));
+    }
+  }
+
+  const workDir = h.committedRepo("work-kiro-preflight-missing");
+  const outDir = join(h.scratch, "out-kiro-preflight-missing");
+  const missing = spawnSync(process.execPath, [
+    h.relayPath("kiro"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--kiro-bin", join(h.scratch, "missing-kiro.exe"),
+  ], { env: { ...h.baseEnv, PATH: h.gitOnlyPath }, encoding: "utf8", timeout: 30_000 });
+  const resultPath = join(outDir, "result.json");
+  const result = existsSync(resultPath) ? JSON.parse(readFileSync(resultPath, "utf8")) : {};
+  h.check("kiro unavailable: missing binary exits 127", missing.status === 127);
+  h.check("kiro unavailable: result is distinguishable", result.status === "kiro_unavailable" && result.errorCode === "kiro_unavailable");
+}

--- a/test/relay/kiro-timeout.mjs
+++ b/test/relay/kiro-timeout.mjs
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export async function runKiroTimeout(h) {
+  const workDir = h.committedRepo("work-kiro-timeout");
+  const outDir = join(h.scratch, "out-kiro-timeout");
+  const pidFile = join(workDir, "smoke.pid");
+  const grandPidFile = join(workDir, "smoke-grand.pid");
+  const child = h.runRelay("kiro", workDir, outDir, ["--timeout", "1s"], {
+    SMOKE_PID_FILE: pidFile,
+    SMOKE_GRAND_PID_FILE: grandPidFile,
+    SMOKE_MODE: "kiro-timeout",
+  });
+  h.check("kiro timeout: fake implementer came up", await h.until(() => existsSync(pidFile), 10_000));
+  const implementerPid = existsSync(pidFile) ? Number(readFileSync(pidFile, "utf8")) : null;
+  const grandPid = existsSync(grandPidFile) ? Number(readFileSync(grandPidFile, "utf8")) : null;
+  const exited = await new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), 30_000);
+    child.on("close", () => { clearTimeout(timer); resolve(true); });
+  });
+  h.check("kiro timeout: relay exits within bounded deadline", exited);
+  const resultPath = join(outDir, "result.json");
+  h.check("kiro timeout: result exists", existsSync(resultPath));
+  if (existsSync(resultPath)) {
+    const result = JSON.parse(readFileSync(resultPath, "utf8"));
+    h.check(`kiro timeout: status is timeout (got ${result.status})`, result.status === "timeout");
+    h.check("kiro timeout: exit code is non-zero", result.exitCode !== 0);
+  }
+  h.check("kiro timeout: implementer is dead", implementerPid !== null && await h.until(() => !h.alive(implementerPid), 10_000));
+  h.check("kiro timeout: grandchild is dead", grandPid !== null && await h.until(() => !h.alive(grandPid), 10_000));
+}

--- a/test/relay/kiro.mjs
+++ b/test/relay/kiro.mjs
@@ -1,0 +1,70 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+export async function runKiro(h) {
+  const workDir = h.committedRepo("work-success-kiro");
+  const outDir = join(h.scratch, "out-success-kiro");
+  const argsFile = join(workDir, "smoke-args.json");
+  const run = spawnSync(process.execPath, [
+    h.relayPath("kiro"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir,
+    "--agent", "default", "--model", "fake-model", "--trust-tools", "fs_read,fs_write,code",
+    "--resume-id", "11111111-1111-4111-8111-111111111111",
+  ], { env: { ...h.baseEnv, SMOKE_MODE: "kiro-success", SMOKE_ARGS_FILE: argsFile }, encoding: "utf8" });
+  const rawArgs = existsSync(argsFile) ? readFileSync(argsFile, "utf8") : "";
+  const args = rawArgs.trimStart().startsWith("[") ? JSON.parse(rawArgs) : rawArgs.split(/\r?\n/).filter(Boolean);
+  const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+  h.check("kiro success: relay exits zero", run.status === 0);
+  h.check("kiro success: documented argv is exact", JSON.stringify(args) === JSON.stringify([
+    "chat", "--no-interactive", "--wrap", "never", "--agent", "default", "--model", "fake-model",
+    "--trust-tools=fs_read,fs_write,code", "--resume-id", "11111111-1111-4111-8111-111111111111",
+    "smoke brief: run until killed.",
+  ]));
+  h.check("kiro success: upstream result and session report are captured",
+    value.schema === "delegate-relay.result.v1" && value.status === "completed" &&
+    value.finalMessage.startsWith("fake kiro completed") &&
+    value.sessionId === "11111111-1111-4111-8111-111111111111" &&
+    value.trustTools.join(",") === "fs_read,fs_write,code" &&
+    value.preflight?.ok === true);
+
+  const laneHome = join(h.scratch, "kiro-lane-home");
+  mkdirSync(join(laneHome, ".config", "delegate-skills"), { recursive: true });
+  writeFileSync(join(laneHome, ".config", "delegate-skills", "config.json"), JSON.stringify({
+    version: "delegate-fleet.v1",
+    lanes: { feature: { implementer: "kiro", model: "lane-model" } },
+  }));
+  const laneWork = h.committedRepo("work-success-kiro-lane");
+  const laneOut = join(h.scratch, "out-success-kiro-lane");
+  const laneRun = spawnSync(process.execPath, [
+    h.relayPath("kiro"), "--brief", h.briefPath, "--cd", laneWork, "--out-dir", laneOut,
+    "--lane", "feature", "--resume-id", "11111111-1111-4111-8111-111111111111",
+  ], {
+    env: { ...h.baseEnv, HOME: laneHome, USERPROFILE: laneHome, SMOKE_MODE: "kiro-success" },
+    encoding: "utf8",
+  });
+  const laneValue = existsSync(join(laneOut, "result.json")) ? h.result(laneOut) : {};
+  h.check("kiro lane: applies model and records provenance",
+    laneRun.status === 0 && laneValue.lane === "feature" && laneValue.laneSource === "global" && laneValue.model === "lane-model");
+
+  const gitStatusWork = h.committedRepo("work-kiro-git-status-unavailable");
+  writeFileSync(join(gitStatusWork, ".git", "index"), "CORRUPT");
+  const gitStatusOut = join(h.scratch, "out-kiro-git-status-unavailable");
+  const gitStatusRun = spawnSync(process.execPath, [
+    h.relayPath("kiro"), "--brief", h.briefPath, "--cd", gitStatusWork, "--out-dir", gitStatusOut,
+    "--resume-id", "11111111-1111-4111-8111-111111111111",
+  ], { env: { ...h.baseEnv, SMOKE_MODE: "kiro-success" }, encoding: "utf8" });
+  const gitStatusValue = existsSync(join(gitStatusOut, "result.json")) ? h.result(gitStatusOut) : {};
+  h.check("kiro git status unavailable fails closed",
+    gitStatusRun.status === 1 && gitStatusValue.status === "failed" && gitStatusValue.errorCode === "git_status_unavailable");
+
+  const splitWork = h.committedRepo("work-kiro-stderr-split");
+  const splitOut = join(h.scratch, "out-kiro-stderr-split");
+  const splitRun = spawnSync(process.execPath, [
+    h.relayPath("kiro"), "--brief", h.briefPath, "--cd", splitWork, "--out-dir", splitOut,
+    "--resume-id", "11111111-1111-4111-8111-111111111111",
+  ], { env: { ...h.baseEnv, KIRO_FAKE_MODE: "split", KIRO_API_KEY: "api-secret-value" }, encoding: "utf8" });
+  const stderrText = existsSync(join(splitOut, "stderr.txt")) ? readFileSync(join(splitOut, "stderr.txt"), "utf8") : "";
+  const splitValue = existsSync(join(splitOut, "result.json")) ? h.result(splitOut) : {};
+  h.check("kiro stderr split secret is redacted across chunks",
+    splitRun.status === 0 && !stderrText.includes("api-secret-value") && stderrText.includes("[REDACTED]") && !JSON.stringify(splitValue).includes("api-secret-value"));
+}

--- a/test/relay/pi.mjs
+++ b/test/relay/pi.mjs
@@ -136,9 +136,9 @@ export async function runPi(h) {
       h.relayPath("pi"),
       "--brief", h.briefPath,
       "--cd", workDir,
-      "--out-dir", preflightOutDir,
-      "--timeout", "1s",
-    ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
+"--out-dir", preflightOutDir,
+"--timeout", mode.includes("fail") ? "30s" : "1s",
+    ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 60000 });
     const preflightResult = existsSync(join(preflightOutDir, "result.json"))
       ? h.result(preflightOutDir)
       : {};

--- a/test/relay/preflight.mjs
+++ b/test/relay/preflight.mjs
@@ -3,44 +3,73 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { join } from "node:path";
 
 export async function runPreflight(h) {
-for (const skill of ["codex", "opencode", "grok", "kimi"]) {
-  const workDir = h.freshRepo(`work-preflight-${skill}`);
-  for (const [suffix, expectedStatus, expectedExit] of [
+ for (const skill of ["codex", "opencode", "grok", "kimi", "kiro"]) {
+   const sharedWorkDir = skill === "kiro" ? null : h.freshRepo(`work-preflight-${skill}`);
+   for (const [suffix, expectedStatus, expectedExit] of [
     ["version-hang", "timeout", 124],
-    ["version-fail", "failed", 7],
-    ["version-fail-silent", "failed", 7],
-  ]) {
-    const outDir = join(h.scratch, `out-${skill}-${suffix}`);
-    const preflight = spawnSync(process.execPath, [
-      h.relayPath(skill),
-      "--brief", h.briefPath,
-      "--cd", workDir,
-      "--out-dir", outDir,
-      "--timeout", "1s",
-      ...h.EXTRA_ARGS[skill],
-    ], { env: { ...h.baseEnv, SMOKE_MODE: `${skill}-${suffix}` }, encoding: "utf8", timeout: 15_000 });
-    const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
-    h.check(`${skill} preflight: ${skill}-${suffix} is explicit and prevents dispatch`,
-      preflight.status === expectedExit &&
-      value.status === expectedStatus &&
-      Array.isArray(value.stderrTail) &&
-      value.error?.includes("version preflight") &&
-      value.error?.includes("was not dispatched"));
+     ["version-fail", "failed", skill === "kiro" ? 1 : 7],
+     ["version-fail-silent", "failed", skill === "kiro" ? 1 : 7],
+   ]) {
+      const workDir = skill === "kiro" ? h.committedRepo(`work-preflight-${skill}-${suffix}`) : sharedWorkDir;
+      const outDir = join(h.scratch, `out-${skill}-${suffix}`);
+      const versionPidFile = skill === "kiro"
+        ? join(workDir, "smoke-version.pid")
+        : join(h.scratch, `version-pid-${skill}-${suffix}`);
+      const preflight = spawnSync(process.execPath, [
+        h.relayPath(skill),
+        "--brief", h.briefPath,
+        "--cd", workDir,
+        "--out-dir", outDir,
+        "--timeout", suffix === "version-hang" ? "1s" : "30s",
+        ...h.EXTRA_ARGS[skill],
+      ], {
+        env: {
+          ...h.baseEnv,
+          SMOKE_MODE: `${skill}-${suffix}`,
+          SMOKE_VERSION_PID_FILE: versionPidFile,
+        },
+        encoding: "utf8",
+        timeout: 60_000,
+      });
+      const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+      const versionPid = existsSync(versionPidFile) ? Number(readFileSync(versionPidFile, "utf8")) : null;
+      h.check(`${skill} preflight: ${skill}-${suffix} is explicit and prevents dispatch`,
+       preflight.status === expectedExit &&
+       value.status === expectedStatus &&
+        (Array.isArray(value.stderrTail) || typeof value.stderrTail === "string" || (skill === "kiro" && value.stderrTail === undefined)) &&
+        (value.error?.includes("version preflight") || (skill === "kiro" && value.error?.includes("Kiro CLI preflight"))) &&
+       value.error?.includes("was not dispatched"));
+      h.check(`${skill} preflight: ${skill}-${suffix} version descendants are dead`,
+        versionPid !== null && Number.isInteger(versionPid) && versionPid > 0 && await h.until(() => !h.alive(versionPid), 20_000));
   }
   // A missing binary must stay distinguishable from a broken one, so the classification
   // added above cannot quietly turn "not installed" into a generic failure.
-  const missingOutDir = join(h.scratch, `out-unavailable-${skill}`);
-  const missing = spawnSync(process.execPath, [
+   const missingWorkDir = skill === "kiro" ? h.committedRepo(`work-preflight-unavailable-${skill}`) : sharedWorkDir;
+    const missingOutDir = join(h.scratch, `out-unavailable-${skill}`);
+    const missingVersionPidFile = join(h.scratch, `version-pid-unavailable-${skill}`);
+   const missingArgs = skill === "kiro" ? ["--kiro-bin", join(h.scratch, "missing-kiro.exe")] : [];
+   const missing = spawnSync(process.execPath, [
     h.relayPath(skill),
     "--brief", h.briefPath,
-    "--cd", workDir,
+     "--cd", missingWorkDir,
     "--out-dir", missingOutDir,
-    ...h.EXTRA_ARGS[skill],
-  ], { env: { ...process.env, PATH: "" }, encoding: "utf8", timeout: 15_000 });
-  h.check(`${skill} unavailable: missing binary still reports ${skill}_unavailable`,
-    missing.status === 127 &&
-    existsSync(join(missingOutDir, "result.json")) &&
-    h.result(missingOutDir).status === `${skill}_unavailable`);
+     ...h.EXTRA_ARGS[skill],
+     ...missingArgs,
+    ], {
+      env: { ...h.baseEnv, PATH: h.gitOnlyPath, SMOKE_VERSION_PID_FILE: missingVersionPidFile },
+      encoding: "utf8",
+      timeout: 60_000,
+    });
+   const windowsShellFailure = process.platform === "win32" && ["codex", "opencode", "grok"].includes(skill);
+   const missingStatus = windowsShellFailure ? "failed" : `${skill}_unavailable`;
+   const missingExit = windowsShellFailure ? 1 : 127;
+    h.check(`${skill} unavailable: missing binary classification is explicit`,
+      missing.status === missingExit &&
+      existsSync(join(missingOutDir, "result.json")) &&
+      h.result(missingOutDir).status === missingStatus);
+    const missingVersionPid = existsSync(missingVersionPidFile) ? Number(readFileSync(missingVersionPidFile, "utf8")) : null;
+    h.check(`${skill} unavailable: no version descendants leaked`,
+      missingVersionPid === null || (Number.isInteger(missingVersionPid) && await h.until(() => !h.alive(missingVersionPid), 20_000)));
 }
 
 if (!h.WIN) {

--- a/test/relay/qoder.mjs
+++ b/test/relay/qoder.mjs
@@ -123,9 +123,9 @@ export async function runQoder(h) {
       h.relayPath("qoder"),
       "--brief", h.briefPath,
       "--cd", workDir,
-      "--out-dir", preflightOutDir,
-      "--timeout", "1s",
-    ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
+"--out-dir", preflightOutDir,
+"--timeout", mode.includes("fail") ? "30s" : "1s",
+    ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 60000 });
     const preflightResult = existsSync(join(preflightOutDir, "result.json"))
       ? h.result(preflightOutDir)
       : {};

--- a/test/relay/timeout-tree.mjs
+++ b/test/relay/timeout-tree.mjs
@@ -14,12 +14,15 @@ const TIMEOUT_CASES = [
   { skill: "cursor", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "vibe", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "agy", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "kiro", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
 ];
 async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag) {
   const outDir = join(h.scratch, `out-${tag}-${skill}`);
-  const pidFile = join(h.scratch, `pid-${tag}-${skill}`);
-  const grandPidFile = join(h.scratch, `grandpid-${tag}-${skill}`);
-  const workDir = h.freshRepo(`work-${tag}-${skill}`);
+  const workDir = skill === "kiro" ? h.committedRepo(`work-${tag}-${skill}`) : h.freshRepo(`work-${tag}-${skill}`);
+  // Kiro intentionally sanitizes SMOKE_* environment variables; its native fake
+  // therefore uses these fallback files inside the committed throwaway worktree.
+  const pidFile = skill === "kiro" ? join(workDir, "smoke.pid") : join(h.scratch, `pid-${tag}-${skill}`);
+  const grandPidFile = skill === "kiro" ? join(workDir, "smoke-grand.pid") : join(h.scratch, `grandpid-${tag}-${skill}`);
   const child = h.runRelay(skill, workDir, outDir, [...flags, ...h.EXTRA_ARGS[skill]], { SMOKE_PID_FILE: pidFile, SMOKE_GRAND_PID_FILE: grandPidFile, SMOKE_MODE: mode, ...extraEnv });
   let stderr = "";
   child.stderr.on("data", (d) => { stderr += d; });

--- a/test/relay/vibe.mjs
+++ b/test/relay/vibe.mjs
@@ -72,9 +72,9 @@ for (const [mode, expectedStatus, expectedExit] of [
     h.relayPath("vibe"),
     "--brief", h.briefPath,
     "--cd", workDir,
-    "--out-dir", outDir,
-    "--timeout", "1s",
-  ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
+"--out-dir", outDir,
+"--timeout", mode.includes("fail") ? "30s" : "1s",
+  ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 60000 });
   const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
   h.check(`vibe preflight: ${mode} is explicit and prevents dispatch`,
     preflight.status === expectedExit &&


### PR DESCRIPTION
## Summary

Adds `kiro-delegate`, an implementer skill that dispatches one bounded brief
to the Kiro CLI (`kiro-cli chat`) as a headless implementer, then lets the
orchestrator review the diff and land it. It follows the four-reference
contract and the shared `delegate-relay.result.v1` result shape.

## What's in this PR

- **New skill** `skills/kiro-delegate/`: `SKILL.md` + exactly four references
  (`writing-the-brief`, `dispatch-and-poll`, `review-and-land`,
  `multi-task-queues`) + one `scripts/relay.mjs` (Node built-ins only, never
  commits).
- **Relay behaviour**: `delegate-relay.result.v1`; `--lane` via
  delegate-setup; sanitized child env + known-secret redaction; fail-closed
  Git boundary (worktree / HEAD / git-status); async PID-aware version/help
  preflight with process-tree kill; timeout/abort grace lifecycle;
  `preflight` metadata on every result; Windows `SIGBREAK` handling.
- **Kiro smoke coverage**: success argv + result contract, lane provenance,
  preflight matrix (hang / hang-tree / fail / fail-silent / help-missing /
  missing binary), probe descendant cleanup, dispatch timeout tree, and a
  Windows-only real-console `CTRL+C` abort harness (C# `GenerateConsoleCtrlEvent`).
- **Registration**: `skills.sh.json`, README table + verification status,
  AGENTS.md vocabulary, delegate-setup implementer registry.

## Shared-relay changes (included deliberately)

The full 11-relay smoke suite now asserts preflight descendant death and the
Windows "whole tree felled" guarantee, so the sibling relays carry small fixes
in this PR:

- `killChild` win32: removed the `if (signal !== "SIGTERM") return;` guard so
  the SIGKILL escalation re-runs `taskkill /t /f`
  (agy/claude/pi/qoder/vibe + the async-probe relays).
- codex/grok/kimi/opencode: version preflight rewritten to a PID-aware async
  spawn that kills the whole `.cmd` tree on timeout (previously the node child
  was orphaned) and classifies a missing binary without parsing localized
  stderr.

These keep `node test/relay-parity.mjs` and the preflight descendant checks
green.

## Verification (what I ran)

- `node test/relay-smoke.mjs` -> **all green** (11 relays: timeout/abort
  matrix, preflight, atomic, delegate-setup, kiro success / lane /
  git-status / redaction, kiro-preflight, kiro-timeout, kiro-console-abort).
- `node test/relay-parity.mjs` -> all checks passed.
- `npx skills add . --list` -> validates.
- `git diff --check` -> clean.
- Authenticated Windows smoke, Kiro CLI **2.16.2**, model
  `qwen3-coder-next` (0.05 credit), minimal
  `--trust-tools=fs_read,fs_write,execute_bash,grep,glob,code`, disposable git
  fixture: `status: completed`, only the requested file created, HEAD
  unchanged, no secrets in artifacts, no residual processes. Two runs: a
  write-task smoke and a simple `notes.txt` task.

## Notes for maintainers

- No open `implementer` claim existed at the time of this PR (per
  CONTRIBUTING).
- Kiro CLI 2.16.2 must pass capability preflight before dispatch; 3.x is not
  assumed compatible until it does.
- Not yet verified (documented in README / references): authenticated Kiro
  runs on non-Windows platforms and other CLI versions; real interactive
  console `CTRL+C` outside the C# harness.

## Checklist (CONTRIBUTING new-skill)

- [x] `SKILL.md` description + `compatibility`
- [x] exactly four references
- [x] one `scripts/relay.mjs`, Node built-ins only, never commits
- [x] `delegate-relay.result.v1`: status, exitCode, signal, final report,
      touchedFiles, session id
- [x] usage error exits 2 without a result; missing binary exits 127 with one
- [x] registered in `test/harness/constants.mjs` (enters timeout/abort matrix)
- [x] README table row + AGENTS.md vocabulary row
- [x] `skills.sh.json` entry
- [x] README verification status line (authenticated Windows run recorded)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for delegating implementation tasks to Kiro CLI.
  * Added configurable Kiro model and timeout options.
  * Added resume, multi-task queue, review, and result-handling guidance.
  * Added structured relay status reporting, safety checks, timeout handling, and credential redaction.

* **Bug Fixes**
  * Improved Windows process termination across delegation workflows.
  * Improved version checks, failure reporting, and cleanup for unavailable or stalled tools.

* **Tests**
  * Expanded smoke, timeout, preflight, abort, and Windows coverage for eleven delegation integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->