### PR TITLE
feat: add warp-delegate (Warp Agent CLI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,12 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Thirteen implementer skills ship today: `claude-delegate` (Claude Code),
+and land the result. Fourteen implementer skills ship today: `claude-delegate` (Claude Code),
 `cline-delegate` (Cline CLI), `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode),
 `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code),
 `qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI),
-`pi-delegate` (Pi CLI), `aider-delegate` (Aider), and `copilot-delegate` (GitHub Copilot CLI); siblings like `gemini-delegate` can be added
+`pi-delegate` (Pi CLI), `aider-delegate` (Aider), `copilot-delegate` (GitHub Copilot CLI), and
+`warp-delegate` (Warp Agent CLI); siblings like `gemini-delegate` can be added
 later without renaming the repo. One **utility** skill
 ships alongside them: `delegate-setup` (configure fleet lanes — setup only, never dispatches).
 
@@ -19,7 +20,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Aider, Copilot) | "worker", "sub-agent", "executor" |
+| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Aider, Copilot, Warp) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -37,6 +38,7 @@ jargon. Use these terms; don't invent synonyms.
 | `session`, `--continue`, `--resume`, `permission mode` (`acceptEdits`/`plan`/`bypassPermissions`), `sandbox`, `subagents`, `agent teams`, `background sessions` | Claude Code's own terms — use verbatim when discussing Claude | never use `subagents` as a generic synonym for implementer |
 | `session`, `--json`, `-v` (verbose), `--auto-approve`, `--cwd`, `--model`, `--provider`, `--id` (unsupported by the JSON relay), `--plan`, `--data-dir` / `CLINE_SANDBOX` (sandbox), `-t`/`--timeout` (CLI's own flag) | Cline's own terms — use verbatim when discussing `cline`. The relay's `--timeout` watchdog is a different flag with the same spelling | don't invent a Cline permission-mode enum |
 | `session`, `-c`, `--resume`, `permission mode` (`default`/`accept_edits`/`auto`/`bypass_permissions`/`dont_ask`/`plan`), `print mode`, `stream-json`, `model`, `context window` | Qoder CLI's own terms — use verbatim when discussing Qoder | don't paraphrase them |
+| `agent run`, `conversation` / `--conversation`, `run_id`, `run_url`, `--cwd`, `--output-format ndjson`, `--profile`, `--skill`, `--no-snapshot`, `run-cloud` | Warp Agent CLI's own terms — use verbatim when discussing `oz` | never call `oz` "the warp CLI" in a launch context — `warp` is the interactive TUI and cannot be relayed; don't invent a Warp sandbox or permission-mode enum (`oz agent run` has neither) |
 | `--prompt`, `--output` (`streaming`/`json`/`text`), `--agent` (`plan`/`accept-edits`/`auto-approve`), `--max-turns`, `--max-price`, `--max-tokens`, `--trust`, `--resume`, `--continue`, `--enabled-tools`, `--disabled-tools` | Mistral Vibe's own terms — use verbatim when discussing `vibe` | don't invent a Vibe sandbox enum; `--trust` is not a permission mode |
 | `session`, `--continue`, `--session`, `print mode`, `--mode json`, `tools`, `context files`, `project trust` | Pi's own terms — use verbatim when discussing `pi` | don't paraphrase them |
 | `--message-file`, `--yes-always`, `--suggest-shell-commands`, `--auto-commits`/`--dirty-commits`, `--dry-run`, `--edit-format`, `--architect`, `--file`/`--read`, `chat history` | Aider's own terms — use verbatim when discussing `aider` | Aider has no sandbox, no permission modes, and no session ids; don't imply any. `--file`/`--read` scope the chat context — never call them a boundary |
@@ -49,7 +51,7 @@ version a run was made against is what makes the claim checkable; and claims tha
 ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
 `cline` / `codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi` /
-`aider` / `copilot`) and the skill's `relay.mjs`.
+`aider` / `copilot` / `oz`) and the skill's `relay.mjs`.
 
 ## Conventions
 
@@ -89,10 +91,13 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   child process cwd; the other launches quote spaceable args, and all value flags are token-validated.
   The `claude` and `cursor-agent` launches serialize a pre-joined
   command string through the shell on win32 for the same shim reason; `agy`, `kimi`, current
-  `qodercli`, `vibe`, and `aider` installs use native binaries (pip puts a real `aider.exe` in
-  Scripts, so that launch needs no `shell:true`). Each changed launch still needs its own Windows
-  smoke before claiming support. Upstream Vibe works on Windows but officially supports and targets
-  UNIX; this repository's native Windows Cline stdin launch and Vibe relay launch are unverified.
+  `qodercli`, `vibe`, `aider`, and `oz` installs use native binaries (pip puts a real `aider.exe` in
+  Scripts, so that launch needs no `shell:true`). The `oz` launch must never gain a shell on any
+  platform: `oz agent run` takes the brief as its `--prompt` argv value (its `-f/--file` config path
+  does not satisfy the required prompt group), and a shell would reinterpret that text. Each changed
+  launch still needs its own Windows smoke before claiming support. Upstream Vibe works on Windows
+  but officially supports and targets UNIX; this repository's native Windows Cline stdin launch and
+  Vibe relay launch are unverified.
 - Keep the README's "Verification status" honest — claim only what's been run.
 
 ## Local Claude Code config

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`qoder-delegate`](skills/qoder-delegate/SKILL.md) | [Qoder](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` permission mode; bypass opt-in | `--permission-mode plan` | `--resume-last`, `--resume <id>` |
 | [`vibe-delegate`](skills/vibe-delegate/SKILL.md) | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits`; `--full-access` opt-in | `--plan-only` (`plan` agent) | `--resume-last`, `--session <id>` |
 | [`copilot-delegate`](skills/copilot-delegate/SKILL.md) | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli) (`copilot`) | `--allow-all-tools` opt-in; headless auto-deny otherwise | `--read-only` (`--mode plan`) | `--resume-last`, `--session <id>` |
+| [`warp-delegate`](skills/warp-delegate/SKILL.md) | [Warp Agent CLI](https://docs.warp.dev/cli/) (`oz`) | full local tools — no sandbox, no permission modes [^none] | — [^none] | `--conversation <id>` |
 
 [^none]: No CLI-enforced read-only mode. `touchedFiles` and the diff, not a flag, are the guarantee.
 
@@ -238,6 +239,20 @@ Per skill — platform, CLI version, and what the run exercised:
   `--session`, and `--resume-last` runs are contributor-reported.
 - `qoder-delegate` — macOS, `qodercli` 1.0.47, by the contributor: Lite edit run, `accept_edits`,
   explicit model and 32768-token context window, no commit.
+- `warp-delegate` — macOS, `oz` 0.2026.05.27.15.44.stable_01: **live edit run verified**. A relay
+  dispatch against a throwaway git repository had Warp add a function plus four assertions across
+  two files; both project gates were re-run independently by the orchestrator, the diff matched the
+  brief, and `HEAD` was untouched. Verified end to end: version preflight, launch, ndjson parsing
+  (`run_started` → `runId`/`runUrl`, `conversation_started` → `conversationId`), report extraction
+  from `{"type":"agent","text":…}` events with `agent_reasoning` excluded, `touchedFiles`, and
+  `status: "completed"` / exit 0. A second dispatch with `--conversation` verified resume: a delta
+  brief saying only "the function you just added" — never naming it — produced exactly the right
+  edit, with `resumed: true` and the conversation id preserved. Also observed on a prior run:
+  `touchedFiles: []` on a clean tree and exit 1 → `status: "failed"`. Two caveats are documented in the skill rather than fixed,
+  because they are Warp's behaviour and not the relay's: `finalMessage` is the agent's full
+  narration rather than a distinct final-message event, and `--cwd` governed shell commands while
+  the agent's file tool resolved bare relative paths against `$HOME`. `--no-snapshot`, `--profile`,
+  `--skill`, and `--mcp` are contract-tested only.
 - `codex-delegate`, `opencode-delegate`, `vibe-delegate` — contract-tested only: argument validation,
   bounded version preflight, missing binary, result parsing, and whole-process-tree timeout/abort
   cleanup. No end-to-end run is recorded here.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`copilot-delegate`](skills/copilot-delegate/SKILL.md) | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli) (`copilot`) | `--allow-all-tools` opt-in; headless auto-deny otherwise | `--read-only` (`--mode plan`) | `--resume-last`, `--session <id>` |
 | [`warp-delegate`](skills/warp-delegate/SKILL.md) | [Warp Agent CLI](https://docs.warp.dev/cli/) (`oz`) | full local tools — no sandbox, no permission modes [^none] | — [^none] | `--conversation <id>` |
 
-[^none]: No CLI-enforced read-only mode. `touchedFiles` and the diff, not a flag, are the guarantee.
+[^none]: No CLI-enforced read-only mode. `touchedFiles` and the diff are what you review against, not
+a guarantee: they are post-run `git status` in the workspace, so they cannot show ignored files,
+reverted edits, or writes outside the repository.
 
 [^aider]: Aider is the one implementer here that commits by default. Its `--auto-commits` and
 `--dirty-commits` both default to `True`, the second of which commits your pre-existing uncommitted

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -17,7 +17,8 @@
         "cursor-delegate",
         "pi-delegate",
         "aider-delegate",
-        "copilot-delegate"
+        "copilot-delegate",
+        "warp-delegate"
       ]
     },
     {

--- a/skills/delegate-setup/references/schema.md
+++ b/skills/delegate-setup/references/schema.md
@@ -59,6 +59,7 @@ later-edited project config fails closed until it is reviewed and written again 
 | `pi` | pi-delegate | `pi` | provider, model, timeout, readOnly |
 | `aider` | aider-delegate | `aider` | model, timeout, readOnly |
 | `copilot` | copilot-delegate | `copilot` | model, effort, timeout, readOnly |
+| `warp` | warp-delegate | `oz` | model, timeout |
 
 OpenCode uses `variant` for reasoning intensity, not `effort`. Do not write `effort` on an `opencode` lane.
 OpenCode lanes **require** `model` in `provider/model` form, with a non-empty provider before the first

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -279,6 +279,29 @@ export const IMPLEMENTERS = Object.freeze([
     supports: ["model", "effort", "timeout", "readOnly"],
     winShell: true,
   },
+  {
+    key: "warp",
+    skill: "warp-delegate",
+    binary: "oz",
+    versionArgs: ["--version"],
+    // `--output-format text` prints one `type:id` line; the default `pretty` format
+    // spells the type out ("User ID: …") and so reads differently per principal. A
+    // headless host authenticated with WARP_API_KEY is a service account, not a
+    // user, so the probe must accept both or it reports CI as logged out.
+    authProbe: {
+      args: ["whoami", "--output-format", "text"],
+      successPattern: /^(?:user|service_account):\S/m,
+    },
+    // `oz model list` emits a JSON array of {id} objects, which none of the shared
+    // list formats parse; ids are read from the CLI directly instead of probed.
+    modelProbe: null,
+    // Conversations live server-side, so there is no local session directory to count.
+    usageProbe: null,
+    // `oz agent run` exposes no sandbox, permission-mode, or read-only flag, so
+    // those dials are deliberately absent — the relay refuses a lane that sets one.
+    supports: ["model", "timeout"],
+    winShell: false,
+  },
 ]);
 
 /** Prototype-free map so names like "toString" cannot pass as implementers. */

--- a/skills/warp-delegate/SKILL.md
+++ b/skills/warp-delegate/SKILL.md
@@ -124,7 +124,7 @@ Treat Warp's final message and gate claims as claims:
 - Round-trip migrations and grep for dangling references after removals or renames.
 
 Because there is no read-only mode to fall back on, the diff is the **only** record you get - and it
-records what git can see in the workspace afterwards, not everything the run did. Dispatch from a
+records what git can see in the workspace afterward, not everything the run did. Dispatch from a
 clean tree so the two are as close as they can be. See
 [references/review-and-land.md](references/review-and-land.md).
 

--- a/skills/warp-delegate/SKILL.md
+++ b/skills/warp-delegate/SKILL.md
@@ -123,8 +123,10 @@ Treat Warp's final message and gate claims as claims:
 - Run relevant guard skills if installed.
 - Round-trip migrations and grep for dangling references after removals or renames.
 
-Because there is no read-only mode to fall back on, the diff is the **only** record of what the run
-touched. See [references/review-and-land.md](references/review-and-land.md).
+Because there is no read-only mode to fall back on, the diff is the **only** record you get - and it
+records what git can see in the workspace afterwards, not everything the run did. Dispatch from a
+clean tree so the two are as close as they can be. See
+[references/review-and-land.md](references/review-and-land.md).
 
 ### 5. Land it
 
@@ -143,7 +145,11 @@ would imply an enforcement that does not exist. The controls you actually have a
    Treat this as *aim*, not a fence: on oz 0.2026.05.27 shell commands did run in the pinned
    workspace, but the agent's file tool resolved bare relative paths against `$HOME`. Name absolute
    paths in the brief - see [references/writing-the-brief.md](references/writing-the-brief.md).
-2. **Review the diff.** `touchedFiles` plus `git diff` is the record of what changed.
+2. **Review the diff.** `touchedFiles` is `git status --porcelain` taken after the run - post-run,
+   git-visible worktree state, not a log of what the agent did. It cannot show an ignored file, an
+   edit the run made and then reverted, or a write outside the repository (see item 1), and it
+   carries anything that was already dirty before dispatch. Dispatch from a clean tree so those are
+   the same set, and treat the diff as the best available record, not a complete one.
 3. **Snapshot egress.** `--no-snapshot` forwards Warp's flag so the end-of-run workspace snapshot is
    not uploaded. Without it, the upload is Warp's default.
 

--- a/skills/warp-delegate/SKILL.md
+++ b/skills/warp-delegate/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: warp-delegate
+description: >-
+  Delegate a coding task to the Warp Agent CLI (`oz`) as a background implementer, then review its
+  diff and land it yourself. Use this whenever the user wants to hand implementation work to Warp -
+  phrasings like "have Warp implement X", "delegate this to the Warp CLI", "run it through Warp", "use
+  oz to implement/fix/refactor" - or wants to run a queue of coding tasks through Warp while staying
+  the reviewer. DO NOT USE for tasks small enough to do inline, when the user wants the code written
+  directly without delegating, or for the interactive `warp` TUI (this skill drives the headless
+  `oz agent run`, not the terminal app).
+license: MIT
+compatibility: Requires the `oz` CLI (Warp Agent CLI) installed and authenticated (`oz login`, or `WARP_API_KEY` for a headless host; Warp AI features need an eligible Warp plan or your own provider key), Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.4.2
+---
+
+# Warp Delegate
+
+You are the **orchestrator**. Delegate a bounded coding task to a separate **implementer** - the
+Warp Agent CLI - then review what it produced and land it yourself. You write the brief and own the
+judgment; the implementer makes changes in its own conversation; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## The binary is `oz`, not `warp`
+
+Warp ships two different programs, and only one of them can be delegated to:
+
+- **`oz`** - the Warp Agent CLI. Headless and scriptable; `oz agent run` executes an agent against a
+  local directory. **This is what the relay drives.**
+- **`warp`** - the interactive Warp TUI. It requires a terminal device, has no prompt or print flag
+  (its only options are `--resume`, `--auto-approve`, `--api-key`, and the provider-key commands),
+  and exits with `Device not configured` when stdin is a pipe. It cannot be relayed.
+
+If `oz` is missing but `warp` is installed, you have the TUI, not the CLI.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `oz` CLI is not installed or authenticated.
+- You need a sandboxed or read-only implementer. `oz agent run` has **no sandbox, no permission
+  mode, and no read-only run** - see [Autonomy and permissions](#autonomy-and-permissions).
+- The work must stay off Warp's servers. `oz agent run` uploads an end-of-run workspace snapshot
+  unless `--no-snapshot` is passed, and conversations live server-side.
+
+## Prerequisites (check once)
+
+1. Install the Warp Agent CLI - see <https://docs.warp.dev/cli/>.
+2. Authenticate: `oz login`, or set `WARP_API_KEY` for CI, a container, or any headless host.
+3. Confirm the account has AI quota. **A working login is not enough** - unlike the other CLIs in
+   this package. `oz whoami` can succeed while every dispatch fails with `In order to use Warp's AI
+   features, subscribe to a Warp plan, or bring your own inference.` Warp records this internally as
+   `QuotaLimit` / "lack of AI quota", so it is a credit condition on the account rather than a
+   CLI-specific entitlement: `oz` runs the same agent harness as the Warp app and draws on the same
+   account, plan, and credits. Check that `oz whoami` names the account holding the plan - if it
+   does not, `oz logout && oz login` fixes it. Otherwise confirm the plan's AI credits are not
+   spent, or store your own provider key -
+   `warp --set-provider-api-key <openai|anthropic|google|grok>`, or `/api-keys` inside the TUI.
+   Bring-your-own-key needs no paid Warp plan.
+4. Confirm `oz --version` succeeds and `oz whoami` prints your user.
+5. Work in, or point `--cd` at, the target git repository.
+
+On macOS the CLI is distributed as a signed Developer ID binary; a first run may be held by
+Gatekeeper until it is approved.
+
+## Choose the model (optional)
+
+Omit `--model` to use Warp's configured default. To pick another, choose an id from `oz model list`
+and pass it verbatim. The relay accepts letters, digits, and `. _ : / -` only, so a value cannot be
+mistaken for another `oz` flag.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Warp sees only the text you send plus what it can inspect in the workspace - no chat history or
+shared context. Include the goal, current state, what to change, what to leave untouched, the
+project's **actual** gates, and a report contract. Tell it not to commit. Keep one task per brief.
+The brief is delivered as the `--prompt` value on argv, so it is visible in the host process list -
+keep secrets out of it and reference workspace files instead. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled relay. It runs `oz agent run --output-format ndjson`, captures the event stream, and
+writes `result.json`. (`<skill-dir>` is the installed folder containing this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model:                          add --model <id from oz model list>
+# use an agent profile:                    add --profile <id>
+# label the run:                           add --name <label>
+# continue an existing conversation:       add --conversation <id> (delta brief only)
+# base the run on a Warp skill:            add --skill <name|repo:name|org/repo:name>
+# start MCP servers:                       add --mcp <path-or-inline-json>  (repeatable)
+# suppress the workspace snapshot upload:  add --no-snapshot
+# hard time limit (watchdog):              add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                         node .../relay.mjs --help
+```
+
+The relay pins the workspace with both the child process's cwd and Warp's own `--cwd`. It writes
+artifacts under the system temp dir by default and never commits. See
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until `oz` finishes. Run it with the orchestrator's background-command facility, or
+background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `oz` exits 127 and writes `status: "warp_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process
+exited and `result.json` exists. Warp's report is the `finalMessage` field in `result.json` (also
+printed on stdout between the report markers); the raw event stream is always in `events.jsonl`.
+
+### 4. Review - do not trust the self-report
+
+Treat Warp's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+Because there is no read-only mode to fall back on, the diff is the **only** record of what the run
+touched. See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates
+pass and the diff holds. If rework is needed, send a delta brief with `--conversation <id>` using the
+`conversationId` from `result.json`, then review again.
+
+## Autonomy and permissions
+
+`oz agent run` has **no sandbox, no permission mode, and no read-only mode**. A headless run reads,
+writes, edits, and executes commands with your own user permissions and never prompts. There is
+nothing in the CLI to restrict that surface, so this relay ships no `--read-only` flag - offering one
+would imply an enforcement that does not exist. The controls you actually have are:
+
+1. **Scope by directory.** `--cd` pins the workspace, and the relay passes it to Warp's own `--cwd`.
+   Treat this as *aim*, not a fence: on oz 0.2026.05.27 shell commands did run in the pinned
+   workspace, but the agent's file tool resolved bare relative paths against `$HOME`. Name absolute
+   paths in the brief - see [references/writing-the-brief.md](references/writing-the-brief.md).
+2. **Review the diff.** `touchedFiles` plus `git diff` is the record of what changed.
+3. **Snapshot egress.** `--no-snapshot` forwards Warp's flag so the end-of-run workspace snapshot is
+   not uploaded. Without it, the upload is Warp's default.
+
+`--auto-approve` belongs to the interactive `warp` TUI and has no bearing on `oz agent run`.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"),
+committing verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't
+absorb** (report Warp's design decisions, defensible-but-unasked turns, and non-blocking nitpicks)
+and **stop for scope changes** (if correct completion needs going beyond the brief, ask instead of
+expanding the mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, report contract,
+  real gates, argv delivery, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist, commit
+  boundary, and rework through Warp conversations.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues,
+  constraint carry-forward, progress tracking, and the final coherence pass.

--- a/skills/warp-delegate/references/dispatch-and-poll.md
+++ b/skills/warp-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,161 @@
+# Dispatch and poll
+
+The relay is the only Warp-specific machinery in this skill. It launches `oz agent run`, captures
+the event stream, and writes one result file the orchestrator can read.
+
+## What the relay runs
+
+```text
+oz agent run --output-format ndjson --cwd <cd> [--model …] [--profile …] [--name …]
+             [--conversation …] [--skill …] [--mcp … …] [--no-snapshot] --prompt <brief>
+```
+
+`--output-format ndjson` makes Warp emit one JSON object per line, so a long run reports progress
+instead of buffering to the end. The workspace is pinned twice: the child process's cwd and Warp's
+own `--cwd`.
+
+## Flags
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Path to the brief. Omit to read it from stdin. |
+| `--cd <dir>` | Working root (default: current directory). Also passed as Warp's `--cwd`. |
+| `--lane <name>` | Resolve dials from a `delegate-setup` fleet lane. Explicit flags win. |
+| `--model <id>` | Warp model id from `oz model list`. Letters, digits, and `. _ : / -` only. |
+| `--profile <id>` | Warp agent profile. |
+| `--name <label>` | Labels the run in Warp's own run list. |
+| `--conversation <id>` | Continue an existing Warp conversation. Send a delta brief only. |
+| `--skill <spec>` | Warp skill as the base prompt: `name`, `repo:name`, or `org/repo:name`. |
+| `--mcp <spec>` | MCP config path or inline JSON. Repeatable. |
+| `--no-snapshot` | Forward Warp's `--no-snapshot` so no end-of-run workspace snapshot is uploaded. |
+| `--timeout <dur>` | Relay watchdog, h/m/s (default `30m`). Warp has no timeout flag of its own. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh dir under the system temp dir). |
+
+Values for `--model`, `--profile`, and `--conversation` are token-validated. `--skill`, `--mcp`, and
+`--name` accept freer text but must not start with `-`, which `oz` would read as another flag.
+
+## Artifacts
+
+Written to `--out-dir`:
+
+- `brief.txt` — exactly what was sent.
+- `events.jsonl` — the raw ndjson stream, byte for byte. The fallback whenever a parsed field looks
+  wrong.
+- `final.txt` — the assembled report, when one was captured.
+- `stderr.txt` — everything Warp wrote to stderr.
+- `result.json` — the structured result, written atomically via a temp file and rename, so a polling
+  reader never sees a half-written file.
+
+## `result.json`
+
+Schema id `delegate-relay.result.v1`. Synthetic example:
+
+```json
+{
+  "schema": "delegate-relay.result.v1",
+  "tool": "oz",
+  "status": "completed",
+  "exitCode": 0,
+  "signal": null,
+  "ozVersion": "Oz v0.0000.00.00.00.00.stable_01",
+  "workdir": "/path/to/repo",
+  "model": null,
+  "profile": null,
+  "snapshotDisabled": false,
+  "resumed": false,
+  "runId": "00000000-0000-0000-0000-000000000000",
+  "runUrl": "https://oz.warp.dev/runs/00000000-0000-0000-0000-000000000000",
+  "conversationId": null,
+  "finalMessage": "Changed src/export/csv.ts …",
+  "touchedFiles": [" M src/export/csv.ts", "?? src/export/csv.test.ts"],
+  "startedAt": "2026-01-01T00:00:00.000Z",
+  "finishedAt": "2026-01-01T00:04:12.000Z"
+}
+```
+
+Field notes:
+
+- **`status`** — `completed`, `failed`, `timeout`, `aborted`, or `warp_unavailable`.
+- **`touchedFiles`** — `git status --porcelain` lines. `null` when git cannot report (not a
+  repository, git missing); `[]` when the tree is genuinely clean. `[]` and `null` mean different
+  things — do not collapse them.
+- **`runId` / `runUrl`** — from Warp's `run_started` system event. `runUrl` opens the run in Warp.
+- **`conversationId`** — the handle to pass back as `--conversation` for rework. Present only when
+  Warp emitted it on the stream.
+- **`finalMessage`** — Warp's own report. Assembled from the text-bearing events in the stream; see
+  the caveat below.
+- **`stderrTail`** — last 20 stderr lines, included on every non-clean outcome.
+
+### What `finalMessage` actually contains
+
+Confirmed against a live edit run on oz 0.2026.05.27. The stream carries:
+
+| Event | Meaning |
+| --- | --- |
+| `{"type":"system","event_type":"run_started","run_id":…,"run_url":…}` | Run registered. |
+| `{"type":"system","event_type":"conversation_started","conversation_id":…}` | The `--conversation` handle. Re-emitted on a resumed run carrying the *same* id, so `conversationId` stays stable across a rework chain. |
+| `{"type":"agent","text":…}` | Agent output. **This is what `finalMessage` is built from.** |
+| `{"type":"agent_reasoning","text":…}` | Private reasoning. Same shape, deliberately **excluded**. |
+| `{"type":"tool_call"\|"tool_result"\|"tool_error",…}` | Tool traffic. No `text` field. |
+
+Two consequences:
+
+- **`finalMessage` is the whole narration, not just the closing report.** Warp emits no distinct
+  final-message event, so every `agent` chunk is concatenated — including running commentary like
+  "Now let me run both gates." This is why the brief must specify a report contract: `FILES:` /
+  `GATES:` / `NOTES:` at the end gives you a stable anchor to read instead of parsing prose.
+- **`agent_reasoning` must stay excluded.** It carries a `text` field of exactly the same shape, so
+  matching on `text` alone splices the model's reasoning into the report.
+
+Past those two rules the extraction stays tolerant — it also accepts `agent_output`, `content`, and
+a nested `message.content` — so a renamed output event still reports rather than yielding an empty
+`finalMessage`. If one ever does come back empty on a successful run, `events.jsonl` holds the raw
+stream and `collectText` is the one place to correct.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Warp exited 0 and reported no stream error. |
+| `1` | Generic failure, or a stream-reported agent error even when `oz` exited 0. |
+| `2` | Usage error — bad flag, bad `--timeout`, missing or empty brief. **No result file is written.** |
+| `124` | The bounded `oz --version` preflight timed out; Warp was never dispatched. |
+| `127` | `oz` is not on PATH. A result file **is** written, with `status: "warp_unavailable"`. |
+| `128 + n` | The child died on signal *n*; `signal` records which. |
+
+## Polling
+
+The relay blocks until the run ends. Background it and poll for `result.json`:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo \
+  --out-dir /tmp/warp-run-1 &
+until [ -f /tmp/warp-run-1/result.json ]; do sleep 5; done
+```
+
+Completion means the process exited **and** `result.json` exists. Do not infer completion from
+stdout going quiet — a long tool call looks identical to a finished run.
+
+## Timeouts and aborts
+
+`oz` has no timeout flag, so the watchdog is the relay's. When `--timeout` expires the relay kills
+the whole process group (SIGTERM, then SIGKILL after 10s) and writes `status: "timeout"`.
+
+If the relay itself is killed, it still writes `status: "aborted"`, forwards the kill to `oz`, and
+re-snapshots `touchedFiles` after a 2-second grace window so files flushed during shutdown are
+recorded. On Windows the process tree is felled with `taskkill /t /f`; Windows delivers no catchable
+SIGTERM, so the aborted path cannot be driven there.
+
+**A timed-out or aborted run leaves a partially edited tree.** Inspect `git status` and `git diff`
+before re-dispatching, and consider `git stash` or a reset if the state is incoherent.
+
+## Failure recovery
+
+| Symptom | What it means | Do |
+| --- | --- | --- |
+| `warp_unavailable`, exit 127 | `oz` is not on PATH | Install the Warp Agent CLI; check `oz --version`. |
+| stderr `subscribe to a Warp plan, or bring your own inference` | Authenticated, but the account has no AI quota. Warp logs it as `QuotaLimit` / "lack of AI quota". `oz` shares the Warp app's account, plan, and credits, so this is a credit condition, not a CLI-only gate | Check `oz whoami` names the account holding the plan - if not, `oz logout && oz login`. Otherwise confirm its AI credits are not spent, or store your own provider key: `warp --set-provider-api-key <openai\|anthropic\|google\|grok>` (or `/api-keys` in the TUI). Bring-your-own-key needs no paid plan. Warp's log is at `~/Library/Logs/oz/warp.log` on macOS. |
+| `Device not configured` | The `warp` TUI was launched, not `oz` | Use `oz`; the TUI cannot be relayed. |
+| exit 2, no result file | Usage error | Read the relay's stderr line; fix the flag. |
+| `status: "timeout"` | The watchdog fired | Raise `--timeout`, or split the brief. |
+| Empty `finalMessage`, exit 0 | Text extraction missed the event shape | Read `events.jsonl`; see the caveat above. |

--- a/skills/warp-delegate/references/dispatch-and-poll.md
+++ b/skills/warp-delegate/references/dispatch-and-poll.md
@@ -147,7 +147,9 @@ recorded. On Windows the process tree is felled with `taskkill /t /f`; Windows d
 SIGTERM, so the aborted path cannot be driven there.
 
 **A timed-out or aborted run leaves a partially edited tree.** Inspect `git status` and `git diff`
-before re-dispatching, and consider `git stash` or a reset if the state is incoherent.
+before re-dispatching. If the state is incoherent, discard it against the recorded baseline rather
+than stashing — a bare `git stash` leaves behind every file the run created. See
+[review-and-land.md](review-and-land.md#rework-through-a-conversation).
 
 ## Failure recovery
 

--- a/skills/warp-delegate/references/multi-task-queues.md
+++ b/skills/warp-delegate/references/multi-task-queues.md
@@ -1,0 +1,80 @@
+# Multi-task queues
+
+A queue is a list of briefs run through Warp one at a time, each reviewed before the next is
+dispatched. It is the shape to reach for when the user hands you a backlog rather than a single
+task.
+
+## Run them sequentially
+
+Dispatch one brief, review it, land it, then dispatch the next. Parallel runs against the same
+working tree interleave edits into a diff nobody can review — and because `oz agent run` has no
+sandbox, there is nothing to keep two runs out of each other's files.
+
+If tasks are genuinely independent and you want them concurrent, give each its own checkout (a git
+worktree) and its own `--cd`. Otherwise, keep the queue serial.
+
+## Carry constraints forward
+
+Each brief is self-contained, so a constraint discovered in task 2 does not reach task 5 by itself.
+Keep a short running list and paste the relevant lines into every subsequent brief:
+
+- Conventions you had to correct in an earlier review ("use the existing `Result` type, not
+  exceptions").
+- Files that are off-limits for the whole queue.
+- Gates that turned out to be slow, flaky, or need a flag.
+- Decisions already made, so a later task does not relitigate them.
+
+A constraint that had to be corrected twice belongs in the repository's own skill directory
+(`.agents/skills/`, `.warp/skills/`) instead — then pass it with `--skill` and stop re-pasting it.
+
+## One out-dir per task
+
+Give every dispatch its own `--out-dir` so artifacts do not overwrite each other:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief briefs/03-stream-export.txt \
+  --cd /path/to/repo --out-dir /tmp/warp-queue/03 --name "queue-03-stream-export"
+```
+
+`--name` labels the run in Warp's own run list, which makes a queue far easier to follow later.
+Keeping the out-dirs numbered means `result.json`, `events.jsonl`, and `final.txt` for any task stay
+recoverable after the queue has moved on.
+
+## Track progress where the user can see it
+
+Maintain a visible checklist — the orchestrator's task list, or a scratch file — with one line per
+task and its state: pending, dispatched, under review, landed, or abandoned. Record the commit sha
+as each task lands, and the reason whenever one is abandoned.
+
+## When a task fails
+
+Do not roll straight into the next brief. Decide first:
+
+- **Rework** — the diff is close. Continue the conversation with `--conversation <id>` and a delta
+  brief.
+- **Re-scope** — the task was too big or the brief was wrong. Split it and requeue the parts.
+- **Abandon** — it depends on something that is not true yet. Record why and move on.
+
+A failed task that leaves a dirty tree must be cleaned up before the next dispatch. `git status`
+should be clean, or clean except for work you have deliberately kept.
+
+## Stop the queue when
+
+- Two consecutive tasks fail for the same underlying reason — the shared assumption is wrong, and
+  the remaining briefs probably inherit it.
+- A task reveals the plan itself is wrong. Re-plan with the user rather than working the list.
+- The gates start failing for reasons unrelated to the current task; something earlier in the queue
+  broke and the diff is no longer trustworthy.
+
+## Final coherence pass
+
+Ten individually correct diffs can still add up to an incoherent whole. When the queue is done,
+review the aggregate — `git diff <first-commit>~1..HEAD`:
+
+- Duplicated helpers that separate tasks each introduced.
+- Naming that drifted between early and late tasks.
+- Docs, types, or tests that an earlier task's assumption made stale.
+- Dead code left by a later task superseding an earlier one.
+
+Fix these yourself if small. If the cleanup is substantial, it is one more brief — dispatch it with
+the aggregate diff as the current state.

--- a/skills/warp-delegate/references/review-and-land.md
+++ b/skills/warp-delegate/references/review-and-land.md
@@ -80,13 +80,17 @@ and it destroys any uncommitted work of your own that predates the run. Dispatch
 commit your own changes, or `git stash push --include-untracked` them. A bare `git stash` leaves
 untracked files in place, and those resurface as `??` entries in `touchedFiles`, where the cleanup
 below would delete work the run never made. Confirm `git status --porcelain` prints nothing before
-dispatching, so that everything dirty afterwards is Warp's, then drop exactly what the run
+dispatching, so that everything dirty afterward is Warp's, then drop exactly what the run
 introduced, reading the paths off `touchedFiles`:
 
 ```bash
 git restore --staged --worktree -- <tracked paths>   # the ' M' / 'M ' entries
 git clean -f -- <untracked paths>                    # the '??' entries
 ```
+
+A `??` entry can name a whole directory rather than each file under it; passing that path removes
+the directory and its contents, since `-d` only governs the no-pathspec case. The exception is a
+nested git repository — if the run scaffolded one, `git clean -f` skips it and `-ff` is required.
 
 If dispatching from a clean tree is not an option, give Warp its own `git worktree` instead: then
 discarding is `git worktree remove --force`, and your work was never in reach. Either way, rewrite

--- a/skills/warp-delegate/references/review-and-land.md
+++ b/skills/warp-delegate/references/review-and-land.md
@@ -1,0 +1,84 @@
+# Review and land
+
+Warp edits the working tree. **You commit.** That boundary is the point of the skill: the
+implementer produces a diff, and a reviewer who did not write it decides whether it ships.
+
+## Why the review is not optional here
+
+Every delegate skill asks you to verify the implementer's claims. Warp raises the stakes: `oz agent
+run` has no sandbox, no permission mode, and no read-only run, so nothing constrained what the run
+could touch while it worked. The diff is not a courtesy record — it is the only record.
+
+## The checklist
+
+Work through these in order. Stop at the first one that fails and decide whether to rework or
+discard.
+
+1. **Read `result.json` first.** Check `status` and `exitCode` before anything else. A `timeout` or
+   `aborted` status means the tree may be mid-edit and incoherent.
+2. **Start from `touchedFiles`.** It is the porcelain list of what moved. `null` means git could not
+   report — inspect the tree by hand. `[]` on a run that claimed edits is a contradiction worth
+   chasing.
+3. **Re-run the gates yourself.** Do not accept "tests pass" from `finalMessage`. Run the project's
+   actual lint, typecheck, build, and test commands and read the output.
+4. **Read the whole diff against the brief.** `git diff` and `git diff --staged`. Ask of each hunk:
+   did the brief ask for this? Changes outside the brief's stated scope are the thing to catch.
+5. **Check what should NOT have changed.** Lockfiles, CI config, formatter config, unrelated
+   modules, and anything the brief listed under "leave untouched".
+6. **Grep for dangling references** after any removal or rename — imports, string keys, docs.
+7. **Round-trip migrations.** Apply and roll back before trusting a schema change.
+8. **Run guard skills** if the repository has them installed.
+9. **Confirm nothing was committed.** `git log -1` should still be your last commit. The relay never
+   commits; if a commit exists, the agent made it despite the brief — treat that as a finding.
+
+## Reading `finalMessage` correctly
+
+`finalMessage` is Warp's self-report: a claim, not evidence. Read it for two things only —
+
+- **Decisions it made that the brief did not specify.** These are the parts you most need to surface
+  to the user.
+- **What it says it could not do.** Usually accurate, and it tells you where to look first.
+
+Everything else in it — "all tests pass", "no other files changed" — is a hypothesis your gates and
+your diff read either confirm or refute. If `finalMessage` is empty on a run that exited 0, read
+`events.jsonl` rather than assuming the run did nothing.
+
+## Rework through a conversation
+
+When the diff is close but wrong, continue the same conversation rather than starting cold:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief delta-brief.txt --cd /path/to/repo \
+  --conversation "$(jq -r .conversationId /tmp/warp-run-1/result.json)"
+```
+
+Warp still holds the earlier exchange, so send only the delta — what was wrong, what to change, what
+to leave alone. See [writing-the-brief.md](writing-the-brief.md#delta-briefs).
+
+If `conversationId` is `null`, the stream did not carry one; dispatch a fresh run with a brief that
+restates the corrected requirements.
+
+Discard rather than rework when the diff misunderstood the goal, wanders far outside the brief, or
+would take longer to correct than to redo. `git checkout -- .` and rewrite the brief.
+
+## Landing
+
+Commit once the gates pass and the diff holds. Write the commit message yourself: it should describe
+the change, not the delegation. Do not credit the tool in the message unless the project's own
+convention asks for it.
+
+## Surface, don't absorb
+
+Delegation is something the human opted into, and committing verified, gate-passing work is the
+agreed contract. Two limits stay with you:
+
+- **Surface, don't absorb.** Report Warp's design decisions, its defensible-but-unasked turns, and
+  the non-blocking nitpicks you chose not to fix. Silently smoothing them over hides the
+  implementer's judgment from the person who owns the code.
+- **Stop for scope changes.** If finishing correctly requires going beyond the brief — a dependency
+  bump, a schema change, an interface the brief did not mention — ask rather than expanding the
+  mandate yourself.
+
+Also surface the things unique to this implementer: whether the run uploaded a workspace snapshot
+(`snapshotDisabled: false`) if the repository is sensitive, and the `runUrl` when someone will want
+to inspect the run in Warp.

--- a/skills/warp-delegate/references/review-and-land.md
+++ b/skills/warp-delegate/references/review-and-land.md
@@ -77,8 +77,11 @@ would take longer to correct than to redo.
 Discard against a known baseline, never with a blanket revert. `git checkout -- .` is the wrong
 reach: it leaves staged and untracked files behind, so the tree stays dirty for the next dispatch,
 and it destroys any uncommitted work of your own that predates the run. Dispatch from a clean tree —
-commit or `git stash` your own changes first — so that everything dirty afterwards is Warp's, then
-drop exactly what the run introduced, reading the paths off `touchedFiles`:
+commit your own changes, or `git stash push --include-untracked` them. A bare `git stash` leaves
+untracked files in place, and those resurface as `??` entries in `touchedFiles`, where the cleanup
+below would delete work the run never made. Confirm `git status --porcelain` prints nothing before
+dispatching, so that everything dirty afterwards is Warp's, then drop exactly what the run
+introduced, reading the paths off `touchedFiles`:
 
 ```bash
 git restore --staged --worktree -- <tracked paths>   # the ' M' / 'M ' entries

--- a/skills/warp-delegate/references/review-and-land.md
+++ b/skills/warp-delegate/references/review-and-land.md
@@ -16,9 +16,12 @@ discard.
 
 1. **Read `result.json` first.** Check `status` and `exitCode` before anything else. A `timeout` or
    `aborted` status means the tree may be mid-edit and incoherent.
-2. **Start from `touchedFiles`.** It is the porcelain list of what moved. `null` means git could not
-   report — inspect the tree by hand. `[]` on a run that claimed edits is a contradiction worth
-   chasing.
+2. **Start from `touchedFiles`.** It is `git status --porcelain` taken after the run: post-run,
+   git-visible worktree state, not a log of what the agent did. It cannot show an ignored file, an
+   edit the run made and then reverted, or a write outside the repository, and it includes anything
+   already dirty before dispatch. Start there, but do not read it as the complete set. `null` means
+   git could not report — inspect the tree by hand. `[]` on a run that claimed edits is a
+   contradiction worth chasing.
 3. **Re-run the gates yourself.** Do not accept "tests pass" from `finalMessage`. Run the project's
    actual lint, typecheck, build, and test commands and read the output.
 4. **Read the whole diff against the brief.** `git diff` and `git diff --staged`. Ask of each hunk:
@@ -59,7 +62,22 @@ If `conversationId` is `null`, the stream did not carry one; dispatch a fresh ru
 restates the corrected requirements.
 
 Discard rather than rework when the diff misunderstood the goal, wanders far outside the brief, or
-would take longer to correct than to redo. `git checkout -- .` and rewrite the brief.
+would take longer to correct than to redo.
+
+Discard against a known baseline, never with a blanket revert. `git checkout -- .` is the wrong
+reach: it leaves staged and untracked files behind, so the tree stays dirty for the next dispatch,
+and it destroys any uncommitted work of your own that predates the run. Dispatch from a clean tree —
+commit or `git stash` your own changes first — so that everything dirty afterwards is Warp's, then
+drop exactly what the run introduced, reading the paths off `touchedFiles`:
+
+```bash
+git restore --staged --worktree -- <tracked paths>   # the ' M' / 'M ' entries
+git clean -f -- <untracked paths>                    # the '??' entries
+```
+
+If dispatching from a clean tree is not an option, give Warp its own `git worktree` instead: then
+discarding is `git worktree remove --force`, and your work was never in reach. Either way, rewrite
+the brief before dispatching again.
 
 ## Landing
 
@@ -79,6 +97,10 @@ agreed contract. Two limits stay with you:
   bump, a schema change, an interface the brief did not mention — ask rather than expanding the
   mandate yourself.
 
-Also surface the things unique to this implementer: whether the run uploaded a workspace snapshot
-(`snapshotDisabled: false`) if the repository is sensitive, and the `runUrl` when someone will want
-to inspect the run in Warp.
+Snapshot egress is a decision you make **before** dispatch, not something you report after it. `oz
+agent run` uploads an end-of-run workspace snapshot by default, so reading `snapshotDisabled: false`
+off a finished run tells you only that the upload already happened. If the repository is sensitive,
+pass `--no-snapshot` on the dispatch and confirm `snapshotDisabled: true` in `result.json` before
+going further. Keep reporting the field either way — it is the evidence of which way the run went.
+
+Also surface the `runUrl` when someone will want to inspect the run in Warp.

--- a/skills/warp-delegate/references/review-and-land.md
+++ b/skills/warp-delegate/references/review-and-land.md
@@ -14,8 +14,12 @@ could touch while it worked. The diff is not a courtesy record — it is the onl
 Work through these in order. Stop at the first one that fails and decide whether to rework or
 discard.
 
-1. **Read `result.json` first.** Check `status` and `exitCode` before anything else. A `timeout` or
-   `aborted` status means the tree may be mid-edit and incoherent.
+1. **Read `result.json` first.** If there is no `result.json`, stop: a usage error exits 2 before
+   Warp is ever dispatched and writes none, so an absent file means the run did not happen — read the
+   relay's stderr, not the tree. Otherwise require `status: "completed"` and `exitCode: 0` before
+   going further. `failed`, `timeout`, `aborted`, and `warp_unavailable` all mean the run did not
+   finish on its own terms, and `timeout` and `aborted` additionally mean the tree may be mid-edit
+   and incoherent. Rework or discard from the baseline rather than reviewing a partial run.
 2. **Start from `touchedFiles`.** It is `git status --porcelain` taken after the run: post-run,
    git-visible worktree state, not a log of what the agent did. It cannot show an ignored file, an
    edit the run made and then reverted, or a write outside the repository, and it includes anything
@@ -23,9 +27,15 @@ discard.
    git could not report — inspect the tree by hand. `[]` on a run that claimed edits is a
    contradiction worth chasing.
 3. **Re-run the gates yourself.** Do not accept "tests pass" from `finalMessage`. Run the project's
-   actual lint, typecheck, build, and test commands and read the output.
-4. **Read the whole diff against the brief.** `git diff` and `git diff --staged`. Ask of each hunk:
-   did the brief ask for this? Changes outside the brief's stated scope are the thing to catch.
+   actual lint, typecheck, build, and test commands and read the output. Take "actual" from
+   `CONTRIBUTING.md`, the CI config, or `package.json`: a project's gate set often includes a
+   packaging, manifest, or schema validation step that lint and test do not cover, and that is
+   exactly the gate a run can break without any test going red.
+4. **Read the whole diff against the brief.** `git diff` and `git diff --staged` — then open every
+   `??` path in `touchedFiles` directly, including everything inside an untracked directory. Neither
+   diff command shows the contents of an untracked file, so a file Warp created is invisible to both
+   and would otherwise reach your commit unread. Ask of each hunk and each new file: did the brief
+   ask for this? Changes outside the brief's stated scope are the thing to catch.
 5. **Check what should NOT have changed.** Lockfiles, CI config, formatter config, unrelated
    modules, and anything the brief listed under "leave untouched".
 6. **Grep for dangling references** after any removal or rename — imports, string keys, docs.

--- a/skills/warp-delegate/references/writing-the-brief.md
+++ b/skills/warp-delegate/references/writing-the-brief.md
@@ -1,0 +1,105 @@
+# Writing the brief
+
+The brief is the whole contract. Warp sees only the text you send plus whatever it can inspect in
+the workspace — no chat history, no shared context, none of the reasoning that led you here.
+
+## How the brief reaches Warp
+
+`oz agent run` requires one of `--prompt`, `--saved-prompt`, `--task-id`, or `--skill`. Its
+`-f/--file` config path does **not** satisfy that requirement, so there is no stdin or file channel
+for the task text: the relay passes the brief as the `--prompt` value on argv.
+
+Two consequences that do not apply to the other skills in this package:
+
+- **The brief is visible in the host process list** (`ps`, Activity Monitor, Task Manager) for as
+  long as the run is live. Keep credentials, tokens, and customer data out of it. Point Warp at a
+  file in the repo or an environment variable instead of inlining a secret.
+- **A very large brief can hit the OS argument limit.** Practical briefs are far below it, but a
+  brief that inlines whole files can trip it. Reference paths rather than pasting file contents —
+  Warp can read the workspace itself.
+
+Because the brief rides argv, the relay never launches `oz` through a shell on any platform.
+
+## Structure
+
+Cover these in order. Skip a heading only when it genuinely does not apply.
+
+1. **Goal** — one sentence on the outcome, not the mechanics.
+2. **Current state** — where the code is now, and the paths that matter. **Name the workspace root
+   as an absolute path**, and prefer absolute paths for the files you call out. `--cwd` is not
+   uniformly honoured: on a verified run against oz 0.2026.05.27, shell commands executed in the
+   pinned workspace (`pwd` returned it), but the agent stated its working directory was `/` and its
+   file-reading tool resolved bare relative paths against `$HOME` — so `src/strings.js` was first
+   read as `/Users/<you>/src/strings.js`. The agent recovered by running `pwd` and retrying, but it
+   burned a turn, and in a home directory that happened to hold a matching path it would have read
+   the wrong file. There is no sandbox to catch that.
+3. **What to change** — the specific edits, in the order they make sense.
+4. **What to leave untouched** — files, patterns, and public interfaces that must not move. Warp has
+   no sandbox, so this is a written boundary, not an enforced one.
+5. **Gates** — the project's *actual* commands. Read them out of `package.json`, `Makefile`, or the
+   CI config; do not invent `npm test` because it is conventional.
+6. **Report contract** — what the final message must state (below).
+7. **Do not commit** — say it explicitly. Committing is the orchestrator's job.
+
+## The report contract
+
+Ask for a final message that states, plainly:
+
+- What changed, file by file.
+- Which gate commands were run, and their exact outcome.
+- Anything the run could not do, and why.
+- Any decision it made that the brief did not specify.
+
+The relay captures that message as `finalMessage` in `result.json` and as `final.txt`. Treat it as a
+claim to verify, never as verification — see [review-and-land.md](review-and-land.md).
+
+## Repository context files
+
+Warp reads skills from `.agents/skills/`, `.warp/skills/`, `.claude/skills/`, and `.codex/skills/`.
+If the repository carries conventions in one of those, name it with the relay's `--skill` flag
+(`name`, `repo:name`, or `org/repo:name`) so it becomes the base prompt and your brief stays the
+task. Anything not in one of those locations — a plain `CONTRIBUTING.md`, for instance — must be
+referenced by path in the brief; do not assume it is loaded.
+
+## One task per brief
+
+A brief that carries two unrelated changes produces a diff you cannot review cleanly and a
+conversation you cannot resume precisely. Split them and queue the parts — see
+[multi-task-queues.md](multi-task-queues.md).
+
+## Delta briefs
+
+When you continue a conversation with `--conversation <id>`, Warp still holds the earlier exchange.
+Send only what changed:
+
+- What you reviewed and what was wrong — be specific about the file and the symptom.
+- What to do about it.
+- What to leave alone from the previous round.
+- The gates to re-run.
+
+Do not re-send the original brief. Restating a satisfied requirement invites Warp to redo work that
+was already correct.
+
+## Worked example
+
+```text
+Goal: make the CSV export stream instead of buffering the whole result set.
+
+Current state: src/export/csv.ts builds one string in memory (see toCsv) and
+returns it from the /export route in src/routes/export.ts.
+
+Change:
+- Rewrite toCsv to return a Readable that yields one row at a time.
+- Update the /export route to pipe that stream to the response.
+- Keep the column order and the quoting behaviour exactly as they are now.
+
+Leave untouched: the public signature of toCsv's caller in src/routes/export.ts
+beyond the pipe change, and every file under src/import/.
+
+Gates: `npm run lint`, `npm run typecheck`, `npm test -- export`.
+
+Report: list each file you changed, quote the exact output of each gate command,
+and state anything you could not finish.
+
+Do not commit. Leave the changes in the working tree.
+```

--- a/skills/warp-delegate/scripts/relay.mjs
+++ b/skills/warp-delegate/scripts/relay.mjs
@@ -378,7 +378,7 @@ async function probeOzVersion(timeoutMs, onChild) {
     child.on("close", (code) => finish({ code, error: null, timedOut }));
     timer = setTimeout(() => {
       timedOut = true;
-      killChild(child, "SIGKILL");
+      killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
     }, limit);
   });
 

--- a/skills/warp-delegate/scripts/relay.mjs
+++ b/skills/warp-delegate/scripts/relay.mjs
@@ -1,0 +1,820 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · warp-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Warp Agent CLI (`oz agent run
+ * --output-format ndjson`), capture the newline-delimited JSON event stream,
+ * and write a structured result the orchestrating agent can review. The
+ * orchestrator runs this one command and reads the result JSON — every
+ * Warp-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `oz` and `git`, plus the platform
+ * process-termination utility when a Windows process-tree kill requires one.
+ * The `oz` process it launches does authenticate — exactly as you do at the
+ * terminal. Read this file before you run it.
+ *
+ * Brief delivery: `oz agent run` requires one of --prompt/--saved-prompt/
+ * --task-id/--skill, and its -f/--file config path does NOT satisfy that
+ * requirement, so the brief rides argv as the --prompt value. Two consequences
+ * the other relays in this package do not have: the brief is visible in the
+ * host process list while the run is live, and a very large brief can hit the
+ * OS argv limit. Keep secrets out of the brief — reference workspace files or
+ * environment variables instead — and on a shared machine prefer a short brief
+ * that points `oz` at files in the repo. Because the brief rides argv, this
+ * relay never launches `oz` through a shell on any platform.
+ *
+ * Workspace snapshots: `oz agent run` uploads an end-of-run workspace snapshot
+ * by default. The relay does not change that default — it is the CLI's own
+ * behavior — but --no-snapshot forwards Warp's flag when you do not want the
+ * upload. Decide deliberately for private repositories.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Autonomy: `oz agent run` has NO sandbox, NO permission mode, and NO
+ * read-only mode. A headless run reads, writes, edits, and executes commands
+ * with the user's own permissions and never prompts. This relay therefore
+ * offers no --read-only flag: there is nothing in the CLI to enforce it, and
+ * advertising one would be a lie. (`--auto-approve` belongs to the interactive
+ * `warp` TUI, not to `oz agent run`.) The diff reported in `touchedFiles` is
+ * the record of what changed — inspect it after every run.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for oz (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <id>            Warp model id (default: Warp's own). See `oz model list`.
+ *   --profile <id>          Warp agent profile id.
+ *   --name <name>           Label for the run (Warp's `--name`).
+ *   --conversation <id>     Continue an existing Warp conversation; send only the delta brief.
+ *   --skill <spec>          Warp skill used as the base prompt (`name`, `repo:name`, `org/repo:name`).
+ *   --mcp <spec>            MCP server config path or inline JSON. Repeatable.
+ *   --no-snapshot           Forward Warp's --no-snapshot (disable the end-of-run snapshot upload).
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). Durations use h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, ozVersion, runId, runUrl, conversationId,
+ *   finalMessage (the agent's own report), model, touchedFiles (git porcelain,
+ *   null if git cannot report), snapshotDisabled, and paths to brief.txt,
+ *   final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `oz` binary exits 127;
+ * otherwise the exit code mirrors oz's own (0 success, non-zero failure),
+ * except a stream-reported agent error exits 1 even if oz exits 0. If the child
+ * dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome — completed, failed, timeout (the --timeout watchdog
+ * fired, or the bounded --version preflight hung), aborted (the relay itself
+ * was killed and forwarded the kill to oz), or warp_unavailable.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const VERSION_TIMEOUT_MS = 10_000;
+// Values that ride argv beside the brief. `oz` is launched without a shell, so
+// the risk is not quoting but flag injection: a value starting with "-" would be
+// read by oz as another option. Require a leading alphanumeric.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "warp";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    // Warp exposes no read-only, sandbox, or permission-mode flag on `oz agent
+    // run`, so those dials cannot be honoured here. Dropping one silently would
+    // run a lane the user believes is restricted, so refuse instead.
+    if (["readOnly", "sandbox", "permissionMode", "force", "effort", "variant", "provider"].includes(field)) {
+      fail(`lane "${opts.lane}" sets the ${field} dial, which the Warp Agent CLI has no flag for; remove it from the lane or use a different implementer`);
+    }
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    profile: null,
+    name: null,
+    conversation: null,
+    skill: null,
+    mcp: [],
+    noSnapshot: false,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--profile": opts.profile = next(); break;
+      case "--name": opts.name = next(); break;
+      case "--conversation": opts.conversation = next(); break;
+      case "--skill": opts.skill = next(); break;
+      case "--mcp": opts.mcp.push(next()); break;
+      case "--no-snapshot": opts.noSnapshot = true; break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  for (const flag of ["model", "profile", "conversation"]) {
+    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  // --skill and --mcp legitimately carry characters the token rule rejects (an
+  // inline MCP JSON blob, a path). Only a leading "-" is dangerous: oz would
+  // read the value as the next option.
+  for (const [flag, values] of [["skill", opts.skill === null ? [] : [opts.skill]], ["mcp", opts.mcp]]) {
+    for (const value of values) {
+      if (value === "" || value.startsWith("-")) {
+        fail(`--${flag} value must be non-empty and must not start with "-"`);
+      }
+    }
+  }
+  if (opts.name !== null && (opts.name === "" || opts.name.startsWith("-"))) {
+    fail('--name value must be non-empty and must not start with "-"');
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
+  // setTimeout overflows past 2^31 - 1 ms (~24.8 days) and fires immediately,
+  // which would read as an instant spurious timeout — reject it up front.
+  if (parseDuration(opts.timeout) > 2_147_483_647) {
+    fail(`--timeout "${opts.timeout}" exceeds the maximum schedulable watchdog (~24.8 days)`);
+  }
+  if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to oz agent run\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+async function probeOzVersion(timeoutMs, onChild) {
+  const limit = Math.min(timeoutMs, VERSION_TIMEOUT_MS);
+  const runProbe = (command, argv, options = {}) => new Promise((resolveProbe) => {
+    const child = spawn(command, argv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      ...options,
+    });
+    onChild(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timer;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveProbe({ stdout, stderr, ...result });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => finish({ code: null, error, timedOut: false }));
+    child.on("close", (code) => finish({ code, error: null, timedOut }));
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child, "SIGKILL");
+    }, limit);
+  });
+
+  // `oz` installs as a native binary on the platforms this relay targets, so
+  // there is no .cmd shim to resolve and the probe runs without a shell — the
+  // same launch discipline the dispatch uses because the brief rides argv.
+  const probe = await runProbe("oz", ["--version"]);
+  if (probe.timedOut) {
+    return { version: null, error: Object.assign(new Error("oz --version timed out"), { code: "ETIMEDOUT", stderr: probe.stderr }) };
+  }
+  if (probe.error && probe.error.code === "ENOENT") return { version: null, error: null };
+  if (probe.error) return { version: null, error: probe.error };
+  if (probe.code !== 0) {
+    return { version: null, error: Object.assign(new Error("oz --version failed"), { status: probe.code, stderr: probe.stderr }) };
+  }
+  return { version: probe.stdout.trim() || "unknown", error: null };
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, brief) {
+  // ndjson streams one event object per line, so a long run reports progress
+  // instead of buffering to the end. The brief is the --prompt value: `oz agent
+  // run` requires one of --prompt/--saved-prompt/--task-id/--skill, and -f/--file
+  // does not satisfy that requirement.
+  const argv = ["agent", "run", "--output-format", "ndjson", "--cwd", opts.cd];
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.profile) argv.push("--profile", opts.profile);
+  if (opts.name) argv.push("--name", opts.name);
+  if (opts.conversation) argv.push("--conversation", opts.conversation);
+  if (opts.skill) argv.push("--skill", opts.skill);
+  for (const spec of opts.mcp) argv.push("--mcp", spec);
+  if (opts.noSnapshot) argv.push("--no-snapshot");
+  argv.push("--prompt", brief);
+  return argv;
+}
+
+/**
+ * Pull agent-visible text out of one ndjson event.
+ *
+ * Verified against a live edit run on oz 0.2026.05.27: the report is carried by
+ * `{"type":"agent","text":…}` events, and system events are `type: "system"`
+ * with an `event_type` of `run_started` / `conversation_started`.
+ *
+ * `agent_reasoning` events carry a `text` field of the SAME shape but hold the
+ * model's private reasoning, not its report — matching on `text` alone splices
+ * that reasoning into finalMessage. They are dropped by type. Tool traffic
+ * (`tool_call`, `tool_result`, `tool_error`) carries no `text` and so needs no
+ * exclusion; it stays in events.jsonl.
+ *
+ * Everything past that stays tolerant rather than pinned to `type === "agent"`,
+ * so a renamed or added output event still reports instead of yielding an empty
+ * finalMessage; events.jsonl always keeps the raw stream.
+ */
+function collectText(event, push) {
+  if (!event || typeof event !== "object") return;
+  if (event.type === "system" || event.type === "agent_reasoning") return;
+  const pushString = (value) => { if (typeof value === "string" && value.trim()) push(value); };
+  if (typeof event.agent_output === "string") { pushString(event.agent_output); return; }
+  if (typeof event.text === "string") { pushString(event.text); return; }
+  if (typeof event.content === "string") { pushString(event.content); return; }
+  if (Array.isArray(event.content)) {
+    for (const part of event.content) if (part && part.type === "text") pushString(part.text);
+    return;
+  }
+  const message = event.message;
+  if (message && typeof message === "object") {
+    if (typeof message.content === "string") { pushString(message.content); return; }
+    if (Array.isArray(message.content)) {
+      for (const part of message.content) if (part && part.type === "text") pushString(part.text);
+    }
+  }
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  // A reused --out-dir must not leak a previous run's artifacts into this one.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "oz",
+      workdir: opts.cd,
+      model: opts.model,
+      profile: opts.profile,
+      snapshotDisabled: opts.noSnapshot,
+      resumed: Boolean(opts.conversation),
+      ozVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Atomic write: a polling orchestrator never reads a half-written result.
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "warp_unavailable",
+    exitCode: 127,
+    signal: null,
+    runId: null,
+    runUrl: null,
+    conversationId: null,
+    stderrTail: [],
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `oz` not found on PATH. Install the Warp Agent CLI (https://docs.warp.dev/cli/), then authenticate with `oz login` (or set WARP_API_KEY on a headless host).\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(writeResult, run, error, timeoutMs) {
+  const timedOut = error && error.code === "ETIMEDOUT";
+  const stderr = String((error && error.stderr) || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `oz --version preflight timed out after ${Math.min(timeoutMs, VERSION_TIMEOUT_MS)}ms; oz was not dispatched`
+    : `oz --version preflight failed${Number.isInteger(error && error.status) ? ` with exit ${error.status}` : ""}; oz was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error && error.status) ? error.status : 1,
+    signal: null,
+    runId: null,
+    runUrl: null,
+    conversationId: null,
+    finalMessage: "",
+    touchedFiles: null,
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        runId: null,
+        runUrl: null,
+        conversationId: null,
+        stderrTail: [],
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the oz version preflight; oz was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
+function dispatchToOz(opts, brief, run, writeResult) {
+  const child = spawn("oz", buildArgv(opts, brief), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    // Never shell:true. The brief is an argv value here, and a shell would
+    // reinterpret it. `oz` is a native binary, so no shim resolution needs one.
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let runId = null;
+  let runUrl = null;
+  let conversationId = null;
+  let streamError = null;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (event && typeof event === "object") {
+      if (typeof event.run_id === "string") runId = event.run_id;
+      if (typeof event.run_url === "string") runUrl = event.run_url;
+      if (typeof event.conversation_id === "string") conversationId = event.conversation_id;
+      if (event.type === "error" || event.event_type === "run_failed") {
+        const detail = typeof event.message === "string" ? event.message
+          : typeof event.error === "string" ? event.error : null;
+        streamError = detail || `oz reported ${event.event_type || event.type}`;
+      }
+    }
+    collectText(event, (text) => textChunks.push(text));
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the oz child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        runId,
+        runUrl,
+        conversationId,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; oz was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      runId,
+      runUrl,
+      conversationId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if oz handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired && !streamError;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      runId,
+      runUrl,
+      conversationId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `oz did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...(!watchdogFired && streamError ? { error: streamError } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const run = prepareRunDir(opts, brief);
+  let writeResult = makeResultWriter(opts, null, run);
+  let preflightChild = null;
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const probe = await probeOzVersion(timeoutMs, (child) => { preflightChild = child; });
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (!probe.version) {
+    clearPreflightSignals();
+    reportVersionFailure(writeResult, run, probe.error, timeoutMs);
+    return;
+  }
+  clearPreflightSignals();
+  dispatchToOz(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  oz ${result.ozVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an oz error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated oz (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  lines.push("mode: full local tool access — the Warp Agent CLI has no sandbox, permission mode, or read-only run");
+  if (result.snapshotDisabled) lines.push("mode: end-of-run workspace snapshot upload disabled (--no-snapshot)");
+  if (result.resumed) lines.push("mode: continued an existing conversation");
+  if (result.model) lines.push(`model: ${result.model}`);
+  if (result.conversationId) lines.push(`conversation id (continue with: --conversation ${result.conversationId}): ${result.conversationId}`);
+  if (result.runId) lines.push(`run id: ${result.runId}`);
+  if (result.runUrl) lines.push(`run url: ${result.runUrl}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- oz final report ---");
+  lines.push(result.finalMessage || "(no final message captured — read events.jsonl for the raw stream)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot"];
+export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp"];
 
 export const EXTRA_ARGS = {
   claude: [],
@@ -16,12 +16,13 @@ export const EXTRA_ARGS = {
   pi: [],
   aider: [],
   copilot: [],
+  warp: [],
 };
 
 export const WIN = process.platform === "win32";
 
 export const binaryName = (skill) =>
-  skill === "qoder" ? "qodercli" : skill === "cursor" ? "cursor-agent" : skill;
+  skill === "qoder" ? "qodercli" : skill === "cursor" ? "cursor-agent" : skill === "warp" ? "oz" : skill;
 
 export const relayPath = (testDir, skill) =>
   join(testDir, "..", "skills", `${skill}-delegate`, "scripts", "relay.mjs");

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -35,6 +35,7 @@ export function installShim(h) {
         // aider's pip install puts a native aider.exe in Scripts, and the relay spawns it
         // without a shell, so a .cmd shim would never be found the way the real one is.
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "aider.exe"));
+        copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "oz.exe"));
       } else {
         console.error(`${compiled.stdout ?? ""}${compiled.stderr ?? ""}`);
       }

--- a/test/relay-isolated.mjs
+++ b/test/relay-isolated.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp"];
 let failed = 0;
 const check = (name, condition) => {
   console.log(`${condition ? "  ok " : "  FAIL"}  ${name}`);

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp"];
 const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],
@@ -27,9 +27,9 @@ const SYMBOLS = [
   ["fingerprintDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["changedDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["readOnlyVerdict", "function", READ_ONLY_TRIPWIRE_RELAYS],
-  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "copilot", "cursor", "grok", "kimi", "opencode", "pi", "qoder", "vibe"]],
+  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "copilot", "cursor", "grok", "kimi", "opencode", "pi", "qoder", "vibe", "warp"]],
   ["makeLineScanner", "function", ["vibe", "copilot"]],
-  ["makeEventScanner", "function", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "qoder"]],
+  ["makeEventScanner", "function", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "qoder", "warp"]],
 ];
 let failed = 0;
 const check = (name, condition) => {

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -7,11 +7,11 @@
  * not complete:
  *
  *   1. timeout  — the watchdog kills the implementer's WHOLE process tree and
- *                 result.json reports status "timeout". Driven for all thirteen
+ *                 result.json reports status "timeout". Driven for all fourteen
  *                 relays on both platforms. On Windows, claude and cursor
  *                 launch a .cmd shim through a serialized cmd.exe invocation,
  *                 while codex/opencode/grok/pi/cline use shell:true. These are exactly the
- *                 cases a plain child.kill would miss; agy, aider, kimi, qoder, and vibe spawn a
+ *                 cases a plain child.kill would miss; agy, aider, kimi, qoder, vibe, and oz spawn a
  *                 native binary directly — a .cmd stand-in cannot represent them,
  *                 so the smoke compiles a real fake .exe with the C# compiler
  *                 that ships in-box with Windows (no install, no network) and
@@ -23,7 +23,7 @@
  *   2. aborted  — killing the relay itself still produces result.json with
  *                 status "aborted", and files the implementer flushes during
  *                 the shutdown grace window appear in the refreshed
- *                 touchedFiles. Driven for all thirteen relays on POSIX; Windows
+ *                 touchedFiles. Driven for all fourteen relays on POSIX; Windows
  *                 delivers no catchable SIGTERM, so the scenario cannot be
  *                 driven there (the skill docs carry the same caveat).
  *
@@ -31,7 +31,7 @@
  * `changelog`), and can be told to hang or fail that probe by mode name, so a
  * relay whose preflight is unbounded — wedging before any result.json exists —
  * or which reports a broken CLI as a missing one is caught here.
- * A shared matrix also drives all thirteen through the --timeout values no
+ * A shared matrix also drives all fourteen through the --timeout values no
  * watchdog can honour — malformed, zero, and past Node's timer ceiling — each of
  * which would otherwise fire on the next tick as a silent instant "timeout".
  * Quick Claude, Cline, Cursor, Qoder, Vibe, and Pi success cases verify brief

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -27,7 +27,7 @@ export function runDelegateSetup(h) {
   h.check("discover reports version", report?.version === "delegate-discover.v1");
   h.check("discover lists discovered or missing", Array.isArray(report?.discovered) && Array.isArray(report?.missing));
   h.check(
-    "discover covers all thirteen implementers",
+    "discover covers every implementer in the smoke matrix",
     Array.isArray(report?.discovered) &&
       Array.isArray(report?.missing) &&
       report.discovered.length + report.missing.length === h.SKILLS.length,

--- a/test/relay/preflight.mjs
+++ b/test/relay/preflight.mjs
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { join } from "node:path";
 
 export async function runPreflight(h) {
-for (const skill of ["codex", "opencode", "grok", "kimi"]) {
+for (const skill of ["codex", "opencode", "grok", "kimi", "warp"]) {
   const workDir = h.freshRepo(`work-preflight-${skill}`);
   for (const [suffix, expectedStatus, expectedExit] of [
     ["version-hang", "timeout", 124],

--- a/test/relay/timeout-tree.mjs
+++ b/test/relay/timeout-tree.mjs
@@ -16,6 +16,7 @@ const TIMEOUT_CASES = [
   { skill: "vibe", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "agy", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "aider", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "warp", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
 ];
 async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag) {
   const outDir = join(h.scratch, `out-${tag}-${skill}`);


### PR DESCRIPTION
**Claim:** #79

**What ran:** macOS (Darwin 25.6.0), `oz` 0.2026.05.27.15.44.stable_01, Node 22.

*Live edit run.* A relay dispatch against a throwaway git repository had Warp add a function plus
four assertions across two files. Both project gates were re-run independently by the orchestrator,
the diff matched the brief, and `HEAD` was untouched — the relay does not commit. Verified end to
end: version preflight, launch, ndjson parsing (`run_started` → `runId`/`runUrl`,
`conversation_started` → `conversationId`), report extraction, `touchedFiles`, and
`status: "completed"` / exit 0.

*Live resume run.* A second dispatch with `--conversation` sent a delta brief saying only "the
function you just added" — never naming it — and got exactly the right edit, with `resumed: true`
and the conversation id preserved.

*Also observed:* `touchedFiles: []` on a clean tree, and exit 1 → `status: "failed"` when a
dispatch was rejected before inference.

*Untested paths:* `--no-snapshot`, `--profile`, `--skill`, and `--mcp` are contract-tested only. The
README's Verification status line says the same.

*Suites:* `node test/relay-smoke.mjs` (full matrix — thirteen relays since the rebase onto `master`),
`node test/relay-parity.mjs`, and `npx skills add . --list`, all green. The package validation was
missing from this list on the first submission; review caught it and it has since been run.

---

**Two Warp behaviours are documented rather than fixed**, because they are the CLI's and not the
relay's:

1. **`finalMessage` is the agent's whole narration.** Warp emits no distinct final-message event, so
   the report is the concatenation of `{"type":"agent","text":…}` events. This is why the skill
   insists on a report contract — `FILES:`/`GATES:`/`NOTES:` gives the reviewer a stable anchor.
   Related: `agent_reasoning` carries an identically shaped `text` field holding private reasoning,
   and is excluded — matching on `text` alone splices chain-of-thought into the report.
2. **`--cwd` is aim, not a fence.** Measured: shell commands executed in the pinned workspace
   (`pwd` returned it), but the agent stated its working directory was `/` and its file-reading tool
   resolved bare relative paths against `$HOME`. `references/writing-the-brief.md` therefore requires
   naming the workspace root as an absolute path; doing so removed the failure entirely (26 events
   with a `tool_error` → 11 clean events).

**On the fourth invariant.** `oz agent run` has no sandbox, no permission mode, and no read-only
run, so this relay ships **no `--read-only` flag** rather than implying an enforcement that does not
exist, and `applyFleetLane` refuses any lane dial Warp cannot honour (`readOnly`, `sandbox`,
`permissionMode`, `force`, `effort`, `variant`, `provider`) with exit 2. `--auto-approve` belongs to
the interactive `warp` TUI and has no bearing on `oz`.

**The binary is `oz`, not `warp`.** The TUI requires a terminal device, has no prompt or print flag,
and exits `Device not configured` on a piped stdin — it cannot be relayed. The skill says so up
front, and `AGENTS.md` gained a vocabulary row so `oz` is never called "the warp CLI" in a launch
context.

**Launch note.** The brief rides argv as `--prompt`: clap requires one of
`--prompt|--saved-prompt|--task-id|--skill`, and `-f/--file` is a config path that does not satisfy
that group, so there is no stdin or file channel. The relay therefore never uses a shell on any
platform, and the brief guidance says to keep secrets out since `--prompt` is visible in the host
process list.

**One prerequisite worth flagging for reviewers.** Authentication and AI quota are separate gates in
Warp. `oz whoami` can succeed while every dispatch fails with "In order to use Warp's AI features,
subscribe to a Warp plan, or bring your own inference" (`QuotaLimit` in `~/Library/Logs/oz/warp.log`).
The CLI shares the Warp app's account, plan, and credits, so the usual cause is being signed into the
wrong account — `oz logout && oz login`. This is prerequisite step 3 in the SKILL.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for delegating coding tasks to the Warp Agent CLI.
  * Added task dispatch, monitoring, artifact capture, timeout handling, and structured results.
  * Added support for task queues, conversational rework, and controlled review workflows.

* **Documentation**
  * Documented task briefs, validation, recovery, Windows requirements, live-edit and resume behavior, and known limitations.

* **Tests**
  * Extended relay, preflight, timeout, parity, and smoke coverage to include Warp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
