### PR TITLE
feat(relay): standardize usage-limit classification across implementers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,13 +81,26 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   a repo-level doc); when the two disagree, the canonical doc is right. **`status` is a closed enum —
   adding a value is a breaking change requiring `delegate-relay.result.v2`.** Express new outcome
   detail as additive optional fields instead.
-- **Usage-limit matchers:** a relay may classify a usage limit only with a committed capture bundle
-  under `test/fixtures/usage-limit/<cli>.json` recording the signature, the transport it appears in,
-  the CLI version, and its provenance (`live-captured`, or version-pinned source of the real
-  transport — never prose docs alone). No bundle → no matcher → that relay keeps reporting an
-  unclassified `failed`, and the README says so. Never add an unverified code or message to a
-  signature table: a false classification tells the orchestrator not to investigate a real bug.
-  Enrolled relays must pass the shared matrix in `test/relay/usage-limit.mjs`.
+- **Usage-limit evidence:** a relay may set `failureClass: "usage_limit"` on exactly two evidence
+  paths, and on nothing else.
+  - *Terminal-event matchers* — reading a limit out of the CLI's own terminal failure. These
+    require a committed capture bundle under `test/fixtures/usage-limit/<cli>.json` recording the
+    signature, the transport it appears in, the CLI version, and its provenance (`live-captured`,
+    or version-pinned source of the real transport — never prose docs alone). No bundle → no
+    matcher → that relay keeps reporting an unclassified `failed`, and the README says so. Never
+    add an unverified code or message to a signature table: a false classification tells the
+    orchestrator not to investigate a real bug. Relays enrolled here must pass the shared matrix
+    in `test/relay/usage-limit.mjs`.
+  - *Preflight exhaustion* — a CLI with a verified headless quota query (today only `agy`, whose
+    `/usage` reply is structured data, not an error message) may refuse to dispatch when that
+    query reports every bucket exhausted. The query's own reply is the evidence, so no
+    terminal-error capture bundle applies; the requirement instead is that the query is verified
+    to spend nothing, the raw reply is written to the out-dir and named by `evidence.source`, and
+    only total exhaustion blocks. A probe that fails, times out, or returns an unfamiliar shape
+    must never block a dispatch. Coverage lives with that relay's own suite, not the shared matrix,
+    because nothing was dispatched to compare.
+
+  Both paths obey the same fail-closed rule: ambiguous evidence stays an unclassified `failed`.
 - **Executables:** keep them minimal and inspectable. Each `*-delegate` skill has one
   `scripts/relay.mjs`. Utility skills may ship other scripts (e.g. `discover.mjs`, `config.mjs`) under
   the same trust line: Node built-ins only, no dependencies, no network calls of their own, no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ jargon. Use these terms; don't invent synonyms.
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
 | **land** | commit the verified work yourself | — |
 | **relay** / `relay.mjs` | the dispatch **script** only | never a *category* of skills |
+| **usage limit** | the provider-imposed quota or rate cap that ends a run through no fault of the brief | "budget", "credits", "out of tokens" |
+| **capture bundle** | the committed fixture proving a CLI's usage-limit signature, with its provenance | "sample", "fixture" (bare) |
 | **lane** | a named fleet binding: implementer + optional dials (`model`, `effort` / `variant`, …) | "route", "profile" |
 | **fleet** | the user's set of lanes (which CLI handles which kind of work) | — |
 | **setup skill** / `delegate-setup` | utility that discovers CLIs and writes the lane map after approval | a `*-delegate` skill |
@@ -72,6 +74,20 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   are separate; bump those only when the JSON contract breaks.
 - **Progressive disclosure:** keep `SKILL.md` lean; push depth into `references/*.md` that load only
   when needed.
+- **Result contract:** [`docs/relay-result-contract.md`](docs/relay-result-contract.md) is the source
+  of truth for `delegate-relay.result.v1` — the closed `status` set, the additive `failureClass` /
+  `limit` fields, the fail-closed classification rule, and the outcome-precedence table. Each skill's
+  `dispatch-and-poll.md` restates what its users need (skills install standalone and cannot depend on
+  a repo-level doc); when the two disagree, the canonical doc is right. **`status` is a closed enum —
+  adding a value is a breaking change requiring `delegate-relay.result.v2`.** Express new outcome
+  detail as additive optional fields instead.
+- **Usage-limit matchers:** a relay may classify a usage limit only with a committed capture bundle
+  under `test/fixtures/usage-limit/<cli>.json` recording the signature, the transport it appears in,
+  the CLI version, and its provenance (`live-captured`, or version-pinned source of the real
+  transport — never prose docs alone). No bundle → no matcher → that relay keeps reporting an
+  unclassified `failed`, and the README says so. Never add an unverified code or message to a
+  signature table: a false classification tells the orchestrator not to investigate a real bug.
+  Enrolled relays must pass the shared matrix in `test/relay/usage-limit.mjs`.
 - **Executables:** keep them minimal and inspectable. Each `*-delegate` skill has one
   `scripts/relay.mjs`. Utility skills may ship other scripts (e.g. `discover.mjs`, `config.mjs`) under
   the same trust line: Node built-ins only, no dependencies, no network calls of their own, no

--- a/README.md
+++ b/README.md
@@ -91,6 +91,51 @@ Each skill name links to its `SKILL.md`, which owns that implementer's prerequis
 caveats. Building one for another CLI? [Claim it first](../../issues?q=is%3Aissue+label%3Aimplementer),
 then see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### Usage-limit detection
+
+When a run dies because the account hit a provider quota, that is **not** a task failure: the brief
+was fine, so reworking it is wasted effort. Where a relay can recognize that with confidence it
+keeps `status: "failed"` and adds `failureClass: "usage_limit"` plus a `limit` object — kind,
+any stated reset time, and bounded evidence you can audit. The response is inspect `touchedFiles`,
+then wait for the reset or re-dispatch on another lane; never rework the brief. Full contract:
+[`docs/relay-result-contract.md`](docs/relay-result-contract.md).
+
+| Implementer | Detection | Evidence |
+| --- | --- | --- |
+| `codex` | detected | source-backed; live run pending [^ul-live] |
+| `cursor` | detected | source-backed; live run pending |
+| `grok` | detected | source-backed; live run pending |
+| `qoder` | detected | source-backed; live run pending |
+| `opencode` | detected — hard exhaustion only [^ul-opencode] | source-backed; live run pending |
+| `agy` | **preflight query instead** [^ul-agy] | live-captured |
+| `aider`, `cline`, `claude`, `kimi`, `pi`, `vibe` | not yet captured | — |
+
+"Not yet captured" means exactly that: no verified signature for that CLI has been committed, so
+its relay reports an ordinary unclassified `failed`. **Absence of `failureClass` is never evidence
+that quota was fine.** Detection is fail-closed by design — only a CLI's terminal failure event is
+inspected, only against provider-specific codes and message templates recorded in a capture bundle
+under `test/fixtures/usage-limit/`, and anything ambiguous stays unclassified. A missed
+classification costs you a diagnosis you can still make; a false one would tell you to wait out a
+real bug.
+
+[^ul-live]: Every relay's error envelope, event ordering, and exit code were verified against the
+real CLI (or its version-pinned source); what is "pending" is a run against a genuinely exhausted
+account, which no bundle fakes. Each `test/fixtures/usage-limit/<cli>.json` records exactly what
+was verified, how, and against which version.
+
+[^ul-opencode]: OpenCode retries a plain HTTP 429 indefinitely and never forwards that retry status
+to its JSON stream, so ordinary throttling *stalls* a run rather than failing it — a `timeout`
+under `--timeout`, an unbounded hang without one. Only the non-retryable quota codes are terminal
+there, so this relay's coverage of transient rate limits is nil, not merely unverified.
+
+[^ul-agy]: Antigravity's limit text is server-provided and appears nowhere in the shipped binary, so
+no matcher is justified. Instead `agy-delegate` gained `--preflight-usage`, which asks
+`agy -p "/usage" --output-format json` — a query that creates no conversation, takes no turns, and
+spends no tokens — and refuses to dispatch when every bucket is exhausted, reporting the provider's
+own remaining fractions and reset times. It blocks *only* on true exhaustion; a probe that fails,
+hangs, or returns an unfamiliar shape never stands between you and your work. It never estimates
+whether remaining quota is "enough" for a task — that is unknowable before a run.
+
 ## Install
 
 Browse first:

--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -93,6 +93,19 @@ Do not trust progress trackers over reality: a run is finished when `result.json
 process has exited. Read the working tree, not a status line. The implementer's full report is
 the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
 
+**Checking quota before you dispatch.** Antigravity is the one implementer here with a headless
+usage query, so the relay offers an opt-in `--preflight-usage`. It runs
+`agy -p "/usage" --output-format json` — which creates no conversation, takes no turns, and spends
+no tokens — and records the provider's own remaining fractions and reset times on the result as
+`usagePreflight`. If **every** bucket is exhausted it refuses to dispatch and reports
+`failureClass: "usage_limit"` with the soonest reset, so a doomed run never starts. A single spent
+bucket does not block anything, and a probe that fails, hangs, or returns an unfamiliar shape lets
+the dispatch proceed — a broken check must never stand between you and your work. It reports
+remaining quota as fact; it never estimates whether that is "enough" for your task, which is
+unknowable before a run. Antigravity's own limit *errors* are server-provided text, so a failed run
+is not classified — inspect `stderrTail`. Details:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
 ### 4. Review - do not trust the self-report
 
 Antigravity's `result.json` includes its own final message and any gate claims. **Re-verify, don't

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -138,3 +138,27 @@ caps a single argument), so have `agy` read large context from the workspace ins
 
 The helper never commits - by design, not omission. The robust contract is: Antigravity edits the
 working tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).
+
+## Checking quota before dispatch
+
+Antigravity is the one implementer in this package with a headless usage query, so the relay offers
+an opt-in `--preflight-usage`. It runs `agy -p "/usage" --output-format json` — verified to create
+no conversation, take no turns, and spend no tokens — before dispatching.
+
+- **Quota remaining:** the run proceeds, and `result.json` gains `usagePreflight` with the
+  provider's own `remainingFraction` and `resetTime` per bucket, plus the exact command used.
+- **Every bucket exhausted:** the relay does **not** dispatch. It writes `status: "failed"` with
+  `failureClass: "usage_limit"`, `limit.kind: "quota_exhausted"`, the soonest stated reset in
+  `limit.resetsAt`, and evidence naming the query — then exits non-zero. A doomed run never starts.
+- **A single spent bucket does not block anything** — only total exhaustion does.
+- **A probe that fails, hangs, or returns an unfamiliar shape lets the dispatch proceed.** A broken
+  check must never stand between you and your work.
+
+It reports remaining quota as fact. It never estimates whether that quota is "enough" for your
+task — that depends on repo size, iteration count and gate behavior, and is unknowable before a run.
+
+Antigravity's own limit *errors* are server-provided text that appears nowhere in the shipped
+binary, so a failed run carries no `failureClass`: there is no verified signature to match, and
+inventing one would risk telling you to wait out a real bug. Inspect `stderrTail` instead. The
+shared result contract is in
+[`docs/relay-result-contract.md`](https://github.com/amElnagdy/delegate-skills/blob/master/docs/relay-result-contract.md).

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -71,6 +71,25 @@ touched-files report shows only Antigravity's edits and nothing of the helper's 
 - `stderrTail` - last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`; also present when `finalMessage` is empty so diagnostics are not discarded
 - `error` - present on a launch failure, `timeout`, `aborted`, headless permission denial, or silent no-op
 
+Three more fields are additive - present only when the run produced them, absent otherwise, so an
+orchestrator that does not know them keeps working:
+
+- `usagePreflight` - `null` unless you passed `--preflight-usage`; otherwise
+  `{ command, checkedAt, status, exhausted, buckets, artifactPath, note }`. `status` is `ok` |
+  `skipped` (the installed agy predates the print-mode `/usage`) | `timeout` | `unavailable` (the
+  probe failed) | `unparseable` (an unfamiliar payload); only `ok` carries a meaningful
+  `exhausted`, which is `null` otherwise. Each entry in `buckets` is
+  `{ group, id, name, window, remainingFraction, resetTime }` - the provider's own numbers,
+  unrounded and uninterpreted. `artifactPath` points at `usage-preflight.json`, the raw reply,
+  and `note` explains any non-`ok` status. See [Checking quota before dispatch](#checking-quota-before-dispatch).
+- `failureClass` - `"usage_limit"`, and **absent on every other failure**. For agy this comes only
+  from the preflight refusal above; Antigravity's own limit *errors* carry no verified signature,
+  so a failed run is never classified from its output.
+- `limit` - accompanies `failureClass`: `{ kind: "quota_exhausted", retryAt, resetsAt, evidence }`,
+  where `evidence` is `{ source, code, excerpt, artifactLine }` naming `usage-preflight.json` as
+  the source. `resetsAt` is the soonest reset the provider stated, `retryAt` is `null` - neither is
+  ever guessed. The status stays `failed`: the enum is closed, and these two fields carry the detail.
+
 The helper also prints a summary to stdout and normally exits with Antigravity's exit code. It forces
 exit 1 when Antigravity exits 0 after a detected headless permission denial or with neither a final
 message nor observable working-tree changes, so a wrapping script can branch on success/failure directly.

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -47,6 +47,13 @@
  *   --dangerously-skip-permissions
  *                           Auto-approve Antigravity tool permission requests. Use only with human approval.
  *                           Mutually exclusive with --read-only.
+ *   --preflight-usage       Before dispatching, ask agy for the account's quota with
+ *                           `agy -p "/usage" --output-format json` - a headless read that
+ *                           starts no agent turn, spends no quota, and leaves no
+ *                           conversation behind. When EVERY quota bucket reads exhausted the
+ *                           brief is not dispatched; otherwise the snapshot is recorded on
+ *                           result.json and the run proceeds unchanged. A probe that fails,
+ *                           times out, or returns an unexpected shape never blocks dispatch.
  *   --print-timeout <dur>   Timeout agy itself applies to print mode (default: 30m).
  *   --timeout <dur>         Relay-side watchdog, h/m/s like 30m (default: --print-timeout
  *                           plus a 60s grace). On expiry the agy process tree is killed and
@@ -60,12 +67,32 @@
  * Result: written to <out-dir>/result.json and summarized on stdout -
  *   status, exitCode, agyVersion, projectId, conversationId, finalMessage
  *   (Antigravity's own report), touchedFiles (git porcelain, null if git can't report),
- *   readOnlyViolation (on --read-only), and the paths to brief.txt, final.txt, agy.log, and stderr.txt.
+ *   readOnlyViolation (on --read-only), usagePreflight (null unless --preflight-usage), and
+ *   the paths to brief.txt, final.txt, agy.log, and stderr.txt.
+ *
+ * Usage limits: this relay ships NO terminal-error matcher, deliberately. agy's quota
+ * message is produced by Google's Antigravity backend, not by the CLI - no such literal
+ * ships in the 1.1.12 binary - so there is no version-pinnable signature to match and any
+ * classification from the error text would be a guess. What agy does have is a headless,
+ * side-effect-free quota query, so classification here is opt-in and happens BEFORE
+ * dispatch. With --preflight-usage, and only when every quota bucket reads exhausted, the
+ * relay refuses to dispatch and writes:
+ *   status: "failed"                      (the status set is a closed enum; this is additive)
+ *   failureClass: "usage_limit"
+ *   limit: { kind: "quota_exhausted", retryAt, resetsAt, evidence: { source, code, excerpt, artifactLine } }
+ * resetsAt is the soonest bucket reset agy stated; retryAt stays null because agy states no
+ * retry time and a guessed one is worse than silence. Otherwise the snapshot (bucket id,
+ * remaining fraction, reset time) is recorded on the result and the run proceeds. The relay
+ * never judges whether the REMAINING quota is "enough" for this brief - that is unknowable
+ * before the run. It reports the provider's own numbers and blocks only on true exhaustion.
+ * A usage limit is not a task failure: do not rework the brief; wait for the reset or
+ * re-dispatch on another lane.
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `agy` binary exits 127;
  * otherwise the exit code mirrors Antigravity's own, except that an exit-zero
- * permission denial or silent write-dispatch no-op is forced to exit 1.
+ * permission denial or silent write-dispatch no-op is forced to exit 1. A
+ * --preflight-usage refusal never dispatches at all and exits 1.
  * If the child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome -
@@ -77,7 +104,7 @@
 
 import {spawn, execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, writeFileSync, renameSync, readFileSync, readlinkSync, lstatSync, existsSync, appendFileSync, realpathSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, readlinkSync, lstatSync, existsSync, appendFileSync, realpathSync, rmSync } from "node:fs";
 import {join, resolve, basename, dirname, relative, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir } from "node:os";
@@ -88,7 +115,161 @@ const MAX_TIMER_MS = 2_147_483_647;
 const MAX_TIMER_DURATION = "596h31m23s";
 const VERSION_PROBE_TIMEOUT_MS = 10_000;
 
+// agy's headless quota query, live-captured on agy 1.1.12. It answers from cached account
+// state: the response carries conversation_id "", num_turns 0 and every token counter 0, so
+// it starts no agent turn, spends no quota, and leaves no conversation behind that a later
+// --resume-last could latch onto. That is the whole reason it qualifies as a preflight -
+// a canary dispatch would fail all three tests.
+const USAGE_PREFLIGHT_ARGS = ["-p", "/usage", "--output-format", "json"];
+const USAGE_PREFLIGHT_COMMAND = 'agy -p "/usage" --output-format json';
+// agy only answers /usage without starting an agent turn from 1.1.12 onward. Older builds
+// treated it as an ordinary prompt and spent the very quota this probe exists to protect
+// (antigravity-cli issues #234 on 1.0.3 and #543 on 1.0.16), so the probe is version-gated.
+const USAGE_PREFLIGHT_MIN_VERSION = [1, 1, 12];
+
 const IMPLEMENTER_KEY = "agy";
+
+// Bound the evidence excerpt: a provider response can carry a very long body, and the
+// orchestrator only needs enough to audit the match. The full raw response stays in
+// usage-preflight.json, which evidence.source/artifactLine point at.
+const MAX_EVIDENCE_CHARS = 400;
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function boundedExcerpt(text) {
+  const flat = String(text ?? "").replace(/\s+/g, " ").trim();
+  return flat.length > MAX_EVIDENCE_CHARS ? `${flat.slice(0, MAX_EVIDENCE_CHARS)}…` : flat;
+}
+
+function parseResetTimestamp(value, mode) {
+  // Only a zoned absolute timestamp or a well-defined duration becomes a time. Anything
+  // ambiguous or localized ("resets 3pm") yields null — a guessed reset time would send
+  // the orchestrator back at the wrong moment, which is worse than reporting nothing.
+  if (value === null || value === undefined) return null;
+  if (mode === "absolute") {
+    if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/.test(value.trim())) return null;
+    const parsed = new Date(value.trim().replace(" ", "T"));
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  if (mode === "duration") {
+    const seconds = typeof value === "number" ? value : typeof value === "string" && /^\d+(\.\d+)?$/.test(value.trim()) ? Number(value) : NaN;
+    if (!Number.isFinite(seconds) || seconds <= 0 || seconds > 30 * 24 * 3600) return null;
+    return new Date(Date.now() + seconds * 1000).toISOString();
+  }
+  return null;
+}
+
+function usageLimitFields(match) {
+  // The additive half of the result contract: status stays "failed" so orchestrators that
+  // switch on the closed status enum keep working; failureClass/limit carry the detail.
+  if (!match) return {};
+  return {
+    failureClass: "usage_limit",
+    limit: {
+      kind: match.kind,
+      retryAt: match.retryAt ?? null,
+      resetsAt: match.resetsAt ?? null,
+      evidence: {
+        source: match.source,
+        code: match.code ?? null,
+        excerpt: boundedExcerpt(match.excerpt),
+        artifactLine: match.artifactLine ?? null,
+      },
+    },
+  };
+}
+
+function usagePreflightSupported(version) {
+  // A version we cannot read as a dotted number (a custom build, a `agy changelog` that
+  // printed something unexpected) is NOT treated as old: every documented regression
+  // reports a parseable version, and refusing to probe on an unreadable one would make the
+  // flag silently inert on installs where it is the whole point of the run.
+  const parts = String(version ?? "").trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!parts) return true;
+  const found = parts.slice(1, 4).map(Number);
+  for (let i = 0; i < USAGE_PREFLIGHT_MIN_VERSION.length; i += 1) {
+    if (found[i] !== USAGE_PREFLIGHT_MIN_VERSION[i]) return found[i] > USAGE_PREFLIGHT_MIN_VERSION[i];
+  }
+  return true;
+}
+
+function queryUsage(opts, run, timeoutMs, version) {
+  // Never throws and never blocks: every failure mode returns a note-bearing snapshot the
+  // caller records and then dispatches anyway. A broken probe must not cost a real run.
+  const checkedAt = new Date().toISOString();
+  const snapshot = (fields) => ({
+    command: USAGE_PREFLIGHT_COMMAND,
+    checkedAt,
+    exhausted: null,
+    buckets: [],
+    artifactPath: null,
+    note: null,
+    ...fields,
+  });
+  if (!usagePreflightSupported(version)) {
+    return snapshot({
+      status: "skipped",
+      note: `agy ${version} predates ${USAGE_PREFLIGHT_MIN_VERSION.join(".")}, where /usage began answering in print mode without starting an agent turn; probing an older build would spend quota, so it was skipped`,
+    });
+  }
+  // Bounded exactly like the version preflight above: the relay watchdog is only armed once
+  // agy is dispatched, so a probe that never returns would wedge the relay here, before any
+  // dispatch and before --timeout could reach it.
+  const bounded = Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+  let raw;
+  try {
+    raw = execFileSync("agy", USAGE_PREFLIGHT_ARGS, {
+      cwd: opts.cd,
+      encoding: "utf8",
+      timeout: bounded,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 8 * 1024 * 1024,
+    });
+  } catch (error) {
+    const detail = String(error?.stderr || error?.message || error).trim().split("\n").slice(-1)[0] || "no detail";
+    return error?.code === "ETIMEDOUT"
+      ? snapshot({ status: "timeout", note: `the usage query did not answer within ${bounded}ms; agy was dispatched anyway` })
+      : snapshot({ status: "unavailable", note: `the usage query failed (${boundedExcerpt(detail)}); agy was dispatched anyway` });
+  }
+  writeFileSync(run.usagePath, raw, "utf8");
+  const groups = safeJson(raw)?.command?.data?.groups;
+  const buckets = [];
+  for (const group of Array.isArray(groups) ? groups : []) {
+    for (const bucket of Array.isArray(group?.buckets) ? group.buckets : []) {
+      buckets.push({
+        group: typeof group?.name === "string" ? group.name : null,
+        id: typeof bucket?.id === "string" ? bucket.id : null,
+        name: typeof bucket?.name === "string" ? bucket.name : null,
+        window: typeof bucket?.window === "string" ? bucket.window : null,
+        // Report the provider's own number, unrounded and uninterpreted.
+        remainingFraction: Number.isFinite(bucket?.remaining_fraction) ? bucket.remaining_fraction : null,
+        resetTime: parseResetTimestamp(bucket?.reset_time, "absolute"),
+      });
+    }
+  }
+  if (!buckets.length) {
+    return snapshot({
+      status: "unparseable",
+      artifactPath: run.usagePath,
+      note: `the usage query returned no command.data.groups[].buckets[]; agy was dispatched anyway`,
+    });
+  }
+  return snapshot({
+    status: "ok",
+    artifactPath: run.usagePath,
+    // Only true exhaustion blocks a dispatch. A bucket whose remaining fraction is missing
+    // or unreadable cannot prove exhaustion, so it keeps the verdict at "dispatch".
+    exhausted: buckets.every((bucket) => bucket.remainingFraction !== null && bucket.remainingFraction <= 0),
+    buckets,
+  });
+}
 
 function applyFleetLane(opts, flagged) {
   if (!opts.lane) return;
@@ -147,6 +328,7 @@ function parseArgs(argv) {
     sandbox: false,
     readOnly: false,
     dangerouslySkipPermissions: false,
+    preflightUsage: false,
     printTimeout: DEFAULT_PRINT_TIMEOUT,
     timeout: null,
     addDirs: [],
@@ -181,6 +363,7 @@ function parseArgs(argv) {
         opts.dangerouslySkipPermissions = true;
         flagged.add("dangerouslySkipPermissions");
         break;
+      case "--preflight-usage": opts.preflightUsage = true; flagged.add("preflightUsage"); break;
       case "--print-timeout": opts.printTimeout = next(); break;
       case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
       case "--add-dir": opts.addDirs.push(next()); break;
@@ -411,8 +594,21 @@ function prepareRunDir(opts, brief) {
     finalPath: join(outDir, "final.txt"),
     logPath: join(outDir, "agy.log"),
     stderrPath: join(outDir, "stderr.txt"),
+    usagePath: join(outDir, "usage-preflight.json"),
     resultPath: join(outDir, "result.json"),
   };
+  // A reused --out-dir must not advertise the previous run: a poller that races the
+  // dispatch would read the old result.json as if it were this run's, and a run with no
+  // report of its own would publish a finalPath holding someone else's. agy.log matters
+  // most — parseIdsFromLog mines it for the project and conversation ids this run
+  // reports, so a stale log would hand back the PREVIOUS conversation as the resume
+  // handle and point a follow-up brief at the wrong thread. usage-preflight.json is the
+  // evidence a usage_limit classification points at, so a stale one would let this run's
+  // result cite the PREVIOUS run's quota reading.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.logPath, { force: true });
+  rmSync(run.usagePath, { force: true });
+  rmSync(run.resultPath, { force: true });
   writeFileSync(run.briefPath, brief, "utf8");
   writeFileSync(run.stderrPath, "", "utf8");
   return run;
@@ -477,7 +673,9 @@ function parseIdsFromLog(logPath) {
   };
 }
 
-function makeResultWriter(opts, version, run) {
+function makeResultWriter(opts, version, run, preflight) {
+  // preflight is a holder the caller fills after the probe runs, so every outcome written
+  // from that point on - including the refusal below - carries the same snapshot.
   return (extra) => {
     const ids = parseIdsFromLog(run.logPath);
     const result = {
@@ -494,6 +692,7 @@ function makeResultWriter(opts, version, run) {
       readOnlyViolation: null,
       dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
       resumed: Boolean(opts.resumeLast || opts.conversation),
+      usagePreflight: preflight.usage,
       agyVersion: version,
       projectId: ids.projectId,
       conversationId: ids.conversationId,
@@ -533,6 +732,39 @@ function reportVersionTimeout(writeResult, run, timeoutMs, error) {
     touchedFiles: null,
     ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
     error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function reportUsageExhausted(opts, writeResult, run, usage) {
+  // Every bucket the provider reported is at zero, so there is nothing to dispatch INTO.
+  // This is the only condition that may stop a run: "is the remaining quota enough for this
+  // brief" is unknowable before the run and is never asked here.
+  const resets = usage.buckets.map((bucket) => bucket.resetTime).filter(Boolean).sort();
+  const detail = usage.buckets
+    .map((bucket) => `${bucket.group ?? "?"}/${bucket.id ?? "?"} remaining_fraction ${bucket.remainingFraction}${bucket.resetTime ? ` (resets ${bucket.resetTime})` : ""}`)
+    .join("; ");
+  const message = `${USAGE_PREFLIGHT_COMMAND} reports every quota bucket exhausted; agy was not dispatched`;
+  const result = writeResult({
+    status: "failed",
+    exitCode: 1,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    error: message,
+    ...usageLimitFields({
+      kind: "quota_exhausted",
+      code: null,
+      source: "usage-preflight.json",
+      // The artifact holds exactly one record - the probe's own response - so the pointer
+      // is its first line; the excerpt names the query that produced it.
+      artifactLine: 1,
+      excerpt: `${message}: ${detail}`,
+      resetsAt: resets[0] ?? null,
+      retryAt: null,
+    }),
   });
   printSummary(result, run.resultPath);
   process.stderr.write(`relay: ${message}\n`);
@@ -720,19 +952,32 @@ function main() {
   // past its own print timeout, which is exactly the case the grace window cannot cover.
   const watchdogMs = opts.timeout !== null ? parseDuration(opts.timeout) : printTimeoutMs + 60_000;
   const run = prepareRunDir(opts, brief);
+  const preflight = { usage: null };
   let version;
   try {
     version = agyVersion(watchdogMs);
   } catch (error) {
-    const writeResult = makeResultWriter(opts, "unknown", run);
+    const writeResult = makeResultWriter(opts, "unknown", run, preflight);
     reportVersionTimeout(writeResult, run, watchdogMs, error);
     return;
   }
-  const writeResult = makeResultWriter(opts, version, run);
+  const writeResult = makeResultWriter(opts, version, run, preflight);
 
   if (!version) {
     reportUnavailable(writeResult, run.resultPath);
     return;
+  }
+
+  if (opts.preflightUsage) {
+    // Runs only after agy is known to exist, and only ever stops the run on exhaustion.
+    // Anything else the probe reports - skipped, failed, timed out, unrecognized shape -
+    // is recorded on the result and dispatch continues: a broken probe must never cost a
+    // real run, and the orchestrator can still see that the check did not answer.
+    preflight.usage = queryUsage(opts, run, watchdogMs, version);
+    if (preflight.usage.exhausted === true) {
+      reportUsageExhausted(opts, writeResult, run, preflight.usage);
+      return;
+    }
   }
 
   dispatchToAgy(opts, brief, run, writeResult, watchdogMs);
@@ -744,6 +989,19 @@ function printSummary(result, resultPath) {
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  agy ${result.agyVersion ?? "?"}`);
   if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an agy error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated agy (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.failureClass === "usage_limit") {
+    const when = result.limit?.retryAt || result.limit?.resetsAt;
+    lines.push(`hint: the provider refused on usage limits (${result.limit?.kind ?? "unknown"})${when ? `, earliest reset ${when}` : ""} — this is not a task failure and the brief was never dispatched. Do NOT rework the brief: wait for the reset, or re-dispatch the same brief on another lane.`);
+    if (result.limit?.evidence?.excerpt) lines.push(`  evidence (${result.limit.evidence.source}:${result.limit.evidence.artifactLine ?? "?"}): ${result.limit.evidence.excerpt}`);
+  }
+  if (result.usagePreflight) {
+    const usage = result.usagePreflight;
+    lines.push(`usage preflight (${usage.command}): ${usage.status}`);
+    for (const bucket of usage.buckets ?? []) {
+      lines.push(`  ${bucket.group ?? "?"} · ${bucket.id ?? "?"} (${bucket.window ?? "?"}): remaining_fraction ${bucket.remainingFraction ?? "?"}${bucket.resetTime ? `, resets ${bucket.resetTime}` : ""}`);
+    }
+    if (usage.note) lines.push(`  ${usage.note}`);
+  }
   if (result.resumed) lines.push("mode: resumed an existing conversation");
   if (result.projectId) lines.push(`project id: ${result.projectId}`);
   if (result.conversationId) lines.push(`conversation id (resume with: --conversation ${result.conversationId}): ${result.conversationId}`);

--- a/skills/claude-delegate/scripts/relay.mjs
+++ b/skills/claude-delegate/scripts/relay.mjs
@@ -113,6 +113,7 @@ import {
   readSync,
   closeSync,
   realpathSync,
+  rmSync,
 } from "node:fs";
 import {basename, delimiter, join, relative, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -564,6 +565,10 @@ function prepareRun(opts, brief) {
     settingsPath: join(outDir, "profile.json"),
     resultPath: join(outDir, "result.json"),
   };
+  // A reused --out-dir must not advertise the previous run: a poller that races the
+  // dispatch would read the old result.json as if it were this run's. The other
+  // artifacts are truncated by their own writes below.
+  rmSync(run.resultPath, { force: true });
   writeFileSync(run.briefPath, brief, "utf8");
   writeFileSync(run.eventsPath, "", "utf8");
   writeFileSync(run.finalPath, "", "utf8");

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -91,6 +91,14 @@ Do not trust progress trackers over reality: a run is finished when `result.json
 process has exited. Read the working tree, not a status line. The implementer's full report is
 the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
 
+**If the result carries `failureClass: "usage_limit"`,** the provider refused on usage limits — the
+brief was never the problem, so do not rework it. Inspect `touchedFiles` first (a limit can strike
+mid-edit), then either wait for the reset in `limit.retryAt`/`limit.resetsAt` and resume the exact
+thread with `--session <threadId>`, or re-dispatch the same brief on another lane **from a clean
+tree**. Detection is fail-closed, so an unrecognized limit still arrives as a plain `failed` — check
+`stderrTail` before concluding the brief was at fault. Details:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
 ### 4. Review — do not trust the self-report
 
 Codex's `result.json` includes its own summary and gate claims. **Re-verify, don't accept:**

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -74,6 +74,32 @@ filtered environment is used for preflight and dispatch.
 - `workdir`, `sandbox`, `model`, `effort`, `resumeLast`, `session`, `cleanEnv`, `keepEnv`, `startedAt`, `finishedAt` — `sandbox` is the applied mode, or a note that Codex used its active config on an unqualified resume; `session` is the explicit session id, or `null` for fresh and `--resume-last` runs; `keepEnv` records names only, never values
 - `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `codex_unavailable`, and launch failures
 - `error` — present on a launch failure, and on `timeout` and `aborted` runs
+- `failureClass` — `"usage_limit"` when the run died on a provider usage/rate limit; **absent otherwise**. Additive: `status` stays `failed`, so any handling that switches on `status` keeps working
+- `limit` — present only alongside `failureClass`. `{ kind, retryAt, resetsAt, evidence }` where `kind` is `quota_exhausted` | `rate_limited` | `unknown`; `retryAt`/`resetsAt` are ISO timestamps or `null` (never guessed — an ambiguous "resets 3pm" stays `null`); `evidence` is `{ source, code, excerpt, artifactLine }`, a bounded excerpt plus the 1-based `events.jsonl` line the match came from, so you can audit the classification instead of trusting it
+
+### Usage limits
+
+A `usage_limit` result is **not a task failure**, and the two need opposite responses:
+
+- **Do not rework the brief** — nothing was wrong with it.
+- **Inspect `touchedFiles` first.** A limit can strike mid-edit, so the tree may hold partial work.
+- Then either wait (`retryAt`/`resetsAt` when the provider stated one) and resume the exact thread
+  with `--session <threadId>`, which is preserved across the limit, or re-dispatch the same brief on
+  another lane **from a clean tree** — rerouting on top of half-applied changes duplicates or
+  corrupts them.
+
+Classification is deliberately fail-closed: only Codex's terminal `turn.failed` event is inspected,
+only against usage-limit codes and message templates verified against the shipped binary
+(`test/fixtures/usage-limit/codex.json` records which, and where they came from). Codex emits
+`item.completed` items of type `error` — and even a top-level `{"type":"error"}` event — during runs
+that go on to succeed, so "an error appeared" is never enough. Anything ambiguous stays an
+unclassified `failed`: a missed classification costs you a diagnosis, while a false one would tell
+you to wait out a bug. A limit whose signature this relay does not recognize therefore looks like a
+plain `failed` — check `stderrTail` and `eventsPath` before concluding the brief was at fault.
+
+Precedence: a run the relay itself ended is never classified — the watchdog reports `timeout` and a
+kill reports `aborted`, even if a limit event was already seen. A limit that somehow arrives with a
+zero exit code is still normalized to a failure, because a run that did no work is not a completion.
 
 The helper also prints a summary to stdout and exits with Codex's exit code, so a wrapping script can
 branch on success/failure directly.
@@ -106,6 +132,8 @@ process has exited and `result.json` is written — not when a status line says 
   Common causes: an auth lapse, an invalid `--model` or unsupported `--effort`, or a sandbox that
   blocked something the task needed. Fix the cause and re-dispatch; don't paper over it by doing the
   work yourself unless that's what the user wants.
+- **`status: failed` with `failureClass: "usage_limit"`:** the provider refused on usage limits —
+  see "Usage limits" above. Wait or reroute; don't rework the brief.
 - **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
   half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
   or a resume.

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -59,6 +59,18 @@
  *   (Codex's own report), touchedFiles (git porcelain, null if git can't report), and the paths to
  *   events.jsonl and final.txt.
  *
+ * Usage limits: when the run ends in Codex's terminal `turn.failed` event carrying a
+ * recognized usage-limit signature, the result stays status "failed" (the status set is a
+ * closed enum orchestrators switch on) and gains two additive fields:
+ *   failureClass: "usage_limit"
+ *   limit: { kind, retryAt, resetsAt, evidence: { source, code, excerpt, artifactLine } }
+ * kind is quota_exhausted | rate_limited | unknown. retryAt/resetsAt are null unless the
+ * provider stated a zoned absolute time or a well-defined duration — never guessed. The
+ * classification is fail-closed: only the terminal event is inspected, only against
+ * provider-specific codes and message templates, and anything ambiguous stays an
+ * unclassified "failed". A usage limit is not a task failure — do not rework the brief;
+ * inspect touchedFiles, then wait for the reset or re-dispatch on another lane.
+ *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `codex` binary exits 127;
  * otherwise the exit code mirrors Codex's own (0 success, non-zero failure).
@@ -72,7 +84,7 @@
  */
 
 import {spawn, execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync, rmSync } from "node:fs";
 import {join, resolve, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir } from "node:os";
@@ -88,6 +100,135 @@ const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
 
 const IMPLEMENTER_KEY = "codex";
+
+// Bound the evidence excerpt: a provider error can carry a very long body, and the
+// orchestrator only needs enough to audit the match. The full raw event stays in
+// events.jsonl, which evidence.artifactLine points at.
+const MAX_EVIDENCE_CHARS = 400;
+
+// Codex's usage-limit signatures, pinned to codex-cli 0.147.0. Every entry below was
+// read out of the shipped binary's string table (see test/fixtures/usage-limit/codex.json
+// for the capture bundle and its provenance); nothing here is inferred. Codes absent from
+// that binary — `rate_limit_exceeded`, `insufficient_quota` — are deliberately NOT listed:
+// an unverified signature is exactly the false positive this classification must avoid.
+// Codex calls its plan quota a "rate limit" internally (hence rate_limit_reached →
+// quota_exhausted); rate_limit_error is the transient-throttle case.
+const USAGE_LIMIT_CODES = new Map([
+  ["usage_limit_exceeded", "quota_exhausted"],
+  ["usage_limit_reached", "quota_exhausted"],
+  ["rate_limit_reached", "quota_exhausted"],
+  ["workspace_owner_usage_limit_reached", "quota_exhausted"],
+  ["workspace_member_usage_limit_reached", "quota_exhausted"],
+  ["workspace_owner_credits_depleted", "quota_exhausted"],
+  ["workspace_member_credits_depleted", "quota_exhausted"],
+  ["rate_limit_error", "rate_limited"],
+]);
+
+// Exact user-facing templates from the same binary. Matched case-insensitively as whole
+// phrases — never bare "quota"/"429"/"rate limit", which appear in ordinary task prose.
+const USAGE_LIMIT_MESSAGES = [
+  ["you've hit your usage limit", "quota_exhausted"],
+  ["you've reached your usage limit", "quota_exhausted"],
+  ["usage limit reached", "quota_exhausted"],
+  ["you've reached your workspace credit limit", "quota_exhausted"],
+  ["you're out of credits", "quota_exhausted"],
+  ["your workspace is out of credits", "quota_exhausted"],
+];
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function boundedExcerpt(text) {
+  const flat = String(text ?? "").replace(/\s+/g, " ").trim();
+  return flat.length > MAX_EVIDENCE_CHARS ? `${flat.slice(0, MAX_EVIDENCE_CHARS)}…` : flat;
+}
+
+function parseResetTimestamp(value, mode) {
+  // Only a zoned absolute timestamp or a well-defined duration becomes a time. Anything
+  // ambiguous or localized ("resets 3pm") yields null — a guessed reset time would send
+  // the orchestrator back at the wrong moment, which is worse than reporting nothing.
+  if (value === null || value === undefined) return null;
+  if (mode === "absolute") {
+    if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/.test(value.trim())) return null;
+    const parsed = new Date(value.trim().replace(" ", "T"));
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  if (mode === "duration") {
+    const seconds = typeof value === "number" ? value : typeof value === "string" && /^\d+(\.\d+)?$/.test(value.trim()) ? Number(value) : NaN;
+    if (!Number.isFinite(seconds) || seconds <= 0 || seconds > 30 * 24 * 3600) return null;
+    return new Date(Date.now() + seconds * 1000).toISOString();
+  }
+  return null;
+}
+
+function usageLimitFields(match) {
+  // The additive half of the result contract: status stays "failed" so orchestrators that
+  // switch on the closed status enum keep working; failureClass/limit carry the detail.
+  if (!match) return {};
+  return {
+    failureClass: "usage_limit",
+    limit: {
+      kind: match.kind,
+      retryAt: match.retryAt ?? null,
+      resetsAt: match.resetsAt ?? null,
+      evidence: {
+        source: match.source,
+        code: match.code ?? null,
+        excerpt: boundedExcerpt(match.excerpt),
+        artifactLine: match.artifactLine ?? null,
+      },
+    },
+  };
+}
+
+function classifyUsageLimit(event, artifactLine) {
+  // Codex-specific detector. Only `turn.failed` — the naturally terminal failure event —
+  // is inspected. Codex also emits `item.completed` items of type "error" mid-run for
+  // ordinary warnings (model-metadata fallback, shortened skill descriptions) and keeps
+  // going, so matching on "an error event" would classify healthy runs. Verified against
+  // codex-cli 0.147.0.
+  if (!event || event.type !== "turn.failed") return null;
+  const raw = typeof event.error?.message === "string" ? event.error.message : "";
+  if (!raw) return null;
+
+  // error.message is either a plain string or the provider's HTTP envelope serialized as
+  // JSON: {"type":"error","status":429,"error":{"type":"...","message":"..."}}
+  let code = null;
+  let detail = raw;
+  let resetsAt = null;
+  let retryAt = null;
+  const nested = safeJson(raw);
+  if (nested && typeof nested === "object") {
+    const inner = nested.error && typeof nested.error === "object" ? nested.error : nested;
+    if (typeof inner.type === "string") code = inner.type;
+    else if (typeof inner.code === "string") code = inner.code;
+    if (typeof inner.message === "string") detail = inner.message;
+    resetsAt = parseResetTimestamp(inner.resets_at ?? nested.resets_at, "absolute");
+    retryAt = parseResetTimestamp(inner.retry_after ?? nested.retry_after, "duration");
+  }
+
+  const codeKind = code ? USAGE_LIMIT_CODES.get(code.toLowerCase()) : undefined;
+  const haystack = `${detail}\n${raw}`.toLowerCase();
+  const messageHit = USAGE_LIMIT_MESSAGES.find(([phrase]) => haystack.includes(phrase));
+  // Require a verified code or a verified message template. A bare 429 status is not
+  // enough on its own — fail closed and let the run report a plain "failed".
+  if (!codeKind && !messageHit) return null;
+
+  return {
+    kind: codeKind ?? messageHit?.[1] ?? "unknown",
+    code: code ?? null,
+    source: "events.jsonl",
+    excerpt: detail || raw,
+    artifactLine,
+    resetsAt,
+    retryAt,
+  };
+}
 
 function applyFleetLane(opts, flagged) {
   if (!opts.lane) return;
@@ -386,15 +527,25 @@ function extractThreadId(event) {
   );
 }
 
-function recordEventLine(eventsPath, line) {
+function recordEventLine(eventsPath, line, scan) {
   // Append one stdout line to the event log and pull a thread id from it when the
   // line is a JSON event. Non-JSON progress lines (and a newline-less final line)
   // are preserved in events.jsonl regardless; they just carry no thread id.
+  // scan carries the run's accumulated state: the events.jsonl line number (so a
+  // classification can point at its own evidence), the latest thread id, and the
+  // usage-limit match from the terminal failure event.
   appendFileSync(eventsPath, `${line}\n`, "utf8");
-  try {
-    return extractThreadId(JSON.parse(line));
-  } catch {
-    return null;
+  scan.lineCount += 1;
+  const event = safeJson(line);
+  if (!event || typeof event !== "object") return;
+  const tid = extractThreadId(event);
+  if (tid) scan.threadId = tid;
+  if (event.type === "turn.failed") {
+    scan.limitMatch = classifyUsageLimit(event, scan.lineCount);
+  } else if (event.type === "turn.completed") {
+    // A turn that recovered and completed supersedes an earlier failure: the run did the
+    // work, so it must not be reported as limit-exhausted.
+    scan.limitMatch = null;
   }
 }
 
@@ -411,6 +562,11 @@ function prepareRunDir(opts, brief) {
     briefPath: join(outDir, "brief.txt"),
     resultPath: join(outDir, "result.json"),
   };
+  // A reused --out-dir must not advertise the previous run: a poller that races the
+  // dispatch would read the old result.json as if it were this run's, and a preflight
+  // failure or a run with no stdout would publish a finalPath for someone else's report.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
   writeFileSync(run.briefPath, brief, "utf8");
   writeFileSync(run.eventsPath, "", "utf8");
   return run;
@@ -487,7 +643,7 @@ function dispatchToCodex(opts, brief, run, writeResult, env) {
   // detached on POSIX: the child leads a new process group so killChild can fell the whole tree
   const child = spawn("codex", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32", detached: process.platform !== "win32", env });
 
-  let threadId = null;
+  const scan = { lineCount: 0, threadId: null, limitMatch: null };
   let stdoutBuf = "";
   const stderrTail = [];
 
@@ -503,8 +659,7 @@ function dispatchToCodex(opts, brief, run, writeResult, env) {
       const line = stdoutBuf.slice(0, nl);
       stdoutBuf = stdoutBuf.slice(nl + 1);
       if (!line.trim()) continue;
-      const tid = recordEventLine(run.eventsPath, line);
-      if (tid) threadId = tid;
+      recordEventLine(run.eventsPath, line, scan);
     }
   });
 
@@ -555,7 +710,7 @@ function dispatchToCodex(opts, brief, run, writeResult, env) {
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
         signal: sig,
-        threadId,
+        threadId: scan.threadId,
         finalMessage,
         touchedFiles: gitTouchedFiles(opts.cd),
         stderrTail: stderrTail.slice(-20),
@@ -578,7 +733,7 @@ function dispatchToCodex(opts, brief, run, writeResult, env) {
     if (settled) return;
     settled = true;
     clearWatchdog();
-    const result = writeResult({ status: "failed", exitCode: 1, signal: null, threadId, finalMessage: "", touchedFiles: gitTouchedFiles(opts.cd), error: String(err && err.message ? err.message : err) });
+    const result = writeResult({ status: "failed", exitCode: 1, signal: null, threadId: scan.threadId, finalMessage: "", touchedFiles: gitTouchedFiles(opts.cd), error: String(err && err.message ? err.message : err) });
     printSummary(result, run.resultPath);
     process.exit(1);
   });
@@ -591,23 +746,32 @@ function dispatchToCodex(opts, brief, run, writeResult, env) {
     // parent is down, sweep the group (no-op where taskkill already felled the tree)
     if (watchdogFired) killChild(child, "SIGKILL");
     if (stdoutBuf.trim()) {
-      const tid = recordEventLine(run.eventsPath, stdoutBuf);
-      if (tid) threadId = tid;
+      // The terminal event can arrive without a trailing newline; scan it before the
+      // outcome is decided so a final-line turn.failed still classifies.
+      recordEventLine(run.eventsPath, stdoutBuf, scan);
     }
     const finalMessage = existsSync(run.finalPath) ? readFileSync(run.finalPath, "utf8").trim() : "";
+    // Outcome precedence: a run the relay itself ended is a timeout (or, in the signal
+    // handler above, aborted) — never a classified provider failure, because the limit
+    // may simply be what codex was about to report when we killed it.
+    const limitMatch = watchdogFired ? null : scan.limitMatch;
     // A timed-out run is never a success even if codex handles SIGTERM by exiting 0 -
-    // orchestrators key off status and the relay exit code.
-    const succeeded = code === 0 && !watchdogFired;
+    // orchestrators key off status and the relay exit code. A usage limit is likewise
+    // never a success: if codex ever exits 0 while its terminal turn.failed carried a
+    // limit signature, normalize to a failure (exit 1 below) rather than report a run
+    // that did no work as completed.
+    const succeeded = code === 0 && !watchdogFired && !limitMatch;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const result = writeResult({
       status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
       exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
       signal: signal ?? null,
-      threadId,
+      threadId: scan.threadId,
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `codex did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...usageLimitFields(limitMatch),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
@@ -651,6 +815,11 @@ function printSummary(result, resultPath) {
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  codex ${result.codexVersion ?? "?"}`);
   if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a codex error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated codex (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.failureClass === "usage_limit") {
+    const when = result.limit?.retryAt || result.limit?.resetsAt;
+    lines.push(`hint: the provider refused on usage limits (${result.limit?.kind ?? "unknown"})${when ? `, earliest retry ${when}` : ""} — this is not a task failure. Do NOT rework the brief: inspect touched files first, then wait for the reset or re-dispatch the same brief on another lane from a clean tree.`);
+    if (result.limit?.evidence?.excerpt) lines.push(`  evidence (${result.limit.evidence.source}:${result.limit.evidence.artifactLine ?? "?"}): ${result.limit.evidence.excerpt}`);
+  }
   if (result.resumeLast) lines.push("mode: resumed most recent session");
   if (result.session) lines.push(`mode: resumed session ${result.session}`);
   if (result.threadId) lines.push(`thread id (resume with: --session ${result.threadId}): ${result.threadId}`);

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -89,6 +89,14 @@ Trust process state and the working tree over a progress display. Completion mea
 and `result.json` exists. Cursor's full report is the `finalMessage` field in `result.json` (also
 printed in full on stdout between the report markers).
 
+**If the result carries `failureClass: "usage_limit"`,** Cursor's provider refused on usage limits —
+the brief was never the problem, so do not rework it. Inspect `touchedFiles` first (a limit can
+strike mid-edit), then either wait for the reset in `limit.retryAt`/`limit.resetsAt` and resume the
+exact session with `--session <sessionId>`, which survives the limit, or re-dispatch the same brief
+on another lane **from a clean tree**. Detection is fail-closed, so an unrecognized limit still
+arrives as a plain `failed` — check `stderrTail` before concluding the brief was at fault. Details:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
 **Windows + hooks caveat:** if the user has Cursor hooks configured (`~/.cursor/hooks.json`, or
 Claude Code `PreToolUse` hooks, which cursor-agent imports), dispatching from a Git Bash (MSYS)
 console makes cursor-agent feed PowerShell-syntax hook wrappers to bash, so every command Cursor

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -160,3 +160,38 @@ values are quoted.
 
 The relay never commits. Cursor edits the working tree; the orchestrator reviews, re-runs the gates,
 and commits. See [review-and-land.md](review-and-land.md).
+
+## Usage limits
+
+When a run dies because the provider refused on usage limits, the result keeps
+`status: "failed"` — the status set is a closed enum orchestrators switch on — and gains two
+additive fields:
+
+- `failureClass` — `"usage_limit"`; **absent** on every other failure.
+- `limit` — `{ kind, retryAt, resetsAt, evidence }`. `kind` is `quota_exhausted` |
+  `rate_limited` | `unknown`. `retryAt`/`resetsAt` are ISO timestamps or `null` — never
+  guessed, so an ambiguous "resets 3pm" stays `null`. `evidence` is
+  `{ source, code, excerpt, artifactLine }`: a bounded excerpt plus the 1-based line of the
+  artifact it came from, so you can audit the classification instead of trusting it.
+
+A usage limit is **not a task failure**, and the two need opposite responses:
+
+- **Do not rework the brief** — nothing was wrong with it.
+- **Inspect `touchedFiles` first.** A limit can strike mid-edit, so the tree may hold partial work.
+- Wait for the reset, then resume the exact session with `--session <sessionId>` — the handle survives the limit, so partial work is not lost.
+- Or re-dispatch the same brief on another lane **from a clean tree** — rerouting on top of
+  half-applied changes duplicates or corrupts them.
+
+Classification is deliberately fail-closed: only Cursor's terminal failure is inspected, only
+against signatures verified against the real CLI or its version-pinned source and recorded in
+`test/fixtures/usage-limit/`, and anything ambiguous stays an unclassified `failed`. A missed
+classification costs you a diagnosis you can still make; a false one would tell you to wait out a
+real bug. **A limit whose signature this relay does not recognize looks like a plain `failed`** —
+check the diagnostics before concluding the brief was at fault.
+
+Precedence: a run the relay itself ended is never classified — the watchdog reports `timeout` and
+a kill reports `aborted`, even if a limit was already seen. A limit arriving with a zero exit code
+is still normalized to a failure, because a run that did no work is not a completion.
+
+The full contract, shared by every relay in this package, is in
+[`docs/relay-result-contract.md`](https://github.com/amElnagdy/delegate-skills/blob/master/docs/relay-result-contract.md).

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -178,9 +178,14 @@ A usage limit is **not a task failure**, and the two need opposite responses:
 
 - **Do not rework the brief** — nothing was wrong with it.
 - **Inspect `touchedFiles` first.** A limit can strike mid-edit, so the tree may hold partial work.
+  `touchedFiles` covers the tree under `--cd` only, so on a run that passed `--add-dir`, check
+  each of those roots yourself as well — a limit can land mid-edit there just as easily, and
+  nothing on the result will tell you it did.
 - Wait for the reset, then resume the exact session with `--session <sessionId>` — the handle survives the limit, so partial work is not lost.
 - Or re-dispatch the same brief on another lane **from a clean tree** — rerouting on top of
-  half-applied changes duplicates or corrupts them.
+  half-applied changes duplicates or corrupts them. "Clean" means every root the run could
+  write to, `--add-dir` roots included; a stale edit outside `--cd` is invisible to the check
+  you would normally trust, and the reroute applies it twice.
 
 Classification is deliberately fail-closed: only Cursor's terminal failure is inspected, only
 against signatures verified against the real CLI or its version-pinned source and recorded in

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -62,6 +62,22 @@
  *   touchedFiles (git porcelain, null if git cannot report), and paths to
  *   brief.txt, final.txt, events.jsonl, and stderr.txt.
  *
+ * Usage limits: when the run ends in cursor-agent's terminal `turn_ended` event with
+ * status "error" carrying a recognized usage-limit sentence — or, when the run emitted no
+ * successful result event, a bare `ActionRequiredError:` line on stderr carrying one — the
+ * result stays status "failed" (the status set is a closed enum orchestrators switch on)
+ * and gains two additive fields:
+ *   failureClass: "usage_limit"
+ *   limit: { kind, retryAt, resetsAt, evidence: { source, code, excerpt, artifactLine } }
+ * kind is quota_exhausted | rate_limited | unknown. cursor-agent surfaces no error code and
+ * no reset hint in its headless stream, so code is null and retryAt/resetsAt stay null —
+ * never guessed. The classification is fail-closed: only the terminal event is inspected,
+ * only against message templates verified for this CLI, and anything ambiguous stays an
+ * unclassified "failed" — `ActionRequiredError:` on its own is never enough, because the
+ * same shape carries Cursor's model-entitlement refusal, which is not a quota stop. A usage
+ * limit is not a task failure — do not rework the brief; inspect touchedFiles, then wait
+ * for the reset or re-dispatch on another lane.
+ *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `cursor-agent` binary
  * exits 127 and writes status `cursor_agent_unavailable`; otherwise the exit
@@ -89,6 +105,165 @@ const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 const SANDBOX_MODES = new Set(["enabled", "disabled"]);
 
 const IMPLEMENTER_KEY = "cursor";
+
+// Bound the evidence excerpt: a provider error can carry a very long body, and the
+// orchestrator only needs enough to audit the match. The full raw event stays in
+// events.jsonl, which evidence.artifactLine points at.
+const MAX_EVIDENCE_CHARS = 400;
+
+// cursor-agent's usage-limit signatures. Cursor surfaces NO error code, no HTTP status, and
+// no retry-after in its headless stream — the vendor's own sentence in the terminal event is
+// the entire signal — so this table holds exact message templates only. Both were captured
+// from real cursor-agent runs under the same flag set this relay uses (--print
+// --output-format stream-json --force); see test/fixtures/usage-limit/cursor.json for the
+// capture bundle and its provenance. Nothing here is inferred, and deliberately absent are
+// the substring needles "quota"/"rate limit"/"429" and the bare "ActionRequiredError:"
+// prefix: the first three appear in ordinary task prose, and the last also introduces
+// Cursor's model-entitlement refusal ("Named models unavailable ... upgrade plans to
+// continue"), which is not a quota stop and must not send an orchestrator away to wait.
+const USAGE_LIMIT_MESSAGES = [
+  // "You've hit your usage limit Get Cursor Pro for more Agent usage, unlimited Tab, and more."
+  ["you've hit your usage limit", "quota_exhausted"],
+  // "Increase limits for faster responses You're out of usage. Switch to Auto, or ask your
+  // admin to increase your limit to continue."
+  ["you're out of usage", "quota_exhausted"],
+];
+
+// cursor-agent's second transport for the same stop: a bare, non-JSON line on stderr. The
+// prefix is a structural gate, never a signature on its own (see USAGE_LIMIT_MESSAGES).
+const ACTION_REQUIRED_PREFIX = /^ActionRequiredError:\s*/;
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function boundedExcerpt(text) {
+  const flat = String(text ?? "").replace(/\s+/g, " ").trim();
+  return flat.length > MAX_EVIDENCE_CHARS ? `${flat.slice(0, MAX_EVIDENCE_CHARS)}…` : flat;
+}
+
+function parseResetTimestamp(value, mode) {
+  // Only a zoned absolute timestamp or a well-defined duration becomes a time. Anything
+  // ambiguous or localized ("resets 3pm") yields null — a guessed reset time would send
+  // the orchestrator back at the wrong moment, which is worse than reporting nothing.
+  if (value === null || value === undefined) return null;
+  if (mode === "absolute") {
+    if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/.test(value.trim())) return null;
+    const parsed = new Date(value.trim().replace(" ", "T"));
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  if (mode === "duration") {
+    const seconds = typeof value === "number" ? value : typeof value === "string" && /^\d+(\.\d+)?$/.test(value.trim()) ? Number(value) : NaN;
+    if (!Number.isFinite(seconds) || seconds <= 0 || seconds > 30 * 24 * 3600) return null;
+    return new Date(Date.now() + seconds * 1000).toISOString();
+  }
+  return null;
+}
+
+function usageLimitFields(match) {
+  // The additive half of the result contract: status stays "failed" so orchestrators that
+  // switch on the closed status enum keep working; failureClass/limit carry the detail.
+  if (!match) return {};
+  return {
+    failureClass: "usage_limit",
+    limit: {
+      kind: match.kind,
+      retryAt: match.retryAt ?? null,
+      resetsAt: match.resetsAt ?? null,
+      evidence: {
+        source: match.source,
+        code: match.code ?? null,
+        excerpt: boundedExcerpt(match.excerpt),
+        artifactLine: match.artifactLine ?? null,
+      },
+    },
+  };
+}
+
+function classifyUsageLimit(event) {
+  // Cursor-specific detector. Only `turn_ended` with status "error" — the event cursor-agent's
+  // stream ends on when a run stops, and the only status observed on a stop — is inspected. A
+  // usage limit emits no `result` envelope at all, so the terminal event is all there is; a
+  // later `turn_ended` or a successful `result` supersedes an earlier match (see the scanner).
+  // Assistant text is never inspected: a brief about rate limiting makes the model quote these
+  // very sentences mid-run, and Cursor also emits ActionRequiredError for a model-entitlement
+  // refusal that is not a quota stop.
+  if (!event || event.type !== "turn_ended") return null;
+  if (typeof event.status !== "string" || event.status.toLowerCase() !== "error") return null;
+  const detail = typeof event.error === "string" ? event.error : "";
+  if (!detail) return null;
+  const haystack = detail.toLowerCase();
+  // Require a verified message template. Cursor ships no error code, so there is no second
+  // gate to fall back on — an unrecognized sentence stays an unclassified "failed".
+  const messageHit = USAGE_LIMIT_MESSAGES.find(([phrase]) => haystack.includes(phrase));
+  if (!messageHit) return null;
+
+  // No captured cursor-agent limit transcript states a reset: no retry-after is surfaced, no
+  // reset field exists, and the only reset wording anyone reports comes from the web dashboard,
+  // not the CLI. Both stay null rather than guessed. The parse still routes through the shared
+  // helper so that if a future cursor-agent does state one, an ambiguous or localized value
+  // yields null instead of sending the orchestrator back at the wrong moment.
+  const resetsAt = parseResetTimestamp(event.resets_at, "absolute");
+  const retryAt = parseResetTimestamp(event.retry_after, "duration");
+
+  return {
+    kind: messageHit[1],
+    code: null,
+    source: "events.jsonl",
+    excerpt: detail,
+    artifactLine: null,
+    resetsAt,
+    retryAt,
+  };
+}
+
+function classifyStderrUsageLimit(lines) {
+  // The stderr half of the same stop: `ActionRequiredError: <vendor sentence>`, a bare line
+  // with no JSON around it. Consulted only after the run ended without a successful result
+  // event, and only on the LAST such line — that is the reason cursor-agent stopped on. An
+  // ActionRequiredError that is not a quota sentence ends the search rather than licensing a
+  // hunt back through the log for one that is.
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index];
+    if (!ACTION_REQUIRED_PREFIX.test(line)) continue;
+    const detail = line.replace(ACTION_REQUIRED_PREFIX, "").trim();
+    const haystack = detail.toLowerCase();
+    const messageHit = USAGE_LIMIT_MESSAGES.find(([phrase]) => haystack.includes(phrase));
+    if (!messageHit) return null;
+    return {
+      kind: messageHit[1],
+      code: null,
+      source: "stderr.txt",
+      excerpt: detail,
+      artifactLine: null,
+      resetsAt: null,
+      retryAt: null,
+    };
+  }
+  return null;
+}
+
+function locateArtifactLine(path, matches) {
+  // evidence.artifactLine must point at the real record in the artifact the match came from,
+  // so an orchestrator can audit the classification instead of trusting it. cursor-agent's
+  // stream is scanned by brace depth rather than by line (makeEventScanner), so there is no
+  // line counter to read during the run — the number is resolved from the written artifact
+  // afterwards. Searching backwards finds the terminal record, not an earlier lookalike.
+  try {
+    const lines = readFileSync(path, "utf8").split("\n");
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      if (lines[index].trim() && matches(lines[index])) return index + 1;
+    }
+  } catch {
+    // The artifact is unreadable; the bounded excerpt still stands on its own.
+  }
+  return null;
+}
+
 
 function makeEventScanner(onObject) {
   let buf = "";
@@ -541,6 +716,12 @@ function dispatchToCursor(opts, brief, run, writeResult) {
   let usage = null;
   let resultMessage = null;
   let resultIsError = false;
+  // limitMatch holds the usage-limit classification of the LATEST terminal turn; a later
+  // turn or a successful result event clears it, so a run that recovered and finished is
+  // never reported as limit-exhausted. sawSuccessfulResult additionally gates the stderr
+  // fallback below, which must not second-guess a run that closed cleanly.
+  let limitMatch = null;
+  let sawSuccessfulResult = false;
   const textChunks = [];
   const stderrTail = [];
   const scan = makeEventScanner((event) => {
@@ -554,9 +735,21 @@ function dispatchToCursor(opts, brief, run, writeResult) {
         if (part && part.type === "text" && typeof part.text === "string") textChunks.push(part.text);
       }
     }
+    if (event.type === "turn_ended") {
+      // The stream ends on turn_ended when cursor-agent stops; a usage limit emits no result
+      // envelope at all. Reassigning on every turn_ended is the supersession rule: a turn that
+      // ended some other way (or ended cleanly) drops the previous turn's match.
+      limitMatch = classifyUsageLimit(event);
+    }
     if (event.type === "result") {
       if (typeof event.result === "string") resultMessage = event.result;
       if (event.is_error === true) resultIsError = true;
+      else {
+        // Cursor reported a clean close: the run did the work, so no earlier limit-looking
+        // event may downgrade it.
+        sawSuccessfulResult = true;
+        limitMatch = null;
+      }
       if (event.usage && typeof event.usage === "object") usage = event.usage;
     }
   });
@@ -680,10 +873,25 @@ function dispatchToCursor(opts, brief, run, writeResult) {
     // a descendant that ignored SIGTERM must not outlive the timeout report: once the
     // parent is down, sweep the group (no-op where taskkill already felled the tree)
     if (watchdogFired) killChild(child, "SIGKILL");
+    // Outcome precedence: a run the relay itself ended is a timeout (or, in the signal
+    // handler above, aborted) — never a classified provider failure, because the limit may
+    // simply be what cursor-agent was about to report when we killed it. The stderr shape is
+    // consulted only as a fallback: it carries no structure, so it may speak only when the
+    // stream produced neither a limit-bearing terminal turn nor a clean close.
+    const limit = watchdogFired
+      ? null
+      : limitMatch ?? (sawSuccessfulResult ? null : classifyStderrUsageLimit(stderrTail));
+    if (limit) {
+      limit.artifactLine = limit.source === "stderr.txt"
+        ? locateArtifactLine(run.stderrPath, (line) => ACTION_REQUIRED_PREFIX.test(line))
+        : locateArtifactLine(run.eventsPath, (line) => safeJson(line)?.type === "turn_ended");
+    }
     // A timed-out run is failed even if cursor-agent handles SIGTERM by exiting 0 —
     // orchestrators key off status and the relay exit code. A result event with
-    // is_error true is failed even on exit 0.
-    const succeeded = code === 0 && !watchdogFired && !resultIsError;
+    // is_error true is failed even on exit 0. A usage limit is likewise never a success: if
+    // cursor-agent ever exits 0 while its terminal turn carried a limit signature, normalize
+    // to a failure rather than report a run that did no work as completed.
+    const succeeded = code === 0 && !watchdogFired && !resultIsError && !limit;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
     const touched = gitTouchedFiles(opts.cd);
@@ -700,6 +908,7 @@ function dispatchToCursor(opts, brief, run, writeResult) {
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `cursor-agent did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
       ...(resultIsError && !watchdogFired ? { error: "cursor-agent reported an error result (is_error: true in its result event)" } : {}),
+      ...usageLimitFields(limit),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
@@ -740,6 +949,11 @@ function printSummary(result, resultPath) {
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  cursor-agent ${result.cursorAgentVersion ?? "?"}`);
   if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a cursor-agent error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated cursor-agent (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.failureClass === "usage_limit") {
+    const when = result.limit?.retryAt || result.limit?.resetsAt;
+    lines.push(`hint: the provider refused on usage limits (${result.limit?.kind ?? "unknown"})${when ? `, earliest retry ${when}` : ""} — this is not a task failure. Do NOT rework the brief: inspect touched files first, then wait for the reset or re-dispatch the same brief on another lane from a clean tree.`);
+    if (result.limit?.evidence?.excerpt) lines.push(`  evidence (${result.limit.evidence.source}:${result.limit.evidence.artifactLine ?? "?"}): ${result.limit.evidence.excerpt}`);
+  }
   if (result.resumed) lines.push("mode: resumed an existing session");
   if (result.readOnly) lines.push("mode: read-only (plan)");
   if (result.resolvedModel) lines.push(`model: ${result.resolvedModel}${result.permissionMode ? `  ·  permission mode: ${result.permissionMode}` : ""}`);

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -724,6 +724,8 @@ function dispatchToCursor(opts, brief, run, writeResult) {
   let sawSuccessfulResult = false;
   const textChunks = [];
   const stderrTail = [];
+  // The tail of a stderr chunk that did not end on a newline, held until the rest arrives.
+  let stderrPartial = "";
   const scan = makeEventScanner((event) => {
     if (typeof event.session_id === "string") sessionId = event.session_id;
     if (event.type === "system" && event.subtype === "init") {
@@ -773,12 +775,26 @@ function dispatchToCursor(opts, brief, run, writeResult) {
   child.stderr.on("data", (chunk) => {
     process.stderr.write(chunk);
     appendFileSync(run.stderrPath, chunk);
-    const text = stderrDecoder.write(chunk);
-    for (const line of text.split("\n")) {
+    // A single stderr line can arrive split across data events, so hold the unterminated
+    // remainder and prepend it to the next chunk. Splitting each chunk on its own would tear
+    // `ActionRequiredError: You've hit your usage limit` into `ActionRequiredError: You` and
+    // `'ve hit your usage limit`: the fallback classifier reads only lines carrying the
+    // prefix, so it would find the prefix without the sentence and the sentence without the
+    // prefix, and report a real limit as an unclassified failure.
+    const parts = (stderrPartial + stderrDecoder.write(chunk)).split("\n");
+    stderrPartial = parts.pop() ?? "";
+    for (const line of parts) {
       if (line.trim()) stderrTail.push(line.trimEnd());
     }
     while (stderrTail.length > 20) stderrTail.shift();
   });
+
+  // Every reader of stderr must also see the held remainder: cursor-agent can die without a
+  // trailing newline, leaving its last — and most diagnostic — line unterminated.
+  const stderrLines = () => {
+    const held = stderrPartial.trim() ? [stderrPartial.trimEnd()] : [];
+    return [...stderrTail, ...held].slice(-20);
+  };
 
   const assembleFinal = () => {
     // Prefer the result event's own report; fall back to the assistant text
@@ -825,7 +841,7 @@ function dispatchToCursor(opts, brief, run, writeResult) {
         usage,
         finalMessage: assembleFinal(),
         touchedFiles: touched,
-        stderrTail: stderrTail.slice(-20),
+        stderrTail: stderrLines(),
         error: `the relay was killed by ${sig}; cursor-agent was terminated with it — inspect the working tree before re-dispatching`,
       };
       const result = writeResult(abortedFields);
@@ -858,7 +874,7 @@ function dispatchToCursor(opts, brief, run, writeResult) {
       usage,
       finalMessage: assembleFinal(),
       touchedFiles: touched,
-      stderrTail: stderrTail.slice(-20),
+      stderrTail: stderrLines(),
       error: String(err && err.message ? err.message : err),
     });
     printSummary(result, run.resultPath);
@@ -880,7 +896,7 @@ function dispatchToCursor(opts, brief, run, writeResult) {
     // stream produced neither a limit-bearing terminal turn nor a clean close.
     const limit = watchdogFired
       ? null
-      : limitMatch ?? (sawSuccessfulResult ? null : classifyStderrUsageLimit(stderrTail));
+      : limitMatch ?? (sawSuccessfulResult ? null : classifyStderrUsageLimit(stderrLines()));
     if (limit) {
       limit.artifactLine = limit.source === "stderr.txt"
         ? locateArtifactLine(run.stderrPath, (line) => ACTION_REQUIRED_PREFIX.test(line))
@@ -905,7 +921,7 @@ function dispatchToCursor(opts, brief, run, writeResult) {
       usage,
       finalMessage: assembleFinal(),
       touchedFiles: touched,
-      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(succeeded ? {} : { stderrTail: stderrLines() }),
       ...(watchdogFired ? { error: `cursor-agent did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
       ...(resultIsError && !watchdogFired ? { error: "cursor-agent reported an error result (is_error: true in its result event)" } : {}),
       ...usageLimitFields(limit),

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -94,6 +94,16 @@ Do not trust progress trackers over reality: a run is finished when `result.json
 process has exited. Read the working tree, not a status line. The implementer's full report is
 the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
 
+**If the result carries `failureClass: "usage_limit"`,** Grok's provider refused on usage limits —
+the brief was never the problem, so do not rework it. Inspect `touchedFiles` first (a limit can
+strike mid-edit), then either wait and resume, or re-dispatch the same brief on another lane **from
+a clean tree**. Grok reports its session id only on the `end` line, which a limit run never reaches,
+so resume that partial work with `--resume-last` unless you dispatched with an explicit `--session`.
+Grok's limit messages state no reset window, so `limit.retryAt`/`limit.resetsAt` are `null` rather
+than guessed. Detection is fail-closed, so an unrecognized limit still arrives as a plain `failed` —
+check `stderrTail` before concluding the brief was at fault. Details:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
 ### 4. Review — do not trust the self-report
 
 Grok's `result.json` includes its own summary and gate claims. **Re-verify, don't accept:**

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -169,3 +169,40 @@ Two alternatives exist if you ever want them, but the helper is the recommended 
 
 The helper never commits — by design, not omission. The robust contract is: Grok edits the working
 tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).
+
+## Usage limits
+
+When a run dies because the provider refused on usage limits, the result keeps
+`status: "failed"` — the status set is a closed enum orchestrators switch on — and gains two
+additive fields:
+
+- `failureClass` — `"usage_limit"`; **absent** on every other failure.
+- `limit` — `{ kind, retryAt, resetsAt, evidence }`. `kind` is `quota_exhausted` |
+  `rate_limited` | `unknown`. `retryAt`/`resetsAt` are ISO timestamps or `null` — never
+  guessed, so an ambiguous "resets 3pm" stays `null`. `evidence` is
+  `{ source, code, excerpt, artifactLine }`: a bounded excerpt plus the 1-based line of the
+  artifact it came from, so you can audit the classification instead of trusting it.
+
+A usage limit is **not a task failure**, and the two need opposite responses:
+
+- **Do not rework the brief** — nothing was wrong with it.
+- **Inspect `touchedFiles` first.** A limit can strike mid-edit, so the tree may hold partial work.
+- Wait, then resume with `--resume-last` — Grok reports its session id only on the `end` line, which a limit run never reaches, so there is no captured handle unless you dispatched with an explicit `--session`.
+- Or re-dispatch the same brief on another lane **from a clean tree** — rerouting on top of
+  half-applied changes duplicates or corrupts them.
+
+Classification is deliberately fail-closed: only Grok's terminal failure is inspected, only
+against signatures verified against the real CLI or its version-pinned source and recorded in
+`test/fixtures/usage-limit/`, and anything ambiguous stays an unclassified `failed`. A missed
+classification costs you a diagnosis you can still make; a false one would tell you to wait out a
+real bug. **A limit whose signature this relay does not recognize looks like a plain `failed`** —
+check the diagnostics before concluding the brief was at fault.
+
+Precedence: a run the relay itself ended is never classified — the watchdog reports `timeout` and
+a kill reports `aborted`, even if a limit was already seen. A limit arriving with a zero exit code
+is still normalized to a failure, because a run that did no work is not a completion.
+
+Grok's limit templates state no reset window, so `retryAt`/`resetsAt` are always `null` here.
+
+The full contract, shared by every relay in this package, is in
+[`docs/relay-result-contract.md`](https://github.com/amElnagdy/delegate-skills/blob/master/docs/relay-result-contract.md).

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -69,6 +69,22 @@
  *   none), touchedFiles (git porcelain, null if git can't report), and the paths
  *   to events.jsonl and final.txt.
  *
+ * Usage limits: when the run ends on Grok's terminal streaming-json `{"type":"error"}`
+ * line carrying a recognized usage-limit message template, the result stays status
+ * "failed" (the status set is a closed enum orchestrators switch on) and gains two
+ * additive fields:
+ *   failureClass: "usage_limit"
+ *   limit: { kind, retryAt, resetsAt, evidence: { source, code, excerpt, artifactLine } }
+ * kind is quota_exhausted | rate_limited | unknown. Every Grok limit template deliberately
+ * states no reset window, so retryAt/resetsAt are null — never guessed. The classification
+ * is fail-closed: only the terminal error line is inspected, only against Grok's own exact
+ * message templates (its wire carries no error code), and anything ambiguous stays an
+ * unclassified "failed". A usage limit is not a task failure — do not rework the brief;
+ * inspect touchedFiles, then wait for the reset or re-dispatch on another lane. Grok
+ * reports its session id only on the `end` line, which a limit run never reaches, so
+ * resume that partial work with --resume-last unless the run was dispatched with an
+ * explicit --session.
+ *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `grok` binary exits 127;
  * otherwise the exit code mirrors Grok's own (0 success, non-zero failure). If
@@ -83,7 +99,7 @@
 
 import { spawn, execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, writeFileSync, renameSync, readFileSync, readdirSync, existsSync, appendFileSync, lstatSync, readlinkSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, readdirSync, existsSync, appendFileSync, lstatSync, readlinkSync, openSync, readSync, closeSync, realpathSync, rmSync } from "node:fs";
 import { join, relative, resolve, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir } from "node:os";
@@ -97,6 +113,119 @@ const MAX_TIMER_MS = 2_147_483_647;
 const AUTONOMY_MODES = new Set(["workspace-write", "read-only", "full-access"]);
 
 const IMPLEMENTER_KEY = "grok";
+
+// Bound the evidence excerpt: a provider error can carry a very long body, and the
+// orchestrator only needs enough to audit the match. The full raw event stays in
+// events.jsonl, which evidence.artifactLine points at.
+const MAX_EVIDENCE_CHARS = 400;
+
+// Grok's usage-limit signatures. Grok's streaming-json wire carries no error code at all —
+// the internal ACP rate-limit code is consumed to pick the user-facing sentence and never
+// serialized — so the exact message templates ARE the signature. Each entry below is a
+// verbatim user-facing constant from xai-grok-shell's sampling/error.rs at the pinned commit
+// recorded in test/fixtures/usage-limit/grok.json; nothing here is inferred, and no template
+// for a non-xAI backend is listed because none was verified. Matched case-insensitively as
+// whole phrases with typographic apostrophes folded to ASCII — never bare "429", "quota", or
+// "rate limit", which appear in ordinary task prose. Grok separates the free-plan paywall
+// (quota exhaustion) from a transient throttle, so the kinds differ.
+const USAGE_LIMIT_MESSAGES = [
+  ["you've reached your free grok build usage limit", "quota_exhausted"],
+  ["you've hit your team's api rate limit", "rate_limited"],
+  ["you've hit the rate limit for your plan", "rate_limited"],
+];
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function boundedExcerpt(text) {
+  const flat = String(text ?? "").replace(/\s+/g, " ").trim();
+  return flat.length > MAX_EVIDENCE_CHARS ? `${flat.slice(0, MAX_EVIDENCE_CHARS)}…` : flat;
+}
+
+function parseResetTimestamp(value, mode) {
+  // Only a zoned absolute timestamp or a well-defined duration becomes a time. Anything
+  // ambiguous or localized ("resets 3pm") yields null — a guessed reset time would send
+  // the orchestrator back at the wrong moment, which is worse than reporting nothing.
+  if (value === null || value === undefined) return null;
+  if (mode === "absolute") {
+    if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/.test(value.trim())) return null;
+    const parsed = new Date(value.trim().replace(" ", "T"));
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  if (mode === "duration") {
+    const seconds = typeof value === "number" ? value : typeof value === "string" && /^\d+(\.\d+)?$/.test(value.trim()) ? Number(value) : NaN;
+    if (!Number.isFinite(seconds) || seconds <= 0 || seconds > 30 * 24 * 3600) return null;
+    return new Date(Date.now() + seconds * 1000).toISOString();
+  }
+  return null;
+}
+
+function usageLimitFields(match) {
+  // The additive half of the result contract: status stays "failed" so orchestrators that
+  // switch on the closed status enum keep working; failureClass/limit carry the detail.
+  if (!match) return {};
+  return {
+    failureClass: "usage_limit",
+    limit: {
+      kind: match.kind,
+      retryAt: match.retryAt ?? null,
+      resetsAt: match.resetsAt ?? null,
+      evidence: {
+        source: match.source,
+        code: match.code ?? null,
+        excerpt: boundedExcerpt(match.excerpt),
+        artifactLine: match.artifactLine ?? null,
+      },
+    },
+  };
+}
+
+function classifyUsageLimit(event, artifactLine) {
+  // Grok-specific detector. Only the streaming-json `{"type":"error"}` line is inspected: it is
+  // emitted from headless mode's single terminal error arm, which returns immediately after and
+  // never emits the `end` line, so it is the naturally terminal failure event. Grok's other
+  // error-shaped lines (auto-compact failure, image-compression notice) are separate event types
+  // and are deliberately not matched — "an error appeared" is never sufficient.
+  if (!event || event.type !== "error") return null;
+  const raw = typeof event.message === "string" ? event.message : "";
+  if (!raw) return null;
+
+  // Grok flattens a provider envelope into a plain sentence before it reaches this wire, but
+  // parse defensively anyway: a build that ever handed the raw body through should still be
+  // matched against its own template rather than against escaped JSON text.
+  const nested = safeJson(raw);
+  const detail = nested && typeof nested === "object" && typeof nested.message === "string" ? nested.message : raw;
+
+  // Grok's templates are typographic — they use U+2019, including mid-word in "team's" — so fold
+  // curly apostrophes on both sides. That keeps the phrase table readable and stops a purely
+  // typographic change upstream from silently disabling the matcher.
+  const haystack = `${detail}\n${raw}`.replace(/[\u2018\u2019]/g, "'").toLowerCase();
+  const messageHit = USAGE_LIMIT_MESSAGES.find(([phrase]) => haystack.includes(phrase));
+  // A verified full-sentence template is the only accepted signature. Fail closed otherwise and
+  // let the run report a plain "failed" — a false classification would tell the orchestrator not
+  // to investigate a real bug.
+  if (!messageHit) return null;
+
+  return {
+    kind: messageHit[1],
+    // Grok's error line has no code field: the ACP rate-limit code is dropped on serialization.
+    code: null,
+    source: "events.jsonl",
+    excerpt: detail || raw,
+    artifactLine,
+    // No Grok limit template states a reset window (the free-usage one promises none on purpose,
+    // because the quota window is backend-configured). Run the shared parser over whatever the
+    // line does carry rather than hard-coding null, so a field a later build adds is subject to
+    // the same never-guess rule as every other relay.
+    resetsAt: parseResetTimestamp(event.resets_at ?? event.resetsAt ?? null, "absolute"),
+    retryAt: parseResetTimestamp(event.retry_after ?? event.retryAfter ?? null, "duration"),
+  };
+}
 
 function makeEventScanner(onObject) {
   let buf = "";
@@ -745,6 +874,10 @@ function prepareRunDir(opts, brief) {
     briefPath: join(outDir, "brief.txt"),
     resultPath: join(outDir, "result.json"),
   };
+  // A reused --out-dir must not advertise the previous run: a poller that races the
+  // dispatch would read the old result.json as if it were this run's. The other
+  // artifacts are truncated by their own writes below.
+  rmSync(run.resultPath, { force: true });
   writeFileSync(run.briefPath, brief, "utf8");
   writeFileSync(run.eventsPath, "", "utf8");
   writeFileSync(run.finalPath, "", "utf8");
@@ -842,6 +975,12 @@ function dispatchToGrok(opts, run, writeResult) {
 
   let sessionId = opts.session || null;
   let usage = null;
+  let limitMatch = null;
+  // 1-based line in events.jsonl that the scanner is currently reading, so a classification can
+  // point at its own evidence. It has to be tracked out here: events.jsonl is the raw byte
+  // stream and makeEventScanner is brace-depth based, not line based, so neither one knows the
+  // line number on its own.
+  let eventLine = 1;
   const textChunks = [];
   const stderrTail = [];
 
@@ -851,7 +990,29 @@ function dispatchToGrok(opts, run, writeResult) {
     const chunk = extractTextChunk(event);
     if (chunk) textChunks.push(chunk);
     if (event.usage && typeof event.usage === "object") usage = event.usage;
+    if (event.type === "error") {
+      limitMatch = classifyUsageLimit(event, eventLine);
+    } else if (event.type === "end") {
+      // `end` is grok's success line and is never emitted after the terminal error arm. If one
+      // arrives anyway, the run did the work, so it must not be reported as limit-exhausted.
+      limitMatch = null;
+    }
   });
+
+  // Feed the scanner one line at a time so an object that completes inside a segment belongs to
+  // the line being fed. Segments can be fragments (a chunk boundary can land mid-line, mid-escape
+  // or mid-multibyte) and the last record can arrive with no trailing newline; the scanner buffers
+  // across calls either way, so splitting here changes only the line bookkeeping.
+  const feedByLine = (text) => {
+    if (!text) return;
+    let start = 0;
+    for (let nl = text.indexOf("\n"); nl !== -1; nl = text.indexOf("\n", start)) {
+      scan(text.slice(start, nl + 1));
+      eventLine += 1;
+      start = nl + 1;
+    }
+    if (start < text.length) scan(text.slice(start));
+  };
 
   // Decode across chunk boundaries: a multibyte UTF-8 character split between
   // two data events would otherwise decode as U+FFFD and corrupt the report.
@@ -860,7 +1021,7 @@ function dispatchToGrok(opts, run, writeResult) {
 
   child.stdout.on("data", (chunk) => {
     appendFileSync(run.eventsPath, chunk); // faithful raw record
-    scan(stdoutDecoder.write(chunk));
+    feedByLine(stdoutDecoder.write(chunk));
   });
 
   child.stderr.on("data", (chunk) => {
@@ -967,9 +1128,16 @@ function dispatchToGrok(opts, run, writeResult) {
     if (watchdogFired) killChild(child, "SIGKILL");
     const finalMessage = assembleFinal();
     const touchedFiles = gitTouchedFiles(opts.cd);
+    // Outcome precedence: a run the relay itself ended is a timeout (or, in the signal handler
+    // above, aborted) — never a classified provider failure, because the limit may simply be
+    // what grok was about to report when we killed it.
+    const limit = watchdogFired ? null : limitMatch;
     // A timed-out run is never a success even if grok handles SIGTERM by exiting 0 -
-    // orchestrators key off status and the relay exit code.
-    const succeeded = code === 0 && !watchdogFired;
+    // orchestrators key off status and the relay exit code. A usage limit is likewise never a
+    // success: if grok ever exits 0 while its terminal error line carried a limit signature,
+    // normalize to a failure (exit 1 below) rather than report a run that did no work as
+    // completed.
+    const succeeded = code === 0 && !watchdogFired && !limit;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const result = writeResult({
       status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
@@ -982,6 +1150,7 @@ function dispatchToGrok(opts, run, writeResult) {
       ...readOnlyFlag(),
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `grok did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...usageLimitFields(limit),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
@@ -1018,6 +1187,12 @@ function printSummary(result, resultPath) {
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  grok ${result.grokVersion ?? "?"}`);
   if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a grok error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated grok (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.failureClass === "usage_limit") {
+    const when = result.limit?.retryAt || result.limit?.resetsAt;
+    lines.push(`hint: the provider refused on usage limits (${result.limit?.kind ?? "unknown"})${when ? `, earliest retry ${when}` : ""} — this is not a task failure. Do NOT rework the brief: inspect touched files first, then wait for the reset or re-dispatch the same brief on another lane from a clean tree.`);
+    if (result.limit?.evidence?.excerpt) lines.push(`  evidence (${result.limit.evidence.source}:${result.limit.evidence.artifactLine ?? "?"}): ${result.limit.evidence.excerpt}`);
+    if (!result.sessionId) lines.push("  note: grok reports its session id only on the end event, which this run never reached — resume the partial work with --resume-last, or re-dispatch from a clean tree.");
+  }
   if (result.readOnlyViolation === null) lines.push("warning: this --read-only run could not be verified - git could not report, or a submodule or unreadable path left coverage incomplete; inspect the working tree directly.");
   if (result.readOnlyViolation === true) lines.push("warning: a git-visible change was detected during this --read-only run — grok's read-only is best-effort; review the diff before trusting the run.");
   lines.push(`autonomy: ${result.autonomy}`);

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -66,7 +66,7 @@
  */
 
 import {spawn, execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync, rmSync } from "node:fs";
 import {join, resolve, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir } from "node:os";
@@ -373,6 +373,11 @@ function prepareRunDir(opts, brief) {
     stderrPath: join(outDir, "stderr.txt"),
     resultPath: join(outDir, "result.json"),
   };
+  // A reused --out-dir must not advertise the previous run: a poller that races the
+  // dispatch would read the old result.json as if it were this run's, and a run with no
+  // report of its own would publish a finalPath holding someone else's.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
   writeFileSync(run.briefPath, brief, "utf8");
   writeFileSync(run.eventsPath, "", "utf8");
   writeFileSync(run.stderrPath, "", "utf8");

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -112,6 +112,16 @@ Do not trust progress trackers over reality: a run is finished when `result.json
 process has exited. Read the working tree, not a status line. The implementer's full report is
 the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
 
+**If the result carries `failureClass: "usage_limit"`,** the provider refused on usage limits — the
+brief was never the problem, so do not rework it. Inspect `touchedFiles` first (a limit can strike
+mid-edit), then either wait for the reset in `limit.retryAt`/`limit.resetsAt` and resume the exact
+session with `--session <sessionId>`, which survives the limit, or re-dispatch the same brief on
+another lane **from a clean tree**. Note what this does *not* cover: OpenCode retries a plain HTTP
+429 indefinitely and never forwards that status here, so ordinary throttling shows up as a stalled
+run — a `timeout` under `--timeout`, an unbounded hang without one — not as a classified failure.
+Always run with a `--timeout` for that reason. Details:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
 ### 4. Review — do not trust the self-report
 
 OpenCode's `result.json` includes its own final message and any gate claims. **Re-verify, don't accept:**

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -154,3 +154,43 @@ If you ever want it, raw `opencode run` is fine for one-offs — you just give u
 
 The helper never commits — by design, not omission. The robust contract is: OpenCode edits the working
 tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).
+
+## Usage limits
+
+When a run dies because the provider refused on usage limits, the result keeps
+`status: "failed"` — the status set is a closed enum orchestrators switch on — and gains two
+additive fields:
+
+- `failureClass` — `"usage_limit"`; **absent** on every other failure.
+- `limit` — `{ kind, retryAt, resetsAt, evidence }`. `kind` is `quota_exhausted` |
+  `rate_limited` | `unknown`. `retryAt`/`resetsAt` are ISO timestamps or `null` — never
+  guessed, so an ambiguous "resets 3pm" stays `null`. `evidence` is
+  `{ source, code, excerpt, artifactLine }`: a bounded excerpt plus the 1-based line of the
+  artifact it came from, so you can audit the classification instead of trusting it.
+
+A usage limit is **not a task failure**, and the two need opposite responses:
+
+- **Do not rework the brief** — nothing was wrong with it.
+- **Inspect `touchedFiles` first.** A limit can strike mid-edit, so the tree may hold partial work.
+- Wait for the reset, then resume the exact session with `--session <sessionId>` — the handle survives the limit, so partial work is not lost.
+- Or re-dispatch the same brief on another lane **from a clean tree** — rerouting on top of
+  half-applied changes duplicates or corrupts them.
+
+Classification is deliberately fail-closed: only OpenCode's terminal failure is inspected, only
+against signatures verified against the real CLI or its version-pinned source and recorded in
+`test/fixtures/usage-limit/`, and anything ambiguous stays an unclassified `failed`. A missed
+classification costs you a diagnosis you can still make; a false one would tell you to wait out a
+real bug. **A limit whose signature this relay does not recognize looks like a plain `failed`** —
+check the diagnostics before concluding the brief was at fault.
+
+Precedence: a run the relay itself ended is never classified — the watchdog reports `timeout` and
+a kill reports `aborted`, even if a limit was already seen. A limit arriving with a zero exit code
+is still normalized to a failure, because a run that did no work is not a completion.
+
+**What this does not cover:** OpenCode retries a plain HTTP 429 indefinitely and never forwards
+that retry status to `--format json`, so ordinary throttling *stalls* the run instead of failing it —
+`timeout` under `--timeout`, an unbounded hang without one. Only the non-retryable quota codes are
+terminal here, which is why a `--timeout` is strongly advised on every run.
+
+The full contract, shared by every relay in this package, is in
+[`docs/relay-result-contract.md`](https://github.com/amElnagdy/delegate-skills/blob/master/docs/relay-result-contract.md).

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -55,6 +55,21 @@
  *   (OpenCode's own report), touchedFiles (git porcelain, null if git can't report), and the
  *   paths to events.jsonl and final.txt.
  *
+ * Usage limits: when the run ends in OpenCode's terminal `{"type":"error"}` event carrying an
+ * APIError with a recognized usage-limit signature, the result stays status "failed" (the status
+ * set is a closed enum orchestrators switch on) and gains two additive fields:
+ *   failureClass: "usage_limit"
+ *   limit: { kind, retryAt, resetsAt, evidence: { source, code, excerpt, artifactLine } }
+ * kind is quota_exhausted | rate_limited | unknown. retryAt/resetsAt are null unless the
+ * provider stated a zoned absolute time or a well-defined duration — never guessed. The
+ * classification is fail-closed: only the terminal error event is inspected, only against
+ * provider-specific codes and message templates, and anything ambiguous stays an unclassified
+ * "failed". OpenCode itself retries an HTTP 429 indefinitely and never forwards its retry status
+ * to this stream, so the ordinary rate limit surfaces as a silently stalled run — status
+ * "timeout" under --timeout, or an unbounded hang without one — not as a classified failure.
+ * A usage limit is not a task failure — do not rework the brief; inspect touchedFiles, then wait
+ * for the reset or re-dispatch on another lane.
+ *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `opencode` binary exits 127;
  * otherwise the exit code mirrors OpenCode's own (0 success, non-zero failure).
@@ -68,7 +83,7 @@
  */
 
 import {spawn, execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync, rmSync } from "node:fs";
 import {join, resolve, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir } from "node:os";
@@ -82,6 +97,32 @@ const MAX_TIMER_MS = 2_147_483_647;
 const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
 
 const IMPLEMENTER_KEY = "opencode";
+
+// Bound the evidence excerpt: a provider error can carry a very long body, and the
+// orchestrator only needs enough to audit the match. The full raw event stays in
+// events.jsonl, which evidence.artifactLine points at.
+const MAX_EVIDENCE_CHARS = 400;
+
+// OpenCode's usage-limit signatures, pinned to opencode 1.17.11. Both entries below were read
+// out of the embedded JS bundle of the installed binary — the `parseStreamError` switch in
+// MessageV2.ProviderError, which maps a provider body code to a fixed message and hard-codes
+// `isRetryable: false` (see test/fixtures/usage-limit/opencode.json for the capture bundle and
+// its provenance); nothing here is inferred. That non-retryability is what makes these two
+// terminal at all: OpenCode retries an HTTP 429 indefinitely and never forwards its retry
+// status to `--format json` stdout, so an ordinary rate limit stalls the run instead of failing
+// it. The opencode Zen `GoUsageLimitError`/`FreeUsageLimitError` templates are deliberately NOT
+// listed — they exist only on that retry status, which this transport never emits.
+const USAGE_LIMIT_CODES = new Map([
+  ["insufficient_quota", "quota_exhausted"],
+  ["usage_not_included", "quota_exhausted"],
+]);
+
+// The exact fixed templates the same switch attaches to those codes. Matched case-insensitively
+// as whole phrases — never bare "quota"/"429"/"rate limit", which appear in ordinary task prose.
+const USAGE_LIMIT_MESSAGES = [
+  ["quota exceeded. check your plan and billing details.", "quota_exhausted"],
+  ["to use codex with your chatgpt plan, upgrade to plus", "quota_exhausted"],
+];
 
 function makeEventScanner(onObject) {
   let buf = "";
@@ -142,6 +183,105 @@ function makeEventScanner(onObject) {
       index = 0;
       start = -1;
     }
+  };
+}
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function boundedExcerpt(text) {
+  const flat = String(text ?? "").replace(/\s+/g, " ").trim();
+  return flat.length > MAX_EVIDENCE_CHARS ? `${flat.slice(0, MAX_EVIDENCE_CHARS)}…` : flat;
+}
+
+function parseResetTimestamp(value, mode) {
+  // Only a zoned absolute timestamp or a well-defined duration becomes a time. Anything
+  // ambiguous or localized ("resets 3pm") yields null — a guessed reset time would send
+  // the orchestrator back at the wrong moment, which is worse than reporting nothing.
+  if (value === null || value === undefined) return null;
+  if (mode === "absolute") {
+    if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/.test(value.trim())) return null;
+    const parsed = new Date(value.trim().replace(" ", "T"));
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  if (mode === "duration") {
+    const seconds = typeof value === "number" ? value : typeof value === "string" && /^\d+(\.\d+)?$/.test(value.trim()) ? Number(value) : NaN;
+    if (!Number.isFinite(seconds) || seconds <= 0 || seconds > 30 * 24 * 3600) return null;
+    return new Date(Date.now() + seconds * 1000).toISOString();
+  }
+  return null;
+}
+
+function usageLimitFields(match) {
+  // The additive half of the result contract: status stays "failed" so orchestrators that
+  // switch on the closed status enum keep working; failureClass/limit carry the detail.
+  if (!match) return {};
+  return {
+    failureClass: "usage_limit",
+    limit: {
+      kind: match.kind,
+      retryAt: match.retryAt ?? null,
+      resetsAt: match.resetsAt ?? null,
+      evidence: {
+        source: match.source,
+        code: match.code ?? null,
+        excerpt: boundedExcerpt(match.excerpt),
+        artifactLine: match.artifactLine ?? null,
+      },
+    },
+  };
+}
+
+function classifyUsageLimit(event, artifactLine) {
+  // OpenCode-specific detector. `opencode run --format json` forwards exactly one error shape —
+  // {"type":"error","sessionID":…,"error":{"name":…,"data":{…}}}, emitted for a session error —
+  // and that same event is what makes the run exit non-zero, so it is the terminal failure event.
+  // Only APIError carries a provider refusal: ProviderAuthError, ContextOverflowError,
+  // MessageOutputLengthError, MessageAbortedError and friends are local conditions and must never
+  // classify. Verified against opencode 1.17.11.
+  if (!event || event.type !== "error") return null;
+  const named = event.error && typeof event.error === "object" ? event.error : null;
+  if (!named || named.name !== "APIError") return null;
+  const data = named.data && typeof named.data === "object" ? named.data : {};
+  const message = typeof data.message === "string" ? data.message : "";
+  const body = typeof data.responseBody === "string" ? data.responseBody : "";
+  if (!message && !body) return null;
+
+  // responseBody is the provider's raw HTTP body; parseStreamError read its
+  // {"error":{"code":"…"}} to choose the fixed message above, so read the same field back for the
+  // code — and for whatever reset the provider happened to state alongside it.
+  let code = null;
+  let resetsAt = null;
+  let retryAt = null;
+  const nested = safeJson(body);
+  if (nested && typeof nested === "object") {
+    const inner = nested.error && typeof nested.error === "object" ? nested.error : nested;
+    if (typeof inner.code === "string") code = inner.code;
+    else if (typeof inner.type === "string") code = inner.type;
+    resetsAt = parseResetTimestamp(inner.resets_at ?? nested.resets_at, "absolute");
+    retryAt = parseResetTimestamp(inner.retry_after ?? nested.retry_after, "duration");
+  }
+
+  const codeKind = code ? USAGE_LIMIT_CODES.get(code.toLowerCase()) : undefined;
+  const haystack = `${message}\n${body}`.toLowerCase();
+  const messageHit = USAGE_LIMIT_MESSAGES.find(([phrase]) => haystack.includes(phrase));
+  // Require a verified code or a verified message template. A 4xx status, or the SDK's own
+  // isRetryable flag, is not enough on its own — fail closed and report a plain "failed".
+  if (!codeKind && !messageHit) return null;
+
+  return {
+    kind: codeKind ?? messageHit?.[1] ?? "unknown",
+    code: code ?? null,
+    source: "events.jsonl",
+    excerpt: message || body,
+    artifactLine,
+    resetsAt,
+    retryAt,
   };
 }
 
@@ -411,6 +551,11 @@ function prepareRunDir(opts, brief) {
     briefPath: join(outDir, "brief.txt"),
     resultPath: join(outDir, "result.json"),
   };
+  // A reused --out-dir must not advertise the previous run: a poller that races the
+  // dispatch would read the old result.json as if it were this run's, and a run with no
+  // report of its own would publish a finalPath holding someone else's.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
   writeFileSync(run.briefPath, brief, "utf8");
   writeFileSync(run.eventsPath, "", "utf8");
   return run;
@@ -506,8 +651,15 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
   const textParts = new Map(); // part.id -> latest text
   const textOrder = []; // part.ids in first-seen order
   const stderrTail = [];
+  // The run's accumulated classification state: how many JSON objects the scanner has seen
+  // (so a match can point at its own evidence) and the usage-limit match standing at exit.
+  const limitScan = { objectCount: 0, limitMatch: null };
 
   const scan = makeEventScanner((event) => {
+    // `opencode run --format json` writes exactly one JSON object per line (its emitter appends
+    // EOL), and events.jsonl is that stdout stream verbatim — so the running object count is the
+    // object's 1-based line number there, which is what evidence.artifactLine must point at.
+    limitScan.objectCount += 1;
     // Session id: real events carry `sessionID` (camelCase); plugin notify objects
     // carry `session_id` (snake_case). Accept either.
     const sid = event.sessionID || event.session_id;
@@ -523,6 +675,15 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
     if (event.type === "step_finish" && event.part && typeof event.part.cost === "number") {
       totalCost += event.part.cost;
       sawCost = true;
+    }
+    // Every forwarded error event replaces the standing match, so the last one before exit is
+    // the one that counts and an unrelated error clears an earlier limit. A step that finishes
+    // afterwards supersedes it entirely: the run recovered and went on doing the work, so it
+    // must not be reported as limit-exhausted.
+    if (event.type === "error") {
+      limitScan.limitMatch = classifyUsageLimit(event, limitScan.objectCount);
+    } else if (event.type === "step_finish") {
+      limitScan.limitMatch = null;
     }
   });
 
@@ -625,9 +786,16 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
     // parent is down, sweep the group (no-op where taskkill already felled the tree)
     if (watchdogFired) killChild(child, "SIGKILL");
     const finalMessage = assembleFinal();
+    // Outcome precedence: a run the relay itself ended is a timeout (or, in the signal handler
+    // above, aborted) — never a classified provider failure, because the limit may simply be
+    // what opencode was about to report when we killed it.
+    const limitMatch = watchdogFired ? null : limitScan.limitMatch;
     // A timed-out run is never a success even if opencode handles SIGTERM by exiting 0 -
-    // orchestrators key off status and the relay exit code.
-    const succeeded = code === 0 && !watchdogFired;
+    // orchestrators key off status and the relay exit code. A usage limit is likewise never a
+    // success: if opencode ever exits 0 while its terminal error event carried a limit
+    // signature, normalize to a failure (exit 1 below) rather than report a run that did no
+    // work as completed.
+    const succeeded = code === 0 && !watchdogFired && !limitMatch;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const result = writeResult({
       status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
@@ -639,6 +807,7 @@ function dispatchToOpenCode(opts, brief, run, writeResult) {
       cost: sawCost ? Number(totalCost.toFixed(6)) : null,
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `opencode did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...usageLimitFields(limitMatch),
     });
     printSummary(result, run.resultPath);
     process.exit(result.exitCode);
@@ -691,6 +860,11 @@ function printSummary(result, resultPath) {
   lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  opencode ${result.opencodeVersion ?? "?"}`);
   if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an opencode error; check host memory and re-dispatch, or split the task into smaller briefs.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated opencode (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.failureClass === "usage_limit") {
+    const when = result.limit?.retryAt || result.limit?.resetsAt;
+    lines.push(`hint: the provider refused on usage limits (${result.limit?.kind ?? "unknown"})${when ? `, earliest retry ${when}` : ""} — this is not a task failure. Do NOT rework the brief: inspect touched files first, then wait for the reset or re-dispatch the same brief on another lane from a clean tree.`);
+    if (result.limit?.evidence?.excerpt) lines.push(`  evidence (${result.limit.evidence.source}:${result.limit.evidence.artifactLine ?? "?"}): ${result.limit.evidence.excerpt}`);
+  }
   if (result.resumed) lines.push("mode: resumed existing session");
   if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
   if (typeof result.cost === "number") lines.push(`cost: $${result.cost}`);

--- a/skills/qoder-delegate/SKILL.md
+++ b/skills/qoder-delegate/SKILL.md
@@ -85,6 +85,14 @@ file contains a `status`; do not trust a progress display.
 A pre-run usage error exits 2 and writes no result. Missing `qodercli` exits 127 and writes
 `status: "qoder_unavailable"` with installation guidance.
 
+**If the result carries `failureClass: "usage_limit"`,** Qoder's provider refused on usage limits —
+the brief was never the problem, so do not rework it. Inspect `touchedFiles` first (a limit can
+strike mid-edit), then either wait for the reset in `limit.retryAt`/`limit.resetsAt` and resume the
+exact session with `--resume <sessionId>`, which survives the limit, or re-dispatch the same brief
+on another lane **from a clean tree**. Detection is fail-closed, so an unrecognized limit still
+arrives as a plain `failed` — check `qoderErrors` and `stderrTail` before concluding the brief was
+at fault. Details: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
 Native Windows relay launch is not yet verified; do not claim it until a native Windows smoke passes.
 
 ### 4. Review - do not trust the self-report

--- a/skills/qoder-delegate/references/dispatch-and-poll.md
+++ b/skills/qoder-delegate/references/dispatch-and-poll.md
@@ -117,3 +117,38 @@ qodercli --output-format stream-json --permission-mode auto \
 
 The relay spawns `qodercli` directly without a shell, never commits, and makes no network calls of its
 own. Continue with [review-and-land.md](review-and-land.md).
+
+## Usage limits
+
+When a run dies because the provider refused on usage limits, the result keeps
+`status: "failed"` — the status set is a closed enum orchestrators switch on — and gains two
+additive fields:
+
+- `failureClass` — `"usage_limit"`; **absent** on every other failure.
+- `limit` — `{ kind, retryAt, resetsAt, evidence }`. `kind` is `quota_exhausted` |
+  `rate_limited` | `unknown`. `retryAt`/`resetsAt` are ISO timestamps or `null` — never
+  guessed, so an ambiguous "resets 3pm" stays `null`. `evidence` is
+  `{ source, code, excerpt, artifactLine }`: a bounded excerpt plus the 1-based line of the
+  artifact it came from, so you can audit the classification instead of trusting it.
+
+A usage limit is **not a task failure**, and the two need opposite responses:
+
+- **Do not rework the brief** — nothing was wrong with it.
+- **Inspect `touchedFiles` first.** A limit can strike mid-edit, so the tree may hold partial work.
+- Wait for the reset, then resume the exact session with `--resume <sessionId>` — the handle survives the limit, so partial work is not lost.
+- Or re-dispatch the same brief on another lane **from a clean tree** — rerouting on top of
+  half-applied changes duplicates or corrupts them.
+
+Classification is deliberately fail-closed: only Qoder's terminal failure is inspected, only
+against signatures verified against the real CLI or its version-pinned source and recorded in
+`test/fixtures/usage-limit/`, and anything ambiguous stays an unclassified `failed`. A missed
+classification costs you a diagnosis you can still make; a false one would tell you to wait out a
+real bug. **A limit whose signature this relay does not recognize looks like a plain `failed`** —
+check the diagnostics before concluding the brief was at fault.
+
+Precedence: a run the relay itself ended is never classified — the watchdog reports `timeout` and
+a kill reports `aborted`, even if a limit was already seen. A limit arriving with a zero exit code
+is still normalized to a failure, because a run that did no work is not a completion.
+
+The full contract, shared by every relay in this package, is in
+[`docs/relay-result-contract.md`](https://github.com/amElnagdy/delegate-skills/blob/master/docs/relay-result-contract.md).

--- a/skills/qoder-delegate/scripts/relay.mjs
+++ b/skills/qoder-delegate/scripts/relay.mjs
@@ -37,6 +37,24 @@
  * write no result. Missing `qodercli` exits 127 with qoder_unavailable. Once
  * dispatched, every outcome writes a result: completed, failed, timeout,
  * aborted, or qoder_unavailable.
+ *
+ * Usage limits: when the run ends in Qoder's terminal stream-json `result` event
+ * carrying is_error and a recognized usage-limit signature, the result stays
+ * status "failed" (the status set is a closed enum orchestrators switch on) and
+ * gains two additive fields:
+ *   failureClass: "usage_limit"
+ *   limit: { kind, retryAt, resetsAt, evidence: { source, code, excerpt, artifactLine } }
+ * kind is quota_exhausted | rate_limited | unknown. retryAt/resetsAt are null
+ * unless Qoder stated a zoned absolute time or a well-defined duration - never
+ * guessed, and its terminal result event states neither today. The
+ * classification is fail-closed: only the terminal result event is inspected,
+ * only its errors[] and error_code, and only against codes and message
+ * templates verified for this CLI - Qoder's mid-run
+ * {"type":"system","subtype":"api_retry","error":"rate_limit"} events are
+ * transient 429s it retries and usually recovers from, so they never classify.
+ * Anything ambiguous stays an unclassified "failed". A usage limit is not a task
+ * failure - do not rework the brief; inspect touchedFiles, then wait for the
+ * reset or re-dispatch on another lane.
  */
 
 import {execFileSync, spawn, spawnSync } from "node:child_process";
@@ -70,6 +88,51 @@ const PERMISSION_MODES = new Set([
 ]);
 
 const IMPLEMENTER_KEY = "qoder";
+
+// Bound the evidence excerpt: a provider error can carry a very long body, and the
+// orchestrator only needs enough to audit the match. The full raw event stays in
+// events.jsonl, which evidence.artifactLine points at.
+const MAX_EVIDENCE_CHARS = 400;
+
+// Qoder's usage-limit signatures, pinned to @qoder-ai/qodercli@1.1.20. Every entry below was
+// read out of the shipped bundle's own error enum and message mapper (see
+// test/fixtures/usage-limit/qoder.json for the capture bundle and its provenance); nothing
+// here is inferred. `error_code` is that enum, carried on the terminal stream-json result
+// event. The kinds follow Qoder's own split: the codes in its terminal-quota set are spent
+// plans and drained credits, while usageLimitExceeded (113) is the per-window cap it treats
+// as retry-after-reset. Codes outside these - loginExpired (105), the BYOK custom-model codes
+// (100400/100401/100403) - are deliberately absent: they are not usage limits, and an
+// unverified signature is exactly the false positive this classification must avoid.
+const USAGE_LIMIT_CODES = new Map([
+  [110, "quota_exhausted"], // todayUsageLimitExceeded
+  [113, "rate_limited"], // usageLimitExceeded
+  [114, "quota_exhausted"], // freeTrialAccountsExceeded
+  [115, "quota_exhausted"], // freeUserQuotaLimit
+  [116, "quota_exhausted"], // teamsAdminCreditsDrainedOut
+  [117, "quota_exhausted"], // teamsMemberCreditsDrainedOut
+  [118, "quota_exhausted"], // personalCreditsDrainedOut
+  [119, "quota_exhausted"], // velaModelFreeLimitReached
+  [122, "quota_exhausted"], // billingGroupCreditsLimitReached
+]);
+
+// Exact templates from the same bundle's message-to-code mapper, matched case-insensitively
+// as whole phrases against the terminal event's errors[] only - never bare "quota", "429", or
+// "rate limit", which appear in ordinary task prose.
+const USAGE_LIMIT_MESSAGES = [
+  ["billing daily count exceeded", "quota_exhausted"], // -> todayUsageLimitExceeded
+  ["user quota exhausted", "rate_limited"], // -> usageLimitExceeded
+];
+
+// The credit-drain variants have no single template: the same mapper discriminates them by a
+// wire code token AND a marker token together. Both must be present, so no bare number and no
+// bare URL field name can match on its own.
+const USAGE_LIMIT_MARKERS = [
+  [["114", "pricingurl"], "quota_exhausted"], // freeTrialAccountsExceeded
+  [["112", "pricingurl"], "quota_exhausted"], // personalCreditsDrainedOut (wire token 112, enum 118)
+  [["116", "purchaseurl"], "quota_exhausted"], // teamsAdminCreditsDrainedOut
+  [["117", "usageurl"], "quota_exhausted"], // teamsMemberCreditsDrainedOut
+  [["122", "billing group"], "quota_exhausted"], // billingGroupCreditsLimitReached
+];
 
 function makeEventScanner(onObject) {
   let buf = "";
@@ -130,6 +193,113 @@ function makeEventScanner(onObject) {
       index = 0;
       start = -1;
     }
+  };
+}
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function boundedExcerpt(text) {
+  const flat = String(text ?? "").replace(/\s+/g, " ").trim();
+  return flat.length > MAX_EVIDENCE_CHARS ? `${flat.slice(0, MAX_EVIDENCE_CHARS)}…` : flat;
+}
+
+function parseResetTimestamp(value, mode) {
+  // Only a zoned absolute timestamp or a well-defined duration becomes a time. Anything
+  // ambiguous or localized ("resets 3pm") yields null — a guessed reset time would send
+  // the orchestrator back at the wrong moment, which is worse than reporting nothing.
+  if (value === null || value === undefined) return null;
+  if (mode === "absolute") {
+    if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/.test(value.trim())) return null;
+    const parsed = new Date(value.trim().replace(" ", "T"));
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  if (mode === "duration") {
+    const seconds = typeof value === "number" ? value : typeof value === "string" && /^\d+(\.\d+)?$/.test(value.trim()) ? Number(value) : NaN;
+    if (!Number.isFinite(seconds) || seconds <= 0 || seconds > 30 * 24 * 3600) return null;
+    return new Date(Date.now() + seconds * 1000).toISOString();
+  }
+  return null;
+}
+
+function usageLimitFields(match) {
+  // The additive half of the result contract: status stays "failed" so orchestrators that
+  // switch on the closed status enum keep working; failureClass/limit carry the detail.
+  if (!match) return {};
+  return {
+    failureClass: "usage_limit",
+    limit: {
+      kind: match.kind,
+      retryAt: match.retryAt ?? null,
+      resetsAt: match.resetsAt ?? null,
+      evidence: {
+        source: match.source,
+        code: match.code ?? null,
+        excerpt: boundedExcerpt(match.excerpt),
+        artifactLine: match.artifactLine ?? null,
+      },
+    },
+  };
+}
+
+function classifyUsageLimit(event, artifactLine) {
+  // Qoder-specific detector. Only the terminal stream-json `result` event - the one carrying
+  // is_error - is inspected. Qoder also emits {"type":"system","subtype":"api_retry",
+  // "error":"rate_limit","error_status":429} mid-run for transient 429s it retries and usually
+  // recovers from, so matching "an error-shaped event" would classify healthy runs. Verified
+  // against @qoder-ai/qodercli@1.1.20 (see test/fixtures/usage-limit/qoder.json).
+  if (!event || (event.type !== "result" && event.type !== "final")) return null;
+  if (event.is_error !== true && event.status !== "error") return null;
+
+  // errors[] is the only quota-bearing text on this transport: Qoder fills it with the raw
+  // upstream error message. The implementer's own report (event.result) is deliberately NOT
+  // searched - ordinary task prose discusses quotas, 429s, and rate limits.
+  const errors = Array.isArray(event.errors) ? event.errors.filter((entry) => typeof entry === "string") : [];
+  const detail = errors.join("\n");
+  let code = Number.isInteger(event.error_code) ? event.error_code : null;
+  if (code === null) {
+    // An errors[] entry is sometimes the provider's serialized JSON body rather than a plain
+    // sentence; recover its numeric code so the verified table below can still decide. This
+    // only supplies a candidate code - an unlisted one still classifies nothing.
+    for (const entry of errors) {
+      const nested = safeJson(entry);
+      const inner = nested && typeof nested === "object"
+        ? (nested.error && typeof nested.error === "object" ? nested.error : nested)
+        : null;
+      const nestedCode = inner ? Number(inner.code ?? inner.error_code) : Number.NaN;
+      if (Number.isInteger(nestedCode)) {
+        code = nestedCode;
+        break;
+      }
+    }
+  }
+
+  const codeKind = code === null ? undefined : USAGE_LIMIT_CODES.get(code);
+  const haystack = detail.toLowerCase();
+  const messageHit = haystack ? USAGE_LIMIT_MESSAGES.find(([phrase]) => haystack.includes(phrase)) : undefined;
+  const markerHit = haystack ? USAGE_LIMIT_MARKERS.find(([tokens]) => tokens.every((token) => haystack.includes(token))) : undefined;
+  // Require a verified error code, an exact message template, or a verified code+marker pair.
+  // A bare 429, "quota", or "rate limit" is never enough - fail closed and let the run report
+  // a plain "failed".
+  if (!codeKind && !messageHit && !markerHit) return null;
+
+  return {
+    kind: codeKind ?? messageHit?.[1] ?? markerHit?.[1] ?? "unknown",
+    code: code === null ? (markerHit?.[0][0] ?? null) : String(code),
+    source: "events.jsonl",
+    // Qoder's terminal result event states no reset and no retry field: the account's reset
+    // time lives behind its HTTP quota endpoint, which this relay never calls. These reads
+    // stay defensive - parseResetTimestamp yields null for anything missing, localized, or
+    // ambiguous, so a time appears only if a later version states an unambiguous one.
+    resetsAt: parseResetTimestamp(event.resets_at, "absolute"),
+    retryAt: parseResetTimestamp(event.retry_after, "duration"),
+    excerpt: detail || `${event.subtype ?? event.type} error_code=${code ?? "?"}`,
+    artifactLine,
   };
 }
 
@@ -464,6 +634,10 @@ function dispatch(opts, brief, run, writeResult) {
   let resultSubtype = null;
   let qoderErrors = [];
   let permissionDenials = [];
+  let limitMatch = null;
+  // 1-based line of events.jsonl currently being scanned, so a classification can point at
+  // its own evidence in the artifact the orchestrator will read.
+  let eventsLine = 1;
   const textChunks = [];
   const deltaChunks = [];
   const stderrTail = [];
@@ -503,14 +677,36 @@ function dispatch(opts, brief, run, writeResult) {
       if (event.usage && typeof event.usage === "object") usage = event.usage;
       if (Array.isArray(event.errors)) qoderErrors = event.errors;
       if (Array.isArray(event.permission_denials)) permissionDenials = event.permission_denials;
+      // A result event that is not an error supersedes any earlier match: the run did the
+      // work, so it must never be reported as limit-exhausted.
+      limitMatch = resultIsError ? classifyUsageLimit(event, eventsLine) : null;
     }
   });
   const stdoutDecoder = new StringDecoder("utf8");
   const stderrDecoder = new StringDecoder("utf8");
 
+  // Feed the scanner one events.jsonl line at a time so `eventsLine` stays in step with the
+  // artifact on disk. The scanner itself is brace-matching rather than line-based (Qoder's
+  // stream-json is not guaranteed to be one object per line), so the counter lives out here:
+  // it names the line an object's closing brace landed on, which is the line an orchestrator
+  // opens to audit a classification. A trailing fragment with no newline is still scanned, so
+  // a terminal event that arrives unterminated classifies like any other.
+  const feedStdout = (text) => {
+    if (!text) return;
+    let from = 0;
+    for (;;) {
+      const nl = text.indexOf("\n", from);
+      if (nl === -1) break;
+      scan(text.slice(from, nl + 1));
+      eventsLine += 1;
+      from = nl + 1;
+    }
+    if (from < text.length) scan(text.slice(from));
+  };
+
   child.stdout.on("data", (chunk) => {
     appendFileSync(run.eventsPath, chunk);
-    scan(stdoutDecoder.write(chunk));
+    feedStdout(stdoutDecoder.write(chunk));
   });
   child.stderr.on("data", (chunk) => {
     process.stderr.write(chunk);
@@ -605,10 +801,17 @@ function dispatch(opts, brief, run, writeResult) {
     settled = true;
     clearWatchdog();
     if (watchdogFired) killChild(child, "SIGKILL");
-    scan(stdoutDecoder.end());
+    feedStdout(stdoutDecoder.end());
     const stderrEnd = stderrDecoder.end();
     if (stderrEnd.trim()) stderrTail.push(stderrEnd.trimEnd());
-    const succeeded = code === 0 && !watchdogFired && !resultIsError;
+    // Outcome precedence: a run the relay itself ended is a timeout (or, in the signal handler
+    // above, aborted) - never a classified provider failure, because the limit may simply be
+    // what qodercli was about to report when we killed it.
+    const limit = watchdogFired ? null : limitMatch;
+    // A usage limit is never a success: if qodercli ever exits 0 while its terminal result
+    // event carried a limit signature, normalize to a failure rather than report a run that
+    // did no work as completed.
+    const succeeded = code === 0 && !watchdogFired && !resultIsError && !limit;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
     const result = writeResult({
@@ -626,6 +829,7 @@ function dispatch(opts, brief, run, writeResult) {
       touchedFiles: gitTouchedFiles(opts.cd),
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
       ...(watchdogFired ? { error: `qodercli did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...usageLimitFields(limit),
     });
     printSummary(result, run.resultPath);
     process.exit(exitCode);
@@ -639,6 +843,11 @@ function printSummary(result, resultPath) {
   ];
   if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed qodercli (commonly an OOM killer or supervisor timeout); check host memory and inspect the working tree before re-dispatching.");
   if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated qodercli; relay watchdogs and relay signals report timeout or aborted instead.");
+  if (result.failureClass === "usage_limit") {
+    const when = result.limit?.retryAt || result.limit?.resetsAt;
+    lines.push(`hint: Qoder refused on usage limits (${result.limit?.kind ?? "unknown"})${when ? `, earliest retry ${when}` : ""} - this is not a task failure. Do NOT rework the brief: inspect touched files first, then wait for the reset or re-dispatch the same brief on another lane from a clean tree.`);
+    if (result.limit?.evidence?.excerpt) lines.push(`  evidence (${result.limit.evidence.source}:${result.limit.evidence.artifactLine ?? "?"}): ${result.limit.evidence.excerpt}`);
+  }
   if (result.resumed) lines.push("mode: resumed an existing session");
   if (result.actualModel) lines.push(`model: ${result.actualModel}`);
   if (result.contextWindow) lines.push(`context window requested: ${result.contextWindow}`);

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -70,6 +70,90 @@ if (process.env.SMOKE_GIT_RENAME_FROM && process.env.SMOKE_GIT_RENAME_TO) {
     "mv", "-f", process.env.SMOKE_GIT_RENAME_FROM, process.env.SMOKE_GIT_RENAME_TO,
   ]);
 }
+if (process.env.SMOKE_MODE === "agy-usage-preflight") {
+  // agy's headless quota query and the dispatch that follows it are two invocations of the
+  // same binary inside one relay run, so one mode serves both. SMOKE_USAGE_MODE drives the
+  // query; anything else is the dispatch, which must NOT happen when the query says the
+  // account is exhausted — SMOKE_ARGS_FILE existing is the proof that it did.
+  if (args.includes("/usage")) {
+    const usageMode = process.env.SMOKE_USAGE_MODE || "healthy";
+    if (usageMode === "hang") Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+    if (usageMode === "fail") {
+      console.error("Error: fake usage query failure");
+      process.exit(2);
+    }
+    if (usageMode === "unparseable") {
+      console.log(JSON.stringify({ conversation_id: "", status: "SUCCESS", num_turns: 0, command: { name: "model", data: {} } }));
+      process.exit(0);
+    }
+    const spent = usageMode === "exhausted";
+    const bucket = (id, name, window, remaining, reset) =>
+      ({ id, name, window, remaining_fraction: remaining, reset_time: reset });
+    console.log(JSON.stringify({
+      conversation_id: "",
+      status: "SUCCESS",
+      response: "",
+      duration_seconds: 0,
+      num_turns: 0,
+      usage: { input_tokens: 0, output_tokens: 0, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 0 },
+      command: {
+        name: "usage",
+        data: {
+          groups: [
+            { name: "Gemini Models", buckets: [
+              bucket("gemini-weekly", "Weekly Limit Remaining", "weekly", spent ? 0 : 0.9833731055259705, "2026-08-18T20:59:10Z"),
+              bucket("gemini-5h", "5 Hour Limit Remaining", "5h", spent ? 0 : 1, "2026-08-13T22:04:33Z"),
+            ] },
+            // The healthy case deliberately leaves this one at zero: a single exhausted
+            // bucket must NOT block a dispatch, only every bucket at once may.
+            { name: "Claude and GPT models", buckets: [
+              bucket("3p-weekly", "Weekly Limit Remaining", "weekly", spent ? 0 : 0.5, "2026-08-17T09:30:00Z"),
+              bucket("3p-5h", "5 Hour Limit Remaining", "5h", 0, "2026-08-13T21:15:00Z"),
+            ] },
+          ],
+        },
+      },
+    }));
+    process.exit(0);
+  }
+  if (process.env.SMOKE_ARGS_FILE) fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
+  const logAt = args.indexOf("--log-file");
+  if (logAt !== -1) fs.writeFileSync(args[logAt + 1], "fake agy log\n");
+  console.log("fake agy dispatch completed");
+  process.exit(0);
+}
+if (process.env.SMOKE_MODE === "usage-limit") {
+  // Replay a usage-limit capture bundle (test/fixtures/usage-limit/<cli>.json) transport
+  // faithfully: the real event ordering, the real exit code, and — when asked — chunk
+  // boundaries that split a line mid-signature and a final record with no trailing
+  // newline. One mode serves every relay; the bundle and scenario say which CLI and case.
+  const bundle = JSON.parse(fs.readFileSync(process.env.SMOKE_LIMIT_FIXTURE, "utf8"));
+  const scenario = bundle.scenarios[process.env.SMOKE_LIMIT_SCENARIO];
+  if (!scenario) {
+    fs.writeSync(2, `fake-cli: unknown usage-limit scenario ${process.env.SMOKE_LIMIT_SCENARIO}\n`);
+    process.exit(99);
+  }
+  const fd = process.env.SMOKE_LIMIT_STREAM === "stderr" ? 2 : 1;
+  const lines = scenario.events;
+  let payload = lines.join("\n");
+  // Default to a trailing newline; the no-newline variant proves the relay still scans a
+  // terminal event that arrives unterminated.
+  if (process.env.SMOKE_LIMIT_NO_TRAILING_NEWLINE !== "1") payload += "\n";
+  if (process.env.SMOKE_LIMIT_SPLIT === "1") {
+    // Deliberately awkward chunk size: lands mid-token, mid-JSON-escape, and mid-multibyte.
+    const buf = Buffer.from(payload, "utf8");
+    for (let i = 0; i < buf.length; i += 7) fs.writeSync(fd, buf.subarray(i, i + 7));
+  } else {
+    fs.writeSync(fd, payload);
+  }
+  if (process.env.SMOKE_LIMIT_HANG === "1") {
+    // Emit the limit signature, then never exit: lets the matrix drive the precedence
+    // cases where the relay itself ends the run (watchdog timeout, orchestrator kill),
+    // which must outrank any classification.
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+  }
+  process.exit(scenario.exitCode);
+}
 if (process.env.SMOKE_MODE === "aider-success") {
   fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
   // Mentions OPENAI_API_KEY in prose so a bare-substring matcher would false-fail.

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -142,7 +142,16 @@ if (process.env.SMOKE_MODE === "usage-limit") {
   if (process.env.SMOKE_LIMIT_SPLIT === "1") {
     // Deliberately awkward chunk size: lands mid-token, mid-JSON-escape, and mid-multibyte.
     const buf = Buffer.from(payload, "utf8");
-    for (let i = 0; i < buf.length; i += 7) fs.writeSync(fd, buf.subarray(i, i + 7));
+    // Back-to-back writes are coalesced by the pipe, so the reader normally sees one `data`
+    // event no matter how small the writes were — which silently makes a chunk-boundary test
+    // prove nothing. SMOKE_LIMIT_SPLIT_DELAY_MS pauses between writes so each one lands as
+    // its own `data` event, which is what a reader that fails to buffer partial lines needs
+    // in order to actually break.
+    const delayMs = Number(process.env.SMOKE_LIMIT_SPLIT_DELAY_MS || 0);
+    for (let i = 0; i < buf.length; i += 7) {
+      fs.writeSync(fd, buf.subarray(i, i + 7));
+      if (delayMs > 0) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+    }
   } else {
     fs.writeSync(fd, payload);
   }

--- a/test/fixtures/fake-cli.cs
+++ b/test/fixtures/fake-cli.cs
@@ -30,6 +30,27 @@ class FakeCli {
     }
     var writeFile = Environment.GetEnvironmentVariable("SMOKE_WRITE_FILE");
     if (!String.IsNullOrEmpty(writeFile)) File.WriteAllText(writeFile, "written by fake cli\n");
+    // Usage-limit replay, so the qoder row of test/relay/usage-limit.mjs runs on Windows too.
+    // The whole scenario is driven by SMOKE_LIMIT_* env vars and reads no arguments, so this
+    // fake defers to the fake-cli.cjs sitting beside it rather than re-reading the capture
+    // bundle itself: a hand-rolled JSON reader here would be a second source of truth for the
+    // things these scenarios exist to prove — chunk boundaries, the missing trailing newline,
+    // the bundle's exit code — and any drift would surface as a Windows-only failure nobody
+    // could reproduce. What this exe exists to provide is the native process boundary, and
+    // that is unchanged: the relay still launches a real .exe with no shell in between.
+    if (mode == "usage-limit") {
+      var cjs = Path.Combine(Path.GetDirectoryName(typeof(FakeCli).Assembly.Location), "fake-cli.cjs");
+      var replay = new ProcessStartInfo {
+        FileName = Environment.GetEnvironmentVariable("SMOKE_NODE"),
+        Arguments = "\"" + cjs + "\"",
+        // No redirection: the child inherits this process's handles, so the relay reads the
+        // replayed bytes exactly as written, in the same chunks.
+        UseShellExecute = false,
+      };
+      var replayer = Process.Start(replay);
+      replayer.WaitForExit();
+      return replayer.ExitCode;
+    }
     if (mode == "aider-success") {
       File.WriteAllLines(Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE"), args);
       Console.WriteLine("Applied the edit and updated docs to explain OPENAI_API_KEY setup.");

--- a/test/fixtures/usage-limit/codex.json
+++ b/test/fixtures/usage-limit/codex.json
@@ -71,7 +71,7 @@
     },
 
     "usageLimitRetryAfter": {
-      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "rate_limited", "retryAtIsSet": true },
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "rate_limited", "retryAtIsSet": true, "retryAfterSeconds": 120 },
       "exitCode": 1,
       "events": [
         "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-aaaa-7a02-8eea-e271ee1b2c90\"}",

--- a/test/fixtures/usage-limit/codex.json
+++ b/test/fixtures/usage-limit/codex.json
@@ -1,0 +1,190 @@
+{
+  "schema": "delegate-usage-limit-capture.v1",
+  "cli": "codex",
+  "binary": "codex",
+  "version": "codex-cli 0.147.0",
+  "platform": "aarch64-apple-darwin",
+  "capturedAt": "2026-08-13",
+
+  "provenance": {
+    "state": "source-backed; live run pending",
+    "envelope": "live-captured",
+    "envelopeMethod": "Forced a terminal failure against the installed CLI without exhausting an account: `codex exec --json --sandbox read-only -m definitely-not-a-real-model-xyz \"say hi\"`. The event sequence, the turn.failed shape, the nested-JSON provider envelope inside error.message, and the exit code below are transcribed from that run. The `unrelatedFailure` scenario is that capture verbatim.",
+    "signature": "source-backed",
+    "signatureMethod": "Error codes and user-facing message templates read from the string table of the shipped binary at ~/.codex/packages/standalone/releases/0.147.0-aarch64-apple-darwin/bin/codex (`strings -n 6`). Occurrence counts recorded per signature below; codes with zero occurrences were excluded.",
+    "liveLimitRun": "pending — no account was exhausted to produce this bundle, so the usage-limit scenario composes the live-captured envelope with source-backed codes rather than transcribing one real limit run",
+    "excludedCandidates": [
+      { "code": "rate_limit_exceeded", "occurrences": 0, "reason": "absent from this binary — matching it would be an invented signature" },
+      { "code": "insufficient_quota", "occurrences": 0, "reason": "absent from this binary; it is an OpenAI platform-API code, not one this CLI emits" }
+    ]
+  },
+
+  "transport": {
+    "stream": "stdout",
+    "flag": "--json",
+    "framing": "JSONL — one JSON object per line; the final line may arrive without a trailing newline",
+    "terminalFailureEvent": "turn.failed",
+    "terminalFailureField": "error.message",
+    "terminalSuccessEvent": "turn.completed",
+    "observedExitCodeOnTurnFailed": 1,
+    "warningsAreNotTerminal": "Verified in live runs: `item.completed` items of type \"error\" AND a top-level {\"type\":\"error\"} event both occur in runs that go on to complete successfully (e.g. model-metadata fallback, shortened skill descriptions). Neither is terminal. A matcher keyed on \"an error event\" would classify healthy runs — only turn.failed is terminal."
+  },
+
+  "signatures": {
+    "codes": [
+      { "code": "usage_limit_exceeded", "kind": "quota_exhausted", "occurrences": 7 },
+      { "code": "usage_limit_reached", "kind": "quota_exhausted", "occurrences": 12 },
+      { "code": "rate_limit_reached", "kind": "quota_exhausted", "occurrences": 26, "note": "Codex calls its plan quota a rate limit internally (cf. rate_limit_resets, rate_limit_reset_credits), so this is quota exhaustion, not transient throttling." },
+      { "code": "workspace_owner_usage_limit_reached", "kind": "quota_exhausted", "occurrences": 11 },
+      { "code": "workspace_member_usage_limit_reached", "kind": "quota_exhausted", "occurrences": 11 },
+      { "code": "workspace_owner_credits_depleted", "kind": "quota_exhausted", "occurrences": 11 },
+      { "code": "workspace_member_credits_depleted", "kind": "quota_exhausted", "occurrences": 11 },
+      { "code": "rate_limit_error", "kind": "rate_limited", "occurrences": 2 }
+    ],
+    "messages": [
+      { "phrase": "you've hit your usage limit", "kind": "quota_exhausted" },
+      { "phrase": "you've reached your usage limit", "kind": "quota_exhausted" },
+      { "phrase": "usage limit reached", "kind": "quota_exhausted" },
+      { "phrase": "you've reached your workspace credit limit", "kind": "quota_exhausted" },
+      { "phrase": "you're out of credits", "kind": "quota_exhausted" },
+      { "phrase": "your workspace is out of credits", "kind": "quota_exhausted" }
+    ],
+    "resetFields": [
+      { "field": "resets_at", "mode": "absolute", "occurrences": 19 },
+      { "field": "retry_after", "mode": "duration", "occurrences": 7 }
+    ]
+  },
+
+  "hardening": ["bare429UnknownCode", "proseInTerminalMessage", "realCodeButNonTerminal", "absurdRetryAfter"],
+
+  "scenarios": {
+    "usageLimit": {
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "resetsAt": "2026-08-13T21:00:00.000Z" },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-7a89-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"error\",\"message\":\"Skill descriptions were shortened to fit the skills context budget.\"}}",
+        "{\"type\":\"error\",\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":429,\\\"error\\\":{\\\"type\\\":\\\"usage_limit_reached\\\",\\\"message\\\":\\\"You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits\\\",\\\"resets_at\\\":\\\"2026-08-13T21:00:00Z\\\"}}\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":429,\\\"error\\\":{\\\"type\\\":\\\"usage_limit_reached\\\",\\\"message\\\":\\\"You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits\\\",\\\"resets_at\\\":\\\"2026-08-13T21:00:00Z\\\"}}\"}}"
+      ]
+    },
+
+    "usageLimitRetryAfter": {
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "rate_limited", "retryAtIsSet": true },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-aaaa-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":429,\\\"error\\\":{\\\"type\\\":\\\"rate_limit_error\\\",\\\"message\\\":\\\"Too many requests, slow down.\\\",\\\"retry_after\\\":120}}\"}}"
+      ]
+    },
+
+    "usageLimitAmbiguousReset": {
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAt": null, "resetsAt": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-bbbb-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"You've hit your usage limit for the week. Resets 3pm tomorrow.\"}}"
+      ]
+    },
+
+    "unrelatedFailure": {
+      "note": "Live capture, verbatim. Must stay an unclassified failure.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-7a89-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"error\",\"message\":\"Model metadata for `definitely-not-a-real-model-xyz` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.\"}}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"error\",\"message\":\"Skill descriptions were shortened to fit the skills context budget. Codex can still see every skill, but some descriptions are shorter. Disable unused skills or plugins to leave more room for the rest.\"}}",
+        "{\"type\":\"error\",\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":400,\\\"error\\\":{\\\"type\\\":\\\"invalid_request_error\\\",\\\"message\\\":\\\"The 'definitely-not-a-real-model-xyz' model is not supported when using Codex with a ChatGPT account.\\\"}}\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":400,\\\"error\\\":{\\\"type\\\":\\\"invalid_request_error\\\",\\\"message\\\":\\\"The 'definitely-not-a-real-model-xyz' model is not supported when using Codex with a ChatGPT account.\\\"}}\"}}"
+      ]
+    },
+
+    "proseThenUnrelatedFailure": {
+      "note": "Adversarial: every trigger word appears in NON-terminal events (the agent discussing usage limits, and a warning), then the run dies of something else. Must stay unclassified.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-cccc-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"I added a rate limit handler for HTTP 429. When you've hit your usage limit the middleware now returns usage_limit_reached with resets_at.\"}}",
+        "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"error\",\"message\":\"You've hit your usage limit. Upgrade to Pro to continue.\"}}",
+        "{\"type\":\"error\",\"message\":\"rate_limit_reached\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":500,\\\"error\\\":{\\\"type\\\":\\\"internal_server_error\\\",\\\"message\\\":\\\"The server had an error while processing your request.\\\"}}\"}}"
+      ]
+    },
+
+    "recoveredThenSuccess": {
+      "note": "A limit-looking terminal failure superseded by a later completed turn, plus the top-level error event that real successful runs emit. Must be a clean completion.",
+      "expect": { "status": "completed", "failureClass": null },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-dddd-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":429,\\\"error\\\":{\\\"type\\\":\\\"rate_limit_reached\\\",\\\"message\\\":\\\"You've hit your usage limit.\\\"}}\"}}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"error\",\"message\":\"Skill descriptions were shortened to fit the skills context budget.\"}",
+        "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"ok\"}}",
+        "{\"type\":\"turn.completed\"}"
+      ]
+    },
+
+    "bare429UnknownCode": {
+      "note": "Hardening: a 429 whose code is not in the verified table. Bare status is never enough.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-1111-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":429,\\\"error\\\":{\\\"type\\\":\\\"some_unknown_throttle\\\",\\\"message\\\":\\\"Slow down please.\\\"}}\"}}"
+      ]
+    },
+
+    "proseInTerminalMessage": {
+      "note": "Hardening: the TERMINAL message itself carries every trigger word as ordinary task prose. The strongest false-positive case — a naive substring matcher fails here.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-2222-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"Task failed: the rate limit middleware test hit a quota assertion and returned 429.\"}}"
+      ]
+    },
+
+    "realCodeButNonTerminal": {
+      "note": "Hardening: a genuine usage-limit code in the top-level error event that real runs emit even on success, with no matching terminal failure. Must not classify.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-3333-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"error\",\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":429,\\\"error\\\":{\\\"type\\\":\\\"usage_limit_reached\\\",\\\"message\\\":\\\"You've hit your usage limit.\\\"}}\"}"
+      ]
+    },
+
+    "absurdRetryAfter": {
+      "note": "Hardening: an out-of-range retry_after (≈3 years) must classify but refuse the time rather than invent a plausible-looking one.",
+      "expect": { "status": "failed", "failureClass": "usage_limit", "retryAt": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-4444-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"error\\\":{\\\"type\\\":\\\"rate_limit_error\\\",\\\"message\\\":\\\"wait\\\",\\\"retry_after\\\":99999999}}\"}}"
+      ]
+    },
+
+    "usageLimitExitZero": {
+      "note": "Defensive: never observed (this CLI exits 1 on turn.failed), but a limit must never be reported as a completed run.",
+      "expect": { "status": "failed", "failureClass": "usage_limit", "exitCode": 1 },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-eeee-7a02-8eea-e271ee1b2c90\"}",
+        "{\"type\":\"turn.started\"}",
+        "{\"type\":\"turn.failed\",\"error\":{\"message\":\"{\\\"type\\\":\\\"error\\\",\\\"status\\\":429,\\\"error\\\":{\\\"type\\\":\\\"usage_limit_exceeded\\\",\\\"message\\\":\\\"You've hit your usage limit.\\\"}}\"}}"
+      ]
+    }
+  }
+}

--- a/test/fixtures/usage-limit/codex.json
+++ b/test/fixtures/usage-limit/codex.json
@@ -59,7 +59,7 @@
 
   "scenarios": {
     "usageLimit": {
-      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "resetsAt": "2026-08-13T21:00:00.000Z" },
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "resetsAt": "2026-08-13T21:00:00.000Z", "artifactLine": 5 },
       "exitCode": 1,
       "events": [
         "{\"type\":\"thread.started\",\"thread_id\":\"019ff870-7a89-7a02-8eea-e271ee1b2c90\"}",

--- a/test/fixtures/usage-limit/cursor.json
+++ b/test/fixtures/usage-limit/cursor.json
@@ -124,6 +124,19 @@
         "{\"type\":\"system\",\"subtype\":\"init\",\"apiKeySource\":\"login\",\"session_id\":\"7ab0c318-6f21-4d9c-8e05-13b7c2a4de60\",\"model\":\"auto\",\"permissionMode\":\"default\"}",
         "{\"type\":\"turn_ended\",\"status\":\"error\",\"error\":\"Increase limits for faster responses You're out of usage. Switch to Auto, or ask your admin to increase your limit to continue.\"}"
       ]
+    },
+    "usageLimitStderrFallback": {
+          "note": "The secondary stream the transport block describes: the same stop surfaced as a bare, non-JSON `ActionRequiredError:` line on stderr, with stdout emitting neither a limit-bearing turn_ended nor a result envelope. Sentence copied verbatim from signatures.messages[0].template, whose sourceRef already records a captured stderr log. Driven from test/relay/cursor.mjs (not the shared matrix, which is one stream per relay), both whole and split across chunk boundaries — the split case is the regression: a line torn mid-sentence used to leave the prefix and the sentence in separate stderr entries, and the fallback classifier saw neither whole.",
+          "expect": {
+                "status": "failed",
+                "failureClass": "usage_limit",
+                "kind": "quota_exhausted",
+                "source": "stderr.txt"
+          },
+          "exitCode": 1,
+          "events": [
+                "ActionRequiredError: You've hit your usage limit Get Cursor Pro for more Agent usage, unlimited Tab, and more."
+          ]
     }
   },
 

--- a/test/fixtures/usage-limit/cursor.json
+++ b/test/fixtures/usage-limit/cursor.json
@@ -1,0 +1,134 @@
+{
+  "schema": "delegate-usage-limit-capture.v1",
+  "cli": "cursor",
+  "binary": "cursor-agent",
+  "version": "cursor-agent 2026.07.17-3e2a980",
+  "platform": "Windows 11 + WSL Ubuntu-22.04 (the platform the signature capture was made on)",
+  "capturedAt": "2026-07-22",
+
+  "provenance": {
+    "state": "source-backed; live run pending",
+    "envelope": "source-backed",
+    "envelopeMethod": "cursor-agent is NOT installed on the machine that produced this bundle (`command -v cursor-agent` exits 1; no binary under ~/.local/bin, no npm global package), so no envelope was captured here and no CLI was run. The `turn_ended` terminal shape is transcribed from github.com/paulocorcino/ralphy @ d7859a9c5655e7a8154873f9f1cec3f1a83f98ca — crates/ralphy-agent-cursor/fixtures/usage-limit-2026-07-21.jsonl (the whole file, 139 bytes: one turn_ended record) and the tail of fixtures/usage-limit-midturn-2026-07-21.jsonl. It is parsed there at crates/ralphy-agent-cursor/src/outcome.rs:221-232 (the (\"turn_ended\", _) arm) and asserted by the tests `a_turn_ended_in_error_carries_the_vendors_reason` (outcome.rs:568) and `a_quota_stop_is_a_limit_with_no_reset_hint` (outcome.rs:611-629). The flags that produced it (crates/ralphy-agent-cursor/src/command.rs:135-141: `-p --model <m> --force --output-format stream-json`) are the same set this relay passes. The surrounding `system`/`init`, `assistant`, and `result` records are this relay's own documented stream contract (skills/cursor-delegate/scripts/relay.mjs event handling, and test/fixtures/fake-cli.cjs `cursor-success`); session ids and file names in the scenarios below are synthesized placeholders, since captures are redacted.",
+    "signature": "source-backed",
+    "signatureMethod": "Two exact vendor sentences, from two independent third-party implementations that measured this same headless transport. cursor-agent ships as a closed-source prebuilt binary with no upstream source repo, so third-party captures are the strongest provenance available short of exhausting an account. (1) The Free-tier sentence is byte-exact from ralphy's fixtures/usage-limit-stderr-2026-07-22.log (verified with `od -c`: single space between 'limit' and 'Get', trailing newline), include_str!'d as USAGE_LIMIT_STDERR at outcome.rs:396 and asserted by `the_bare_stderr_quota_shape_is_a_limit` (outcome.rs:661); measurement conditions in ralphy docs/evidence/251-cursor-capstone-live.md:103-107 and docs/adr/0042-cursor-validation.md:139-144 (cursor-agent 2026.07.17-3e2a980, Free tier, exit 1, no reset hint, no result envelope). The same sentence is the `error` field of the stdout turn_ended fixture. (2) The Pro/premium-pool sentence is quoted verbatim in github.com/agent-tools-org/ai-dispatch @ cdc46cbb8b263eb7aedbc57b33526606a56b65df — src/rate_limit_signatures.rs:110-116, annotated 'cursor premium pool spent, captured 2026-08-07 on t-dfc23e80, t-b38df7a8 and t-d6fef491', with the transport described at src/agent/cursor.rs:384-390 and the flags at src/agent/cursor.rs:106-121 (`-p --output-format stream-json`).",
+    "liveLimitRun": "pending — no cursor-agent install and no account was exhausted to produce this bundle, so every line below is transcribed from the third-party captures named above rather than from a run made by this repository. Nothing here is marked live-captured.",
+    "excludedCandidates": [
+      {
+        "candidate": "quota exceeded for this workspace",
+        "reason": "Weakest of the four candidates found. It appears in ai-dispatch (src/rate_limit_signatures.rs:108-109) as a lowercase substring needle for a workspace quota, not as a captured full message template, and — unlike its neighbours in the same file — it carries no capture-ID annotation. Matching a bare fragment containing 'quota' is exactly the false positive this classification must avoid."
+      },
+      {
+        "candidate": "Your usage limits will reset when your monthly cycle ends on x/x/xxx",
+        "reason": "docs-only. It comes from a forum report (forum.cursor.com/t/cursor-agent-cli-limit-hit/128577, cursor-agent 2025.08.09-d8191f3) and was never reproduced in any captured headless transcript. It is the only reset wording anyone attributes to Cursor, so the relay parses NO reset at all rather than guessing from an unverified template."
+      },
+      {
+        "candidate": "ActionRequiredError: (the bare prefix)",
+        "reason": "Structural gate only, never a signature. The identical prefix carries Cursor's model-entitlement refusal — 'ActionRequiredError: Named models unavailable Free plans can only use Auto. Switch to Auto or upgrade plans to continue.' (ralphy fixtures/model-entitlement-2026-07-21.err; independently corroborated at github.com/agnt-gg/agnt — backend/src/services/ai/CursorCliService.js:50-62, whose comment records that conflating the two 'sent anyone debugging it looking for a quota that was never the problem'). That refusal is the unrelatedFailure scenario below."
+      },
+      {
+        "candidate": "429 / \"rate limit\" / \"quota\" / \"limit\"",
+        "reason": "Never surfaced by this transport at all — cursor-agent exposes no HTTP status, no error code, and no retry-after in stream-json — and each appears in ordinary task prose. See the proseThenUnrelatedFailure scenario."
+      }
+    ]
+  },
+
+  "transport": {
+    "stream": "stdout",
+    "flag": "--print --output-format stream-json",
+    "framing": "JSONL — one JSON object per line. The relay scans stdout by brace depth rather than by line, so a final record without a trailing newline still parses; events.jsonl receives the raw bytes verbatim either way.",
+    "terminalFailureEvent": "turn_ended with status \"error\"",
+    "terminalFailureField": "error (a plain vendor sentence — no code, no status, no retry-after)",
+    "terminalSuccessEvent": "result with is_error false",
+    "observedExitCodeOnUsageLimit": 1,
+    "noResultEnvelopeOnLimit": "A usage-limit stop emits NO result envelope: the stream ends on turn_ended (ralphy outcome.rs:594 asserts !fold.saw_envelope). The relay therefore cannot key the limit off is_error, and the exit code alone would report only an unclassified failure.",
+    "secondaryStream": "stderr — the same stop can also surface as a bare, non-JSON `ActionRequiredError: <vendor sentence>` line. The relay consults it only when the stream produced neither a limit-bearing turn_ended nor a clean result envelope. Not exercised by the scenarios below, which are all stdout.",
+    "warningsAreNotTerminal": "Assistant text is never inspected: a brief about rate limiting makes the model quote these exact sentences mid-run, and ralphy pins the same requirement with `a_quoted_quota_sentence_in_a_green_transcript_is_not_a_limit` (outcome.rs:708-714). `ActionRequiredError:` is likewise not terminal evidence on its own — see excludedCandidates.",
+    "noStructuredCode": "There is no numeric code, no surfaced HTTP 429, no `code` field, and no retry-after anywhere in this transport, so evidence.code is always null and the matcher has no second gate to fall back on when a sentence drifts: an unrecognized sentence stays an unclassified failed.",
+    "twoPools": "Cursor bills the Auto pool and the named/API-model pool separately, so a limit on named models can leave `--model auto` working (ai-dispatch src/rate_limit_signatures.rs:114-116; agnt CursorCliService.js:50-62). A usage_limit result is not necessarily a whole-implementer outage."
+  },
+
+  "signatures": {
+    "codes": [],
+    "codesNote": "cursor-agent emits no error codes in this transport; the message templates below are the only signature.",
+    "messages": [
+      {
+        "phrase": "you've hit your usage limit",
+        "kind": "quota_exhausted",
+        "template": "You've hit your usage limit Get Cursor Pro for more Agent usage, unlimited Tab, and more.",
+        "tier": "Free",
+        "sourceRef": "ralphy fixtures/usage-limit-2026-07-21.jsonl (stdout turn_ended.error) and fixtures/usage-limit-stderr-2026-07-22.log (stderr ActionRequiredError)"
+      },
+      {
+        "phrase": "you're out of usage",
+        "kind": "quota_exhausted",
+        "template": "Increase limits for faster responses You're out of usage. Switch to Auto, or ask your admin to increase your limit to continue.",
+        "tier": "Pro / premium pool spent",
+        "sourceRef": "ai-dispatch src/rate_limit_signatures.rs:110-116 (stderr ActionRequiredError)"
+      }
+    ],
+    "resetFields": [],
+    "resetFieldsNote": "None. Both ralphy docs/adr/0042-cursor-validation.md:139-140 and docs/evidence/251-cursor-capstone-live.md:103-105 record 'no reset hint' on the limit stop, so retryAt and resetsAt are always null for this CLI. The relay still routes its (absent) resets_at/retry_after reads through the shared parseResetTimestamp helper, so a future cursor-agent that states an ambiguous or localized reset still yields null rather than a guess."
+  },
+
+  "scenarios": {
+    "usageLimit": {
+      "note": "Modeled on ralphy's midturn capture: the run streams normally, then the stream ends on turn_ended/error with the Free-tier sentence and no result envelope. Exit 1, and no reset time is stated anywhere — so expect carries no resetsAt.",
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAt": null, "resetsAt": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"apiKeySource\":\"login\",\"session_id\":\"6b3a2f14-9f0d-4c3a-8f21-2b6a5d0e77c1\",\"model\":\"auto\",\"permissionMode\":\"default\"}",
+        "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Adding the retry helper to src/limits.ts.\"}]},\"session_id\":\"6b3a2f14-9f0d-4c3a-8f21-2b6a5d0e77c1\"}",
+        "{\"type\":\"turn_ended\",\"status\":\"error\",\"error\":\"You've hit your usage limit Get Cursor Pro for more Agent usage, unlimited Tab, and more.\"}"
+      ]
+    },
+
+    "unrelatedFailure": {
+      "note": "The documented false-positive trap, verbatim: Cursor's model-entitlement refusal ends the run through the SAME turn_ended/error shape and the same ActionRequiredError prefix, but it is not a quota stop — waiting on it would leave the real problem (a named model the plan cannot use) undiagnosed. Must stay an unclassified failure.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"apiKeySource\":\"login\",\"session_id\":\"1c7d4e90-33ab-4f52-9c18-704e2a5b6d33\",\"model\":\"claude-opus-4-8\",\"permissionMode\":\"default\"}",
+        "{\"type\":\"turn_ended\",\"status\":\"error\",\"error\":\"Named models unavailable Free plans can only use Auto. Switch to Auto or upgrade plans to continue.\"}"
+      ]
+    },
+
+    "proseThenUnrelatedFailure": {
+      "note": "Adversarial: both verified templates, the ActionRequiredError prefix, 429, 'quota' and 'rate limit' all appear in NON-terminal assistant output — the implementer describing a rate-limit handler it just wrote — and the run then dies of the unrelated entitlement refusal. Must stay unclassified.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"apiKeySource\":\"login\",\"session_id\":\"90fe1b22-5d47-4a0e-b3c6-8811ff20a4de\",\"model\":\"auto\",\"permissionMode\":\"default\"}",
+        "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Added the HTTP 429 backoff: on a rate limit the queue parks the job, and the quota probe logs the remaining budget. The fixtures assert both vendor sentences verbatim — \\\"ActionRequiredError: You've hit your usage limit Get Cursor Pro for more Agent usage, unlimited Tab, and more.\\\" and \\\"Increase limits for faster responses You're out of usage. Switch to Auto, or ask your admin to increase your limit to continue.\\\" — so the parser cannot regress.\"}]},\"session_id\":\"90fe1b22-5d47-4a0e-b3c6-8811ff20a4de\"}",
+        "{\"type\":\"turn_ended\",\"status\":\"error\",\"error\":\"Named models unavailable Free plans can only use Auto. Switch to Auto or upgrade plans to continue.\"}"
+      ]
+    },
+
+    "recoveredThenSuccess": {
+      "note": "Constructed, not captured: a limit-shaped turn_ended is superseded by a later turn that closes with a successful result envelope. Cursor's success close is the `result` event with is_error false (the relay's documented contract). Must be a clean completion.",
+      "expect": { "status": "completed", "failureClass": null },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"apiKeySource\":\"login\",\"session_id\":\"4d5c66a1-2e8f-4b70-9a44-0c1de9b37f52\",\"model\":\"auto\",\"permissionMode\":\"default\"}",
+        "{\"type\":\"turn_ended\",\"status\":\"error\",\"error\":\"You've hit your usage limit Get Cursor Pro for more Agent usage, unlimited Tab, and more.\"}",
+        "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Retried on Auto and finished the change.\"}]},\"session_id\":\"4d5c66a1-2e8f-4b70-9a44-0c1de9b37f52\"}",
+        "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"session_id\":\"4d5c66a1-2e8f-4b70-9a44-0c1de9b37f52\",\"result\":\"Updated src/limits.ts and ran the suite.\",\"usage\":{\"input_tokens\":11,\"output_tokens\":4}}"
+      ]
+    },
+
+    "usageLimitExitZero": {
+      "note": "Defensive: never observed (this CLI exits 1 on the limit stop), but a limit must never be reported as a completed run. Uses the Pro/premium-pool sentence, so the second template is exercised too.",
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "exitCode": 1 },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"apiKeySource\":\"login\",\"session_id\":\"7ab0c318-6f21-4d9c-8e05-13b7c2a4de60\",\"model\":\"auto\",\"permissionMode\":\"default\"}",
+        "{\"type\":\"turn_ended\",\"status\":\"error\",\"error\":\"Increase limits for faster responses You're out of usage. Switch to Auto, or ask your admin to increase your limit to continue.\"}"
+      ]
+    }
+  },
+
+  "scenariosOmitted": {
+    "usageLimitRetryAfter": "Not applicable. cursor-agent surfaces no retry-after and no transient-throttle template anywhere in this transport, so there is no rate_limited signature to drive and no duration to parse. Composing one would mean inventing a signature.",
+    "usageLimitAmbiguousReset": "Not applicable. No captured cursor-agent limit transcript states a reset time in any form (ralphy ADR-0042:139-140 and capstone:103-105 both record 'no reset hint'); the only reset wording attributed to Cursor is docs-only and excluded above. The main usageLimit scenario already covers the message-only match with null retryAt/resetsAt."
+  }
+}

--- a/test/fixtures/usage-limit/cursor.json
+++ b/test/fixtures/usage-limit/cursor.json
@@ -74,7 +74,7 @@
   "scenarios": {
     "usageLimit": {
       "note": "Modeled on ralphy's midturn capture: the run streams normally, then the stream ends on turn_ended/error with the Free-tier sentence and no result envelope. Exit 1, and no reset time is stated anywhere — so expect carries no resetsAt.",
-      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAt": null, "resetsAt": null },
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAt": null, "resetsAt": null, "artifactLine": 3 },
       "exitCode": 1,
       "events": [
         "{\"type\":\"system\",\"subtype\":\"init\",\"apiKeySource\":\"login\",\"session_id\":\"6b3a2f14-9f0d-4c3a-8f21-2b6a5d0e77c1\",\"model\":\"auto\",\"permissionMode\":\"default\"}",

--- a/test/fixtures/usage-limit/grok.json
+++ b/test/fixtures/usage-limit/grok.json
@@ -1,0 +1,124 @@
+{
+  "schema": "delegate-usage-limit-capture.v1",
+  "cli": "grok",
+  "binary": "grok",
+  "version": "@xai-official/grok 1.0.3 (npm latest at capture time); signatures and transport read from xai-org/grok-build @ e5fd4816d43260c15ba785f103990c1ed6cea230 (main), whose workspace changelogs top out at 1.0.3",
+  "platform": "n/a — no local install was used; the npm package ships a launcher plus prebuilt platform binaries, so this bundle is read from the pinned upstream Rust source rather than from a binary or a live run",
+  "capturedAt": "2026-08-13",
+
+  "provenance": {
+    "state": "source-backed; live run pending",
+    "envelope": "source-backed",
+    "envelopeMethod": "Terminal-failure shape read from crates/codegen/xai-grok-pager/src/headless.rs:1300-1325 (the single `Some(Err(err))` arm calls on_error and returns Err, so on_end — and therefore the `end` line — never runs) and headless.rs:357-378, which routes the StreamingJson output format to `reducer.error(...)`. The wire line itself is built by AcpReducer::error in crates/codegen/xai-grok-pager/src/headless/reducer/acp.rs: serde tag `type`, snake_case, so `{\"type\":\"error\",\"message\":\"…\"}`, with merged spend fields when usage was recorded. Exit code 1 on that path per crates/codegen/xai-grok-pager/docs/user-guide/14-headless-mode.md:559-566. The success line (`{\"type\":\"end\",\"sessionId\":…}`, the only AcpLine variant carrying a session id) is from the same reducer, AcpEndLine.",
+    "signature": "source-backed",
+    "signatureMethod": "The three user-facing templates are verbatim constants in crates/codegen/xai-grok-shell/src/sampling/error.rs, selected by format_rate_limited_user_message (error.rs:54-80) when the provider answers HTTP 429. Corroborated end to end by crates/codegen/xai-grok-shell/tests/test_built_binary_e2e.rs:329-379 (test_headless_free_usage_exhausted_prints_paywall_message), which drives the built binary against a mock 429 body {\"code\":\"subscription:free-usage-exhausted\",\"error\":\"You have used all your free usage.\"} and asserts a non-zero exit plus output containing \"reached your free Grok Build usage limit\". No template was taken from prose documentation.",
+    "liveLimitRun": "pending — `grok` is not installed on the machine that produced this bundle, no account was exhausted, and nothing was installed or downloaded to make it. Both the envelope and the signatures are read from version-pinned upstream source of the real headless transport, which is why the state above is `source-backed; live run pending` rather than `live-captured`. A live capture should still be taken before the README claims otherwise.",
+    "typography": "All three templates use U+2019 RIGHT SINGLE QUOTATION MARK (written \\u{2019} in the Rust source), including mid-word in \"team’s\". They are stored here verbatim; the relay folds curly apostrophes to ASCII on both sides so the phrase table stays readable and a purely typographic change upstream cannot silently disable the matcher.",
+    "truncation": "crates/codegen/xai-grok-pager/src/app/effects/helpers.rs:251-281 (sanitize_user_error) rewrites internal service names to \"server\" and truncates to the first 180 chars plus \"...\" when the message exceeds 200. The three constants measure 161 / 181 / 81 chars, so none is truncated and none hits a replacement pattern. The relay matches a leading phrase of each rather than the full sentence, so a later suffix change (or a truncated pass-through detail) cannot break the match.",
+    "excludedCandidates": [
+      { "candidate": "ACP JSON-RPC code -32003 (RATE_LIMITED_ERROR_CODE, sampling/error.rs:19)", "reason": "genuinely structured and set only for real HTTP 429s, but it never reaches this transport: headless.rs:1301 consumes the code to pick the message, and AcpReducer::error serializes only `type` + `message` (+ merged spend). Matching it would mean matching a field that is never on the wire." },
+      { "candidate": "StopFailure hook input `error: \"rate_limit\"` (session/acp_session_impl/turn_end.rs:400-406, docs/user-guide/10-hooks.md)", "reason": "a real structured vocabulary, but consuming it requires the relay to install a hook, which mutates the user's grok config — out of scope for a single-shot dispatcher." },
+      { "candidate": "Non-xAI backends (api_backend = chat_completions | responses | messages, docs/user-guide/11-custom-models.md:62-64, :193-266)", "reason": "on a 429 from those, format_rate_limited_user_message falls through to the pass-through branch and emits the provider's own flattened body (ProviderError::display_message renders \"<slug>: <message>\", e.g. \"rate_limit_error: rate limit exceeded\"). No concrete non-xAI template was verified end to end, and `rate_limit_error` alone is generic wording, so no signature is claimed. Those backends keep reporting an unclassified `failed` — this bundle is therefore `partial`, xAI-only." },
+      { "candidate": "AcpLine::AutoCompactFailed { error } and AcpLine::ImageCompressed { message }", "reason": "error-shaped but not terminal, and they are their own event types. The matcher's terminal-event allowlist is exactly `type == \"error\"`." },
+      { "candidate": "Bare \"429\", \"quota\", \"rate limit\", \"usage limit\"", "reason": "ordinary task prose. A brief about rate limiting makes the implementer emit all of them mid-run — see the proseThenUnrelatedFailure scenario." }
+    ]
+  },
+
+  "transport": {
+    "stream": "stdout",
+    "flag": "--output-format streaming-json",
+    "framing": "one JSON object per line; the relay's scanner is brace-depth based rather than line based, so a record may also arrive split across chunks or without a trailing newline",
+    "terminalFailureEvent": "{\"type\":\"error\"}",
+    "terminalFailureField": "message",
+    "terminalSuccessEvent": "{\"type\":\"end\"}",
+    "observedExitCodeOnTerminalError": 1,
+    "errorCodeOnWire": "none — AcpReducer::error emits only `type` and `message` (plus merged spend fields). The message string is the sole discriminator available on this transport.",
+    "sessionIdOnFailure": "absent. `sessionId` rides only on the `end` line, and the terminal error arm never emits one, so a classified failure carries the session id only when the caller passed --session. Otherwise resume with --resume-last (grok's `--continue`).",
+    "spendOnFailure": "preserved — AcpReducer::error merges attach_result_usage into the error line when usage was recorded, so the relay's existing `usage` capture still reports spend on a limit failure.",
+    "warningsAreNotTerminal": "The `{\"type\":\"error\"}` line is emitted from headless mode's single terminal error arm and is immediately followed by a returned Err, so it is terminal by construction. Other error-shaped lines are separate AcpLine variants (AutoCompactFailed, ImageCompressed) and are not matched. The documented event list is explicitly non-exhaustive (14-headless-mode.md:247), which is the second reason the matcher also requires a verified message template rather than trusting the event type alone."
+  },
+
+  "signatures": {
+    "codes": [],
+    "codesNote": "Grok surfaces no error code on this transport — see provenance.excludedCandidates. The message templates are the whole signature.",
+    "messages": [
+      {
+        "phrase": "you've reached your free grok build usage limit",
+        "kind": "quota_exhausted",
+        "template": "You’ve reached your free Grok Build usage limit for now. Get SuperGrok for much higher limits, or try again later: https://grok.com/supergrok?referrer=grok-build",
+        "source": "xai-grok-shell/src/sampling/error.rs:38 (FREE_USAGE_USER_MESSAGE), selected at error.rs:54-72 when the flattened 429 detail carries FREE_USAGE_EXHAUSTED_ERROR_CODE = \"subscription:free-usage-exhausted\" (error.rs:34, sniffed by is_free_usage_exhausted_error at error.rs:43-45)",
+        "note": "A subscription paywall, not a transient throttle, hence quota_exhausted. Its doc comment (error.rs:36-37) states it deliberately promises no reset duration because the quota window is backend-config-driven."
+      },
+      {
+        "phrase": "you've hit your team's api rate limit",
+        "kind": "rate_limited",
+        "template": "You’ve hit your team’s API rate limit. Ask a team admin to purchase more credits for higher limits, or try again later. See https://docs.x.ai/developers/rate-limits#rate-limit-tiers",
+        "source": "xai-grok-shell/src/sampling/error.rs:28 (RATE_LIMITED_USER_MESSAGE_API_KEY), emitted by format_rate_limited_user_message (error.rs:54-80) when is_api_key_auth is true and the server detail is empty or pushes the consumer upsell (pushes_consumer_subscription_upsell, error.rs:101-105)"
+      },
+      {
+        "phrase": "you've hit the rate limit for your plan",
+        "kind": "rate_limited",
+        "template": "You’ve hit the rate limit for your plan. Upgrade your account or try again later.",
+        "source": "xai-grok-shell/src/sampling/error.rs:22-23 (RATE_LIMITED_USER_MESSAGE_OAUTH), the OAuth/session-auth fallback in format_rate_limited_user_message (error.rs:54-80) when the server supplied no usable 429 detail"
+      }
+    ],
+    "resetFields": [],
+    "resetFieldsNote": "None. No Grok limit template carries a timestamp or a duration, and the error line has no reset field, so retryAt and resetsAt are always null for this CLI. Inventing one would send the orchestrator back at the wrong moment. This is why the shared matrix's usageLimitRetryAfter and usageLimitAmbiguousReset scenarios are deliberately absent below — Grok supplies no such data, and a fabricated scenario would test the fixture rather than the CLI."
+  },
+
+  "scenarios": {
+    "usageLimit": {
+      "note": "Free-plan quota exhaustion, the case the upstream e2e test drives. The terminal error line is verbatim FREE_USAGE_USER_MESSAGE. No reset time is stated anywhere, so expect carries no resetsAt.",
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted" },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thought\",\"data\":\"Reading the brief and the touched files before editing.\"}",
+        "{\"type\":\"text\",\"data\":\"Starting on the brief.\"}",
+        "{\"type\":\"error\",\"message\":\"You’ve reached your free Grok Build usage limit for now. Get SuperGrok for much higher limits, or try again later: https://grok.com/supergrok?referrer=grok-build\"}"
+      ]
+    },
+
+    "unrelatedFailure": {
+      "note": "Constructed, not captured: a terminal error line whose message is not a limit template. sanitize_user_error rewrites internal service names to \"server\", which is why the wording looks like this. Must stay an unclassified failure.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"text\",\"data\":\"Looking at the repository layout.\"}",
+        "{\"type\":\"error\",\"message\":\"Request to server failed: 500 Internal Server Error\"}"
+      ]
+    },
+
+    "proseThenUnrelatedFailure": {
+      "note": "Adversarial: every trigger word — and all three verbatim limit templates — appears in NON-terminal output, because the brief was about handling provider limits. The run then dies of something unrelated. Must stay unclassified.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"thought\",\"data\":\"The brief asks for a handler covering HTTP 429, quota exhaustion and rate limit backoff.\"}",
+        "{\"type\":\"text\",\"data\":\"I added a 429 retry path. It now surfaces the provider sentence verbatim: You’ve reached your free Grok Build usage limit for now. Get SuperGrok for much higher limits, or try again later.\"}",
+        "{\"type\":\"text\",\"data\":\"The team branch reports You’ve hit your team’s API rate limit, and the OAuth branch reports You’ve hit the rate limit for your plan. Upgrade your account or try again later.\"}",
+        "{\"type\":\"error\",\"message\":\"Request to server failed: 500 Internal Server Error\"}"
+      ]
+    },
+
+    "recoveredThenSuccess": {
+      "note": "Defensive, not observed: per headless.rs the terminal error arm returns immediately, so nothing follows it. If a build ever emitted a limit-looking error line and then went on to reach grok's success state (the `end` line, exit 0), the run did the work and must be reported as a clean completion.",
+      "expect": { "status": "completed", "failureClass": null },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"error\",\"message\":\"You’ve hit the rate limit for your plan. Upgrade your account or try again later.\"}",
+        "{\"type\":\"text\",\"data\":\"Retried once the throttle cleared and finished the edit.\"}",
+        "{\"type\":\"end\",\"sessionId\":\"grok-session-recovered-1\",\"usage\":{\"input_tokens\":11,\"output_tokens\":4,\"total_tokens\":15}}"
+      ]
+    },
+
+    "usageLimitExitZero": {
+      "note": "Defensive: this CLI exits 1 on the terminal error arm (14-headless-mode.md:559-566), but a limit must never be reported as a completed run, so the relay normalizes a zero exit to a failure.",
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "exitCode": 1 },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"text\",\"data\":\"Starting on the brief.\"}",
+        "{\"type\":\"error\",\"message\":\"You’ve reached your free Grok Build usage limit for now. Get SuperGrok for much higher limits, or try again later: https://grok.com/supergrok?referrer=grok-build\"}"
+      ]
+    }
+  }
+}

--- a/test/fixtures/usage-limit/grok.json
+++ b/test/fixtures/usage-limit/grok.json
@@ -69,7 +69,7 @@
   "scenarios": {
     "usageLimit": {
       "note": "Free-plan quota exhaustion, the case the upstream e2e test drives. The terminal error line is verbatim FREE_USAGE_USER_MESSAGE. No reset time is stated anywhere, so expect carries no resetsAt.",
-      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted" },
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "artifactLine": 3 },
       "exitCode": 1,
       "events": [
         "{\"type\":\"thought\",\"data\":\"Reading the brief and the touched files before editing.\"}",

--- a/test/fixtures/usage-limit/opencode.json
+++ b/test/fixtures/usage-limit/opencode.json
@@ -61,7 +61,7 @@
     },
 
     "usageLimitRetryAfter": {
-      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAtIsSet": true },
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAtIsSet": true, "retryAfterSeconds": 600 },
       "exitCode": 1,
       "events": [
         "{\"type\":\"session_start\",\"sessionID\":\"ses_aa11bb22cc33\"}",

--- a/test/fixtures/usage-limit/opencode.json
+++ b/test/fixtures/usage-limit/opencode.json
@@ -1,0 +1,147 @@
+{
+  "schema": "delegate-usage-limit-capture.v1",
+  "cli": "opencode",
+  "binary": "opencode",
+  "version": "opencode 1.17.11",
+  "platform": "aarch64-apple-darwin",
+  "capturedAt": "2026-08-13",
+
+  "provenance": {
+    "state": "source-backed; live run pending",
+    "envelope": "source-backed",
+    "envelopeMethod": "Event shapes read from the embedded JS bundle of the installed opencode binary (v1.17.11) — the `--format json` writer and the session error event {\"type\":\"error\",\"sessionID\":…,\"error\":{\"name\":…,\"data\":{…}}}. The relay scans stdout by brace depth rather than by line (makeEventScanner), so records may arrive concatenated or split.",
+    "signature": "source-backed",
+    "signatureMethod": "The `parseStreamError` switch in MessageV2.ProviderError, read from the same bundle: it maps a provider body code to a fixed message and hard-codes isRetryable:false. Both listed codes come from that switch.",
+    "liveLimitRun": "pending — no account was exhausted to produce this bundle",
+    "excludedCandidates": [
+      { "code": "GoUsageLimitError", "reason": "opencode Zen template that exists only on the retry status, which `--format json` never emits — matching it would be dead code claiming coverage it cannot have" },
+      { "code": "FreeUsageLimitError", "reason": "same: retry-status only, never reaches this transport" }
+    ]
+  },
+
+  "transport": {
+    "stream": "stdout",
+    "flag": "run --format json",
+    "framing": "JSON objects scanned by brace depth, not by line — records may be concatenated or split mid-object",
+    "terminalFailureEvent": "{\"type\":\"error\"} carrying error.name === \"APIError\"",
+    "terminalFailureField": "error.data.message and error.data.responseBody",
+    "terminalSuccessEvent": "exit code 0 (a step_finish after an error event clears the match)",
+    "observedExitCodeOnError": 1,
+    "warningsAreNotTerminal": "Only APIError is a provider refusal. ProviderAuthError, ContextOverflowError, MessageOutputLengthError and MessageAbortedError are local conditions and must never classify.",
+    "retryCaveat": "OpenCode retries a plain HTTP 429 indefinitely and never forwards its retry status to this stream. An ordinary rate limit therefore STALLS the run — status \"timeout\" under --timeout, or an unbounded hang without one — rather than failing it. Only the non-retryable codes below are terminal here, so this relay's coverage of transient throttling is genuinely nil, not merely unverified."
+  },
+
+  "signatures": {
+    "codes": [
+      { "code": "insufficient_quota", "kind": "quota_exhausted" },
+      { "code": "usage_not_included", "kind": "quota_exhausted" }
+    ],
+    "messages": [
+      { "phrase": "quota exceeded. check your plan and billing details.", "kind": "quota_exhausted" },
+      { "phrase": "to use codex with your chatgpt plan, upgrade to plus", "kind": "quota_exhausted" }
+    ],
+    "resetFields": [
+      { "field": "resets_at", "mode": "absolute" },
+      { "field": "retry_after", "mode": "duration" }
+    ]
+  },
+
+  "hardening": ["proseInTerminalMessage", "nonApiErrorWithLimitText", "unknownCodeQuotaShaped"],
+
+  "scenarios": {
+    "usageLimit": {
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "resetsAt": "2026-08-13T21:00:00.000Z" },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"session_start\",\"sessionID\":\"ses_7f3a91c20b4e\"}",
+        "{\"type\":\"step_start\",\"sessionID\":\"ses_7f3a91c20b4e\"}",
+        "{\"type\":\"text\",\"sessionID\":\"ses_7f3a91c20b4e\",\"text\":\"Editing src/billing.ts.\"}",
+        "{\"type\":\"error\",\"sessionID\":\"ses_7f3a91c20b4e\",\"error\":{\"name\":\"APIError\",\"data\":{\"message\":\"Quota exceeded. Check your plan and billing details.\",\"responseBody\":\"{\\\"error\\\":{\\\"code\\\":\\\"insufficient_quota\\\",\\\"message\\\":\\\"You exceeded your current quota.\\\",\\\"resets_at\\\":\\\"2026-08-13T21:00:00Z\\\"}}\"}}}"
+      ]
+    },
+
+    "usageLimitRetryAfter": {
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAtIsSet": true },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"session_start\",\"sessionID\":\"ses_aa11bb22cc33\"}",
+        "{\"type\":\"error\",\"sessionID\":\"ses_aa11bb22cc33\",\"error\":{\"name\":\"APIError\",\"data\":{\"message\":\"To use Codex with your ChatGPT plan, upgrade to Plus: https://chatgpt.com/explore/plus.\",\"responseBody\":\"{\\\"error\\\":{\\\"code\\\":\\\"usage_not_included\\\",\\\"message\\\":\\\"Not included in plan.\\\",\\\"retry_after\\\":600}}\"}}}"
+      ]
+    },
+
+    "unrelatedFailure": {
+      "note": "A local condition, not a provider refusal. Must stay unclassified.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"session_start\",\"sessionID\":\"ses_bb22cc33dd44\"}",
+        "{\"type\":\"step_start\",\"sessionID\":\"ses_bb22cc33dd44\"}",
+        "{\"type\":\"error\",\"sessionID\":\"ses_bb22cc33dd44\",\"error\":{\"name\":\"ContextOverflowError\",\"data\":{\"message\":\"Context window exceeded for this model.\"}}}"
+      ]
+    },
+
+    "proseThenUnrelatedFailure": {
+      "note": "Adversarial: every trigger word appears in non-terminal text events, then the run dies of an unrelated local error.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"session_start\",\"sessionID\":\"ses_cc33dd44ee55\"}",
+        "{\"type\":\"text\",\"sessionID\":\"ses_cc33dd44ee55\",\"text\":\"Added handling for insufficient_quota and usage_not_included: on HTTP 429 we now surface 'Quota exceeded. Check your plan and billing details.' to the caller.\"}",
+        "{\"type\":\"tool\",\"sessionID\":\"ses_cc33dd44ee55\",\"name\":\"edit\",\"output\":\"rate limit quota 429 usage_not_included\"}",
+        "{\"type\":\"error\",\"sessionID\":\"ses_cc33dd44ee55\",\"error\":{\"name\":\"MessageOutputLengthError\",\"data\":{\"message\":\"Output length exceeded.\"}}}"
+      ]
+    },
+
+    "recoveredThenSuccess": {
+      "note": "An APIError limit superseded by a later step_finish and a zero exit: the run did the work.",
+      "expect": { "status": "completed", "failureClass": null },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"session_start\",\"sessionID\":\"ses_dd44ee55ff66\"}",
+        "{\"type\":\"error\",\"sessionID\":\"ses_dd44ee55ff66\",\"error\":{\"name\":\"APIError\",\"data\":{\"message\":\"Quota exceeded. Check your plan and billing details.\",\"responseBody\":\"{\\\"error\\\":{\\\"code\\\":\\\"insufficient_quota\\\"}}\"}}}",
+        "{\"type\":\"step_finish\",\"sessionID\":\"ses_dd44ee55ff66\"}",
+        "{\"type\":\"text\",\"sessionID\":\"ses_dd44ee55ff66\",\"text\":\"Done.\"}"
+      ]
+    },
+
+    "usageLimitExitZero": {
+      "note": "Defensive: a limit must never be reported as a completed run, whatever the exit code.",
+      "expect": { "status": "failed", "failureClass": "usage_limit", "exitCode": 1 },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"session_start\",\"sessionID\":\"ses_ee55ff66aa77\"}",
+        "{\"type\":\"error\",\"sessionID\":\"ses_ee55ff66aa77\",\"error\":{\"name\":\"APIError\",\"data\":{\"message\":\"Quota exceeded. Check your plan and billing details.\",\"responseBody\":\"{\\\"error\\\":{\\\"code\\\":\\\"insufficient_quota\\\"}}\"}}}"
+      ]
+    },
+
+    "proseInTerminalMessage": {
+      "note": "Hardening: an APIError whose own message quotes the trigger words as task prose, with no verified code or template.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"session_start\",\"sessionID\":\"ses_ff66aa77bb88\"}",
+        "{\"type\":\"error\",\"sessionID\":\"ses_ff66aa77bb88\",\"error\":{\"name\":\"APIError\",\"data\":{\"message\":\"Upstream returned 429 while the rate limit quota test was running.\",\"responseBody\":\"{\\\"error\\\":{\\\"code\\\":\\\"server_error\\\"}}\"}}}"
+      ]
+    },
+
+    "nonApiErrorWithLimitText": {
+      "note": "Hardening: a genuine limit code and template carried by a NON-APIError error. Only APIError is a provider refusal.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"session_start\",\"sessionID\":\"ses_aa77bb88cc99\"}",
+        "{\"type\":\"error\",\"sessionID\":\"ses_aa77bb88cc99\",\"error\":{\"name\":\"ProviderAuthError\",\"data\":{\"message\":\"Quota exceeded. Check your plan and billing details.\",\"responseBody\":\"{\\\"error\\\":{\\\"code\\\":\\\"insufficient_quota\\\"}}\"}}}"
+      ]
+    },
+
+    "unknownCodeQuotaShaped": {
+      "note": "Hardening: an APIError with a quota-shaped but unverified code and no matching template.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"session_start\",\"sessionID\":\"ses_bb88cc99dd00\"}",
+        "{\"type\":\"error\",\"sessionID\":\"ses_bb88cc99dd00\",\"error\":{\"name\":\"APIError\",\"data\":{\"message\":\"Request was throttled.\",\"responseBody\":\"{\\\"error\\\":{\\\"code\\\":\\\"quota_something_else\\\",\\\"message\\\":\\\"Throttled.\\\"}}\"}}}"
+      ]
+    }
+  }
+}

--- a/test/fixtures/usage-limit/opencode.json
+++ b/test/fixtures/usage-limit/opencode.json
@@ -50,7 +50,7 @@
 
   "scenarios": {
     "usageLimit": {
-      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "resetsAt": "2026-08-13T21:00:00.000Z" },
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "resetsAt": "2026-08-13T21:00:00.000Z", "artifactLine": 4 },
       "exitCode": 1,
       "events": [
         "{\"type\":\"session_start\",\"sessionID\":\"ses_7f3a91c20b4e\"}",

--- a/test/fixtures/usage-limit/qoder.json
+++ b/test/fixtures/usage-limit/qoder.json
@@ -65,7 +65,7 @@
   "scenarios": {
     "usageLimit": {
       "note": "Daily plan limit. Carries both a verified error_code and a verified message template, and is preceded by the mid-run api_retry 429 the matcher must not treat as terminal.",
-      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAt": null, "resetsAt": null },
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAt": null, "resetsAt": null, "artifactLine": 4 },
       "exitCode": 1,
       "events": [
         "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"8f2c1d90-4a7b-4c2e-9a10-6b3e5d0f7c11\",\"model\":\"performance\",\"permissionMode\":\"auto\"}",

--- a/test/fixtures/usage-limit/qoder.json
+++ b/test/fixtures/usage-limit/qoder.json
@@ -1,0 +1,125 @@
+{
+  "schema": "delegate-usage-limit-capture.v1",
+  "cli": "qoder",
+  "binary": "qodercli",
+  "version": "@qoder-ai/qodercli 1.1.20",
+  "platform": "npm package, single platform-independent JS bundle (bundle/qodercli.js, 36,352,351 bytes)",
+  "capturedAt": "2026-08-13",
+
+  "provenance": {
+    "state": "source-backed; no live run - qodercli is not installed on the capture host",
+    "envelope": "source-backed",
+    "envelopeMethod": "The CLI is not installed here (`command -v qodercli` finds nothing; nothing under ~/.qoder, /opt/homebrew/bin, /usr/local/bin, ~/.local/bin, or npm -g), so no event sequence below was transcribed from a run. The stream-json envelope is read out of the shipped implementation of @qoder-ai/qodercli@1.1.20: the result-event zod schema at ~28,086,019 (error subtypes are exactly [error_during_execution, error_max_turns, error_max_budget_usd, error_max_structured_output_retries] - there is NO dedicated quota subtype), the emitter `buildResultError` at ~30,868,865 ({type:\"result\",subtype:A,...,is_error:!0,errors:e.errors,...error_code}), its call site at ~24,736,161 (errors[0] is the raw upstream error .message, not a normalized template), and the api_retry schema at ~22,087,155. Field order and cosmetic fields in the events below are illustrative; the field NAMES and the terminal shape are what this bundle pins.",
+    "signature": "source-backed",
+    "signatureMethod": "Error codes and user-facing message templates read from the same bundle, whose user-facing strings are obfuscated with `_$d(s, k=\"0tvtCAtV8w77\")` (base64-decode then XOR) - the decoder is defined in the file's own banner, so every quoted message is a faithful decode, not a guess. Enum at ~29,071,388: {loginExpired:105, todayUsageLimitExceeded:110, usageLimitExceeded:113, freeTrialAccountsExceeded:114, freeUserQuotaLimit:115, teamsAdminCreditsDrainedOut:116, teamsMemberCreditsDrainedOut:117, personalCreditsDrainedOut:118, velaModelFreeLimitReached:119, billingGroupCreditsLimitReached:122}. Message-to-code mapper `Zor(A)` at ~29,069,153. Terminal-quota set `ool` at ~29,071,786 = {110,114,115,116,117,118,119,122}, consumed by `dAn(A)` to drive the CLI's own quota_exhausted classification; 113 sits outside it as the per-window cap, hence kind rate_limited here.",
+    "liveLimitRun": "pending - no Qoder account was exhausted, and the CLI is not installed, so every scenario below is composed from the source-verified transport rather than transcribed from a run. Re-capture against a real limit before upgrading this bundle's state.",
+    "excludedCandidates": [
+      { "code": "system/api_retry error=\"rate_limit\", error_status=429", "reason": "source-backed and really on this transport, but NOT terminal: the CLI retries these 429s (attempt/max_retries/retry_delay_ms) and usually recovers. Matching it would fail healthy runs, so it appears in the scenarios below only as a mid-run warning the matcher must ignore." },
+      { "code": "\"Usage limit reached for <model>.\" / \"Access resets at <time>.\" / \"/stats model for usage details\"", "reason": "interactive-TUI only - built in setFallbackModelHandler (~29,621,540) and never written to stream-json. Docs-only for this transport." },
+      { "code": "\"You have exhausted your daily quota on this model.\" / \"Usage limits span all sessions and reset daily.\"", "reason": "same: TUI strings, absent from the stream-json transport." },
+      { "code": "\"Compression failed because your Qoder credits or usage quota are exhausted.\" / \"Compression failed because the model request was rate limited.\"", "reason": "compaction notices in the TUI, not terminal result events." },
+      { "code": "loginExpired (105)", "reason": "an auth failure, not a usage limit - classifying it would tell the orchestrator to wait out a login problem." },
+      { "code": "customModelService (100400) / customModelAuth (100401) / customModelNotAvailable (100403)", "reason": "BYOK custom-model errors. A BYOK-backed model can surface an upstream provider's own 429 text in errors[0], which this matcher deliberately does not chase - an unverified upstream dialect is exactly the false positive to avoid." },
+      { "code": "bare \"429\" / \"quota\" / \"rate limit\"", "reason": "ordinary task prose. See the proseThenUnrelatedFailure scenario." }
+    ]
+  },
+
+  "transport": {
+    "stream": "stdout",
+    "flag": "--output-format stream-json",
+    "framing": "stream-json - the relay scans stdout with a brace-matching scanner rather than a line splitter, so concatenated or pretty-printed objects both work; the events below are written one per line, and the final one may arrive without a trailing newline",
+    "terminalFailureEvent": "{\"type\":\"result\", is_error:true} (error subtype, normally error_during_execution)",
+    "terminalFailureField": "errors[] plus error_code",
+    "terminalSuccessEvent": "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}",
+    "observedExitCodeOnTerminalFailure": "not verified - the CLI is not installed. The relay does not depend on it: `succeeded` ANDs the exit code with !resultIsError and rewrites a 0 exit to 1, so an exit-zero limit still lands as status failed (see usageLimitExitZero).",
+    "warningsAreNotTerminal": "Source-backed: {\"type\":\"system\",\"subtype\":\"api_retry\",\"error\":\"rate_limit\",\"error_status\":429} is emitted by `Yer` (~22,600,065) for transient 429s the CLI then retries; `dAA` returns \"rate_limit\" for status 429 or a message containing \"rate limit\"/\"429\". It is an early-warning signal only. Only the terminal result event is classified.",
+    "resetFieldsPresent": "none. The terminal result event carries no reset or retry field - quota reset time lives behind GET {openapi}/api/v2/quota/usage (fetchQuotaUsage at ~21,583,484), which the relay never calls. retryAt/resetsAt are therefore always null, and scenarios usageLimitRetryAfter and usageLimitAmbiguousReset are deliberately absent: this CLI supplies no such data on this transport, and inventing it would be inventing a reset time."
+  },
+
+  "signatures": {
+    "codes": [
+      { "code": 110, "name": "todayUsageLimitExceeded", "kind": "quota_exhausted", "note": "in the CLI's own terminal-quota set `ool`" },
+      { "code": 113, "name": "usageLimitExceeded", "kind": "rate_limited", "note": "outside `ool` - the CLI treats it as the per-window cap that resets, not a spent plan" },
+      { "code": 114, "name": "freeTrialAccountsExceeded", "kind": "quota_exhausted" },
+      { "code": 115, "name": "freeUserQuotaLimit", "kind": "quota_exhausted" },
+      { "code": 116, "name": "teamsAdminCreditsDrainedOut", "kind": "quota_exhausted" },
+      { "code": 117, "name": "teamsMemberCreditsDrainedOut", "kind": "quota_exhausted" },
+      { "code": 118, "name": "personalCreditsDrainedOut", "kind": "quota_exhausted" },
+      { "code": 119, "name": "velaModelFreeLimitReached", "kind": "quota_exhausted" },
+      { "code": 122, "name": "billingGroupCreditsLimitReached", "kind": "quota_exhausted" }
+    ],
+    "messages": [
+      { "phrase": "billing daily count exceeded", "kind": "quota_exhausted", "source": "Zor(A): A.includes(\"Billing daily count exceeded\") -> todayUsageLimitExceeded" },
+      { "phrase": "user quota exhausted", "kind": "rate_limited", "source": "Zor(A): A.includes(\"User quota exhausted\") -> usageLimitExceeded" }
+    ],
+    "markerPairs": [
+      { "tokens": ["114", "pricingurl"], "kind": "quota_exhausted", "name": "freeTrialAccountsExceeded" },
+      { "tokens": ["112", "pricingurl"], "kind": "quota_exhausted", "name": "personalCreditsDrainedOut", "note": "the wire token is 112 while the enum value is 118 - the mapper maps the 112+pricingUrl body to personalCreditsDrainedOut" },
+      { "tokens": ["116", "purchaseurl"], "kind": "quota_exhausted", "name": "teamsAdminCreditsDrainedOut" },
+      { "tokens": ["117", "usageurl"], "kind": "quota_exhausted", "name": "teamsMemberCreditsDrainedOut" },
+      { "tokens": ["122", "billing group"], "kind": "quota_exhausted", "name": "billingGroupCreditsLimitReached" }
+    ],
+    "resetFields": []
+  },
+
+  "scenarios": {
+    "usageLimit": {
+      "note": "Daily plan limit. Carries both a verified error_code and a verified message template, and is preceded by the mid-run api_retry 429 the matcher must not treat as terminal.",
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "quota_exhausted", "retryAt": null, "resetsAt": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"8f2c1d90-4a7b-4c2e-9a10-6b3e5d0f7c11\",\"model\":\"performance\",\"permissionMode\":\"auto\"}",
+        "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Reading src/config.ts before editing.\"}]},\"session_id\":\"8f2c1d90-4a7b-4c2e-9a10-6b3e5d0f7c11\"}",
+        "{\"type\":\"system\",\"subtype\":\"api_retry\",\"attempt\":1,\"max_retries\":3,\"retry_delay_ms\":2000,\"error_status\":429,\"error\":\"rate_limit\",\"content\":\"Request was rate limited; retrying.\",\"level\":\"error\",\"uuid\":\"7c1b0a54-2f33-4f0a-8f2e-0a9d4c6b1e22\",\"session_id\":\"8f2c1d90-4a7b-4c2e-9a10-6b3e5d0f7c11\"}",
+        "{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"errors\":[\"Billing daily count exceeded\"],\"error_code\":110,\"session_id\":\"8f2c1d90-4a7b-4c2e-9a10-6b3e5d0f7c11\"}"
+      ]
+    },
+
+    "unrelatedFailure": {
+      "note": "An ordinary tool failure. No error_code is emitted because the mapper has no code for it. Must stay an unclassified failure.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"1a4d7e02-9b31-4c58-9de0-2f61c8a3b407\",\"model\":\"performance\",\"permissionMode\":\"auto\"}",
+        "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Applying the edit to src/config.ts.\"}]},\"session_id\":\"1a4d7e02-9b31-4c58-9de0-2f61c8a3b407\"}",
+        "{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"errors\":[\"Tool execution failed: EACCES: permission denied, open /repo/src/config.ts\"],\"session_id\":\"1a4d7e02-9b31-4c58-9de0-2f61c8a3b407\"}"
+      ]
+    },
+
+    "proseThenUnrelatedFailure": {
+      "note": "Adversarial: every trigger word - both message templates, every code, every marker token, 429 and the words quota and rate limit - appears in NON-terminal output (the implementer reporting on a quota-handling task, plus a mid-run api_retry 429 the CLI recovered from). The run then dies of a failing test suite. Must stay unclassified.",
+      "expect": { "status": "failed", "failureClass": null },
+      "exitCode": 1,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"c3e9b1f7-5d24-4a06-b8c1-9e07d2f4a531\",\"model\":\"performance\",\"permissionMode\":\"auto\"}",
+        "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Wired up the quota handling: error_code 110 (Billing daily count exceeded) and 113 (User quota exhausted) now surface as usage limits instead of a bare 429 rate limit, and the 112/114/116/117/122 branches read pricingUrl, purchaseUrl, usageUrl and the Billing Group label.\"}]},\"session_id\":\"c3e9b1f7-5d24-4a06-b8c1-9e07d2f4a531\"}",
+        "{\"type\":\"system\",\"subtype\":\"api_retry\",\"attempt\":1,\"max_retries\":3,\"retry_delay_ms\":2000,\"error_status\":429,\"error\":\"rate_limit\",\"content\":\"Request was rate limited; retrying.\",\"level\":\"error\",\"uuid\":\"b0d5c7a1-8e42-4a9f-90b3-1c6e5f2d8a44\",\"session_id\":\"c3e9b1f7-5d24-4a06-b8c1-9e07d2f4a531\"}",
+        "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Running the project gates.\"}]},\"session_id\":\"c3e9b1f7-5d24-4a06-b8c1-9e07d2f4a531\"}",
+        "{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"errors\":[\"Tool execution failed: npm test exited 1 - 3 assertions failed in src/quota-limits.test.ts\"],\"session_id\":\"c3e9b1f7-5d24-4a06-b8c1-9e07d2f4a531\"}"
+      ]
+    },
+
+    "recoveredThenSuccess": {
+      "note": "The realistic recovery on this transport: the CLI hits a transient 429, retries it, and reaches its success state. The final report itself quotes both limit templates and both codes, proving the implementer's own prose (event.result) is never part of the haystack. Must be a clean completion.",
+      "expect": { "status": "completed", "failureClass": null },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"5b8a0c46-7f19-4d23-a0e5-3d92b6c1f708\",\"model\":\"performance\",\"permissionMode\":\"auto\"}",
+        "{\"type\":\"system\",\"subtype\":\"api_retry\",\"attempt\":1,\"max_retries\":3,\"retry_delay_ms\":2000,\"error_status\":429,\"error\":\"rate_limit\",\"content\":\"Request was rate limited; retrying.\",\"level\":\"error\",\"uuid\":\"2e6f9b03-4c81-4a57-8b0d-71f3c5a9e264\",\"session_id\":\"5b8a0c46-7f19-4d23-a0e5-3d92b6c1f708\"}",
+        "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Retried after the rate limit and finished the edit.\"}]},\"session_id\":\"5b8a0c46-7f19-4d23-a0e5-3d92b6c1f708\"}",
+        "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"errors\":[],\"session_id\":\"5b8a0c46-7f19-4d23-a0e5-3d92b6c1f708\",\"result\":\"Added the usage-limit handler: User quota exhausted and Billing daily count exceeded now map to error_code 113 and 110; npm test passes.\",\"usage\":{\"input_tokens\":5310,\"output_tokens\":412}}"
+      ]
+    },
+
+    "usageLimitExitZero": {
+      "note": "Defensive: the exit code on a Qoder limit is unverified (the CLI is not installed), so the relay must not depend on it. A limit that arrives with a zero exit is still normalized to a failure with a non-zero relay exit code. Also the only scenario exercising the 113 / rate_limited branch and a message-template-plus-code match with no api_retry warning.",
+      "expect": { "status": "failed", "failureClass": "usage_limit", "kind": "rate_limited", "exitCode": 1, "retryAt": null, "resetsAt": null },
+      "exitCode": 0,
+      "events": [
+        "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"9d4f6a28-3c07-4b91-8e2a-5f10c8b7d3e6\",\"model\":\"performance\",\"permissionMode\":\"auto\"}",
+        "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Starting on the brief.\"}]},\"session_id\":\"9d4f6a28-3c07-4b91-8e2a-5f10c8b7d3e6\"}",
+        "{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"errors\":[\"User quota exhausted\"],\"error_code\":113,\"session_id\":\"9d4f6a28-3c07-4b91-8e2a-5f10c8b7d3e6\"}"
+      ]
+    }
+  }
+}

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -6,6 +6,12 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
 const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok"];
+// Relays carrying the usage-limit result contract. The per-CLI signature tables and
+// classifyUsageLimit deliberately differ (each implementer's terminal event and wording is its
+// own, so those are gated by behavior in test/relay/usage-limit.mjs instead) — but the fields
+// they produce must not drift, so the shape helpers are byte-compared here. agy is included:
+// it ships no matcher, but its --preflight-usage builds the same limit object.
+const USAGE_LIMIT_RELAYS = ["codex", "cursor", "grok", "qoder", "opencode", "agy"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],
   ["parseDuration", "function", RELAYS],
@@ -27,6 +33,11 @@ const SYMBOLS = [
   ["fingerprintDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["changedDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["readOnlyVerdict", "function", READ_ONLY_TRIPWIRE_RELAYS],
+  ["MAX_EVIDENCE_CHARS", "const", USAGE_LIMIT_RELAYS],
+  ["safeJson", "function", USAGE_LIMIT_RELAYS],
+  ["boundedExcerpt", "function", USAGE_LIMIT_RELAYS],
+  ["parseResetTimestamp", "function", USAGE_LIMIT_RELAYS],
+  ["usageLimitFields", "function", USAGE_LIMIT_RELAYS],
   ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "qoder", "vibe"]],
   ["makeEventScanner", "function", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "qoder"]],
 ];

--- a/test/relay/agy.mjs
+++ b/test/relay/agy.mjs
@@ -170,13 +170,13 @@ export async function runAgy(h) {
   // (`agy -p "/usage" --output-format json`: no conversation, no turns, no tokens). The
   // flag may block a dispatch ONLY on true exhaustion — a probe that fails, hangs, or
   // returns an unfamiliar shape must never stand between the user and their work.
-  const preflight = (name, usageMode) => {
+  const preflight = (name, usageMode, extraArgs = []) => {
     const outDir = join(h.scratch, `out-preflight-${name}-agy`);
     const workDir = h.freshRepo(`work-preflight-${name}-agy`);
     const argsFile = join(h.scratch, `args-preflight-${name}-agy`);
     const result = spawnSync(process.execPath, [
       h.relayPath("agy"), "--brief", h.briefPath, "--cd", workDir,
-      "--out-dir", outDir, "--preflight-usage",
+      "--out-dir", outDir, "--preflight-usage", ...extraArgs,
     ], {
       env: { ...h.baseEnv, SMOKE_MODE: "agy-usage-preflight", SMOKE_USAGE_MODE: usageMode, SMOKE_ARGS_FILE: argsFile },
       encoding: "utf8",
@@ -214,11 +214,24 @@ export async function runAgy(h) {
     typeof exhausted.value?.limit?.evidence?.source === "string" &&
     exhausted.value.limit.evidence.source.length > 0);
 
-  for (const [name, mode] of [["a failing probe", "fail"], ["an unfamiliar payload", "unparseable"]]) {
-    const degraded = preflight(mode, mode);
+  // Every degraded probe must let the work through AND still say on the result why the check
+  // did not answer — a silently absent verdict reads like a healthy account. The hanging
+  // probe is the one that could wedge the relay before any result.json exists: the dispatch
+  // watchdog is not armed during the probe, so --timeout cannot reach it and only the probe's
+  // own bound can end it. Passing --timeout 3s shortens that bound (it is the lesser of
+  // --timeout and the 10s probe ceiling), so the case costs seconds instead of the ceiling.
+  const degradedProbes = [
+    ["a failing probe", "fail", "unavailable", []],
+    ["an unfamiliar payload", "unparseable", "unparseable", []],
+    ["a hanging probe", "hang", "timeout", ["--timeout", "3s"]],
+  ];
+  for (const [name, mode, expectedStatus, extraArgs] of degradedProbes) {
+    const degraded = preflight(mode, mode, extraArgs);
     h.check(`agy preflight: ${name} never blocks the work`,
       degraded.dispatched &&
       degraded.value?.status === "completed" &&
       degraded.value?.failureClass === undefined);
+    h.check(`agy preflight: ${name} is recorded as usagePreflight.status "${expectedStatus}"`,
+      degraded.value?.usagePreflight?.status === expectedStatus);
   }
 }

--- a/test/relay/agy.mjs
+++ b/test/relay/agy.mjs
@@ -164,4 +164,61 @@ export async function runAgy(h) {
     analysis.value.status === "completed" &&
     analysis.value.exitCode === 0 &&
     analysis.value.finalMessage === "fake agy analysis completed");
+
+  // ---- --preflight-usage ----
+  // agy is the one implementer in the fleet with a verified headless quota query
+  // (`agy -p "/usage" --output-format json`: no conversation, no turns, no tokens). The
+  // flag may block a dispatch ONLY on true exhaustion — a probe that fails, hangs, or
+  // returns an unfamiliar shape must never stand between the user and their work.
+  const preflight = (name, usageMode) => {
+    const outDir = join(h.scratch, `out-preflight-${name}-agy`);
+    const workDir = h.freshRepo(`work-preflight-${name}-agy`);
+    const argsFile = join(h.scratch, `args-preflight-${name}-agy`);
+    const result = spawnSync(process.execPath, [
+      h.relayPath("agy"), "--brief", h.briefPath, "--cd", workDir,
+      "--out-dir", outDir, "--preflight-usage",
+    ], {
+      env: { ...h.baseEnv, SMOKE_MODE: "agy-usage-preflight", SMOKE_USAGE_MODE: usageMode, SMOKE_ARGS_FILE: argsFile },
+      encoding: "utf8",
+    });
+    return {
+      result,
+      value: existsSync(join(outDir, "result.json")) ? h.result(outDir) : null,
+      dispatched: existsSync(argsFile),
+    };
+  };
+
+  const healthy = preflight("healthy", "healthy");
+  h.check("agy preflight: quota remaining dispatches and records the provider's own numbers",
+    healthy.dispatched &&
+    healthy.value?.status === "completed" &&
+    healthy.value?.failureClass === undefined &&
+    healthy.value?.usagePreflight?.exhausted === false &&
+    Array.isArray(healthy.value?.usagePreflight?.buckets) &&
+    healthy.value.usagePreflight.buckets.length > 0);
+  h.check("agy preflight: one spent bucket among several does not block a dispatch",
+    healthy.dispatched &&
+    healthy.value?.usagePreflight?.buckets?.some((b) => b.remainingFraction === 0));
+
+  const exhausted = preflight("exhausted", "exhausted");
+  h.check("agy preflight: full exhaustion blocks the dispatch and classifies the result",
+    !exhausted.dispatched &&
+    exhausted.value?.status === "failed" &&
+    exhausted.value?.failureClass === "usage_limit" &&
+    exhausted.value?.limit?.kind === "quota_exhausted" &&
+    exhausted.result.status !== 0);
+  h.check("agy preflight: the blocked result carries the soonest stated reset",
+    typeof exhausted.value?.limit?.resetsAt === "string" &&
+    !Number.isNaN(Date.parse(exhausted.value.limit.resetsAt)));
+  h.check("agy preflight: the block names the query as its evidence",
+    typeof exhausted.value?.limit?.evidence?.source === "string" &&
+    exhausted.value.limit.evidence.source.length > 0);
+
+  for (const [name, mode] of [["a failing probe", "fail"], ["an unfamiliar payload", "unparseable"]]) {
+    const degraded = preflight(mode, mode);
+    h.check(`agy preflight: ${name} never blocks the work`,
+      degraded.dispatched &&
+      degraded.value?.status === "completed" &&
+      degraded.value?.failureClass === undefined);
+  }
 }

--- a/test/relay/cursor.mjs
+++ b/test/relay/cursor.mjs
@@ -238,9 +238,26 @@ if (!h.WIN) {
       value?.failureClass === expected.failureClass &&
       value?.limit?.kind === expected.kind &&
       run.status !== 0);
+    // Naming stderr.txt is not enough: the evidence has to be auditable, which means the
+    // artifact exists and artifactLine indexes the line the excerpt was actually read from.
+    // The shared matrix pins this for the stdout path (usage-limit.mjs); the stderr fallback
+    // is the one classification path it cannot drive. It matters most for the split case,
+    // where the reassembled excerpt must still resolve to one whole line on disk.
+    const evidence = value?.limit?.evidence;
+    const stderrPath = join(outDir, expected.source);
+    const stderrLines = existsSync(stderrPath)
+      ? readFileSync(stderrPath, "utf8").split("\n")
+      : [];
     h.check(`cursor stderr limit (${name}): evidence names stderr as its source`,
-      value?.limit?.evidence?.source === expected.source &&
-      /usage limit/i.test(value?.limit?.evidence?.excerpt || ""));
+      evidence?.source === expected.source &&
+      /usage limit/i.test(evidence?.excerpt || ""));
+    h.check(`cursor stderr limit (${name}): artifactLine resolves to the recorded excerpt in stderr.txt`,
+      Number.isInteger(evidence?.artifactLine) &&
+      evidence.artifactLine > 0 &&
+      // Guard the excerpt: every line `includes("")`, so a null excerpt would pass the index
+      // check while proving nothing.
+      Boolean(evidence.excerpt) &&
+      Boolean(stderrLines[evidence.artifactLine - 1]?.includes(evidence.excerpt)));
   }
 }
 }

--- a/test/relay/cursor.mjs
+++ b/test/relay/cursor.mjs
@@ -195,4 +195,52 @@ if (!h.WIN) {
     h.result(outDir).status === "cursor_agent_unavailable" &&
     !existsSync(join(outDir, "final.txt")));
 }
+{
+  // The stderr fallback. cursor-agent can report the same stop as a bare, non-JSON
+  // `ActionRequiredError:` line on stderr with no limit-bearing turn_ended and no result
+  // envelope on stdout — the one path the shared matrix in usage-limit.mjs cannot drive,
+  // because it runs one stream per relay. The split case is the regression: stderr chunks
+  // arrive on `data` boundaries that fall anywhere, and a line torn mid-sentence must still
+  // classify. Before stderr lines were buffered across chunks, `ActionRequiredError: You` and
+  // `'ve hit your usage limit` landed as separate entries and a real limit reported as an
+  // unclassified failure.
+  const fixturePath = join(h.testDir, "fixtures", "usage-limit", "cursor.json");
+  const expected = JSON.parse(readFileSync(fixturePath, "utf8"))
+    .scenarios.usageLimitStderrFallback.expect;
+  for (const [name, extraEnv] of [
+    ["whole", {}],
+    // The delay is load-bearing: without it the pipe coalesces the small writes into a single
+    // `data` event and an unbuffered reader would pass this case by accident.
+    ["split across chunk boundaries", {
+      SMOKE_LIMIT_SPLIT: "1",
+      SMOKE_LIMIT_NO_TRAILING_NEWLINE: "1",
+      SMOKE_LIMIT_SPLIT_DELAY_MS: "15",
+    }],
+  ]) {
+    const outDir = join(h.scratch, `out-stderr-limit-${name.split(" ")[0]}-cursor`);
+    const workDir = h.freshRepo(`work-stderr-limit-${name.split(" ")[0]}-cursor`);
+    const run = spawnSync(process.execPath, [
+      h.relayPath("cursor"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir,
+    ], {
+      env: {
+        ...h.baseEnv,
+        SMOKE_MODE: "usage-limit",
+        SMOKE_LIMIT_FIXTURE: fixturePath,
+        SMOKE_LIMIT_SCENARIO: "usageLimitStderrFallback",
+        SMOKE_LIMIT_STREAM: "stderr",
+        ...extraEnv,
+      },
+      encoding: "utf8",
+    });
+    const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : null;
+    h.check(`cursor stderr limit (${name}): classifies from the ActionRequiredError line`,
+      value?.status === expected.status &&
+      value?.failureClass === expected.failureClass &&
+      value?.limit?.kind === expected.kind &&
+      run.status !== 0);
+    h.check(`cursor stderr limit (${name}): evidence names stderr as its source`,
+      value?.limit?.evidence?.source === expected.source &&
+      /usage limit/i.test(value?.limit?.evidence?.excerpt || ""));
+  }
+}
 }

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -16,6 +16,7 @@ import { runTimeoutTree } from "./timeout-tree.mjs";
 import { runAbort } from "./abort.mjs";
 import { runDelegateSetup } from "./delegate-setup.mjs";
 import { runAider } from "./aider.mjs";
+import { runUsageLimit } from "./usage-limit.mjs";
 
 export const runners = [
   ["package-shape", runPackageShape],
@@ -36,4 +37,5 @@ export const runners = [
   ["timeout-tree", runTimeoutTree],
   ["abort", runAbort],
   ["delegate-setup", runDelegateSetup],
+  ["usage-limit", runUsageLimit],
 ];

--- a/test/relay/usage-limit.mjs
+++ b/test/relay/usage-limit.mjs
@@ -1,0 +1,229 @@
+/**
+ * delegate-skills · usage-limit classification behavior matrix.
+ *
+ * The cross-relay gate for `failureClass: "usage_limit"`. Per-CLI signatures differ by
+ * design (each implementer's terminal event and error wording is its own), so the relays
+ * cannot be byte-compared the way the shared helpers in relay-parity.mjs are. What must
+ * be identical is the BEHAVIOR, so every enrolled relay runs the same scenario set here:
+ *
+ *   1. a terminal usage-limit failure classifies, preserving the resume handle and
+ *      whatever partial work the implementer left behind
+ *   2. the same run split across awkward chunk boundaries with no trailing newline
+ *      still classifies (transport faithfulness)
+ *   3. a stated duration becomes retryAt; an ambiguous human reset time becomes null
+ *   4. an unrelated terminal failure stays unclassified
+ *   5. trigger words in NON-terminal events plus an unrelated failure stay unclassified
+ *   6. a recovered run that completes stays completed
+ *   7. a limit with a zero exit code is still normalized to a failure
+ *   8. the relay's own kill (watchdog, orchestrator) outranks any classification
+ *   9. a reused --out-dir never serves the previous run's artifacts
+ *
+ * Enrolling a relay is one row in ENROLLED plus a capture bundle under
+ * fixtures/usage-limit/. A CLI whose limit signature has not been captured is not
+ * enrolled and keeps reporting an unclassified "failed" — that is the fail-closed
+ * default the plan requires, not a gap in this suite.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { EXTRA_ARGS } from "../harness/constants.mjs";
+
+// cli:          relay + skill directory name (skills/<cli>-delegate/)
+// fixture:      capture bundle under test/fixtures/usage-limit/
+// stream:       where that CLI emits the terminal failure the relay parses
+// resumeField:  the result field holding that CLI's resume handle — each implementer names
+//               its own (Codex threads, everyone else sessions). null when a limit run has
+//               no handle to preserve, which must be justified in the comment.
+export const ENROLLED = [
+  { cli: "codex", fixture: "codex.json", stream: "stdout", resumeField: "threadId" },
+  { cli: "cursor", fixture: "cursor.json", stream: "stdout", resumeField: "sessionId" },
+  // grok reports its session id only on the `end` line, which a limit run never reaches —
+  // partial work there resumes with --resume-last, not a captured handle.
+  { cli: "grok", fixture: "grok.json", stream: "stdout", resumeField: null },
+  { cli: "qoder", fixture: "qoder.json", stream: "stdout", resumeField: "sessionId" },
+  { cli: "opencode", fixture: "opencode.json", stream: "stdout", resumeField: "sessionId" },
+];
+
+export async function runUsageLimit(h) {
+  h.check("usage-limit: at least one relay is enrolled", ENROLLED.length > 0);
+  for (const entry of ENROLLED) await runMatrix(h, entry);
+}
+
+async function runMatrix(h, entry) {
+  const tag = `usage-limit[${entry.cli}]`;
+  const fixturePath = join(h.testDir, "fixtures", "usage-limit", entry.fixture);
+  if (!existsSync(fixturePath)) {
+    h.check(`${tag}: capture bundle exists`, false);
+    return;
+  }
+  const bundle = JSON.parse(readFileSync(fixturePath, "utf8"));
+
+  const env = (scenario, extra = {}) => ({
+    ...h.baseEnv,
+    SMOKE_MODE: "usage-limit",
+    SMOKE_LIMIT_FIXTURE: fixturePath,
+    SMOKE_LIMIT_SCENARIO: scenario,
+    SMOKE_LIMIT_STREAM: entry.stream,
+    ...extra,
+  });
+
+  const run = (scenario, { name, extraArgs = [], extraEnv = {}, writeFile = null }) => {
+    const outDir = join(h.scratch, `ul-${entry.cli}-${name}`);
+    const workDir = h.freshRepo(`ul-${entry.cli}-${name}-repo`);
+    const proc = spawnSync(process.execPath, [
+      h.relayPath(entry.cli), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir,
+      ...(EXTRA_ARGS[entry.cli] || []), ...extraArgs,
+    ], {
+      env: env(scenario, writeFile ? { ...extraEnv, SMOKE_WRITE_FILE: join(workDir, writeFile) } : extraEnv),
+      encoding: "utf8",
+    });
+    const result = existsSync(join(outDir, "result.json")) ? h.result(outDir) : null;
+    return { proc, result, outDir, workDir };
+  };
+
+  // ---- 1. a terminal usage-limit failure classifies ----
+  const expected = bundle.scenarios.usageLimit.expect;
+  const limit = run("usageLimit", { name: "limit", writeFile: "partial.txt" });
+  h.check(`${tag}: status stays "failed" — the status enum is not widened`,
+    limit.result?.status === "failed");
+  h.check(`${tag}: failureClass classifies the run`,
+    limit.result?.failureClass === "usage_limit");
+  h.check(`${tag}: kind distinguishes the response`,
+    limit.result?.limit?.kind === expected.kind);
+  h.check(`${tag}: evidence is structured and auditable`, (() => {
+    const evidence = limit.result?.limit?.evidence;
+    return Boolean(evidence)
+      && typeof evidence.source === "string" && evidence.source.length > 0
+      && typeof evidence.excerpt === "string" && evidence.excerpt.length > 0
+      && Number.isInteger(evidence.artifactLine) && evidence.artifactLine > 0;
+  })());
+  h.check(`${tag}: evidence excerpt is bounded`,
+    (limit.result?.limit?.evidence?.excerpt || "").length <= 401);
+  h.check(`${tag}: evidence.artifactLine points at a real events.jsonl line`, (() => {
+    const line = limit.result?.limit?.evidence?.artifactLine;
+    const events = readFileSync(join(limit.outDir, "events.jsonl"), "utf8").split("\n").filter(Boolean);
+    return Number.isInteger(line) && line >= 1 && line <= events.length;
+  })());
+  if (entry.resumeField) {
+    // Partial work must stay resumable after the reset — for implementers that have a
+    // handle at all. Aider and friends have no session ids; the diff is their only record.
+    h.check(`${tag}: the resume handle (${entry.resumeField}) survives the limit`,
+      typeof limit.result?.[entry.resumeField] === "string" && limit.result[entry.resumeField].length > 0);
+  }
+  h.check(`${tag}: partial work is still reported`,
+    Array.isArray(limit.result?.touchedFiles) && limit.result.touchedFiles.some((f) => f.includes("partial.txt")));
+  h.check(`${tag}: the relay exits non-zero`, limit.proc.status !== 0);
+  h.check(`${tag}: the hint forbids reworking the brief`,
+    /do not rework/i.test(limit.proc.stdout || ""));
+  if (expected.resetsAt !== undefined) {
+    h.check(`${tag}: a zoned reset timestamp is parsed`,
+      limit.result?.limit?.resetsAt === expected.resetsAt);
+  }
+
+  // ---- 2. transport faithfulness: split chunks, no trailing newline ----
+  const split = run("usageLimit", {
+    name: "split",
+    extraEnv: { SMOKE_LIMIT_SPLIT: "1", SMOKE_LIMIT_NO_TRAILING_NEWLINE: "1" },
+  });
+  h.check(`${tag}: classifies across split chunks with no trailing newline`,
+    split.result?.status === "failed" && split.result?.failureClass === "usage_limit");
+
+  // ---- 3. reset-time parsing, both directions ----
+  if (entry.resumeField) {
+    h.check(`${tag}: the resume handle survives chunk splitting`,
+      typeof split.result?.[entry.resumeField] === "string" && split.result[entry.resumeField].length > 0);
+  }
+
+  if (bundle.scenarios.usageLimitRetryAfter) {
+    const retry = run("usageLimitRetryAfter", { name: "retry" });
+    h.check(`${tag}: a stated duration becomes retryAt`,
+      typeof retry.result?.limit?.retryAt === "string"
+      && !Number.isNaN(Date.parse(retry.result.limit.retryAt)));
+    // The kind comes from the bundle, not from this file: a CLI that surfaces transient
+    // throttling reports "rate_limited" here, while one that only ever exposes hard
+    // exhaustion (OpenCode retries a 429 forever and never forwards it) says so instead.
+    h.check(`${tag}: the retry-after case reports its documented kind`,
+      retry.result?.limit?.kind === bundle.scenarios.usageLimitRetryAfter.expect.kind);
+  }
+  if (bundle.scenarios.usageLimitAmbiguousReset) {
+    const ambiguous = run("usageLimitAmbiguousReset", { name: "ambiguous" });
+    h.check(`${tag}: an ambiguous human reset time is never guessed`,
+      ambiguous.result?.limit?.retryAt === null && ambiguous.result?.limit?.resetsAt === null);
+    h.check(`${tag}: a message-only match still classifies`,
+      ambiguous.result?.failureClass === "usage_limit");
+  }
+
+  // ---- 4/5. false positives: unrelated failure, and trigger words in prose ----
+  const unrelated = run("unrelatedFailure", { name: "unrelated" });
+  h.check(`${tag}: an unrelated terminal failure stays unclassified`,
+    unrelated.result?.status === "failed" && unrelated.result?.failureClass === undefined);
+  h.check(`${tag}: no limit object on an unclassified failure`,
+    unrelated.result?.limit === undefined);
+
+  const prose = run("proseThenUnrelatedFailure", { name: "prose" });
+  h.check(`${tag}: trigger words in non-terminal events do not classify`,
+    prose.result?.status === "failed" && prose.result?.failureClass === undefined);
+
+  // ---- 6. a recovered run that completes is a clean completion ----
+  const recovered = run("recoveredThenSuccess", { name: "recovered" });
+  h.check(`${tag}: a superseded limit event does not spoil a completed run`,
+    recovered.result?.status === "completed" && recovered.result?.failureClass === undefined);
+  h.check(`${tag}: a completed run exits zero`, recovered.proc.status === 0);
+
+  // ---- 7. a limit is never a success, even on a zero exit ----
+  const exitZero = run("usageLimitExitZero", { name: "exitzero" });
+  h.check(`${tag}: a limit with exit 0 is normalized to a failure`,
+    exitZero.result?.status === "failed" && exitZero.result?.failureClass === "usage_limit");
+  h.check(`${tag}: the normalized failure exits non-zero`,
+    exitZero.result?.exitCode !== 0 && exitZero.proc.status !== 0);
+
+  // ---- 8. precedence: a run the relay itself ended is never a classification ----
+  const timedOut = run("usageLimit", {
+    name: "timeout",
+    extraArgs: ["--timeout", "1s"],
+    extraEnv: { SMOKE_LIMIT_HANG: "1" },
+  });
+  h.check(`${tag}: the watchdog outranks the classification`,
+    timedOut.result?.status === "timeout" && timedOut.result?.failureClass === undefined);
+
+  // ---- extra: per-CLI hardening cases, asserted straight from the bundle ----
+  // A relay may list scenarios in `hardening` whose only contract is the `expect` block:
+  // the adversarial shapes that CLI's own transport makes possible. Each is checked
+  // field-by-field, so a bundle can pin "classifies but refuses the time" as easily as
+  // "must not classify at all".
+  for (const name of bundle.hardening || []) {
+    const scenario = bundle.scenarios[name];
+    if (!scenario) {
+      h.check(`${tag}: hardening scenario ${name} exists`, false);
+      continue;
+    }
+    const got = run(name, { name: `hard-${name}` });
+    for (const [field, want] of Object.entries(scenario.expect || {})) {
+      const actual = field === "status" || field === "failureClass" || field === "exitCode"
+        ? got.result?.[field]
+        : got.result?.limit?.[field];
+      // `null` in a bundle means "this field must not be set to anything" — an absent
+      // failureClass and an explicit null are both acceptable there.
+      const ok = want === null ? (actual === null || actual === undefined) : actual === want;
+      h.check(`${tag}: hardening ${name} — ${field} is ${JSON.stringify(want)}`, ok);
+    }
+  }
+
+  // ---- 9. a reused --out-dir never serves the previous run's artifacts ----
+  const reuseDir = join(h.scratch, `ul-${entry.cli}-reuse`);
+  const reuseRepo = h.freshRepo(`ul-${entry.cli}-reuse-repo`);
+  mkdirSync(reuseDir, { recursive: true });
+  writeFileSync(join(reuseDir, "result.json"),
+    JSON.stringify({ schema: "delegate-relay.result.v1", status: "completed", exitCode: 0, finalMessage: "STALE REPORT" }), "utf8");
+  writeFileSync(join(reuseDir, "final.txt"), "STALE REPORT", "utf8");
+  const reuse = spawnSync(process.execPath, [
+    h.relayPath(entry.cli), "--brief", h.briefPath, "--cd", reuseRepo, "--out-dir", reuseDir,
+    ...(EXTRA_ARGS[entry.cli] || []),
+  ], { env: env("usageLimit"), encoding: "utf8" });
+  const reuseResult = existsSync(join(reuseDir, "result.json")) ? h.result(reuseDir) : null;
+  h.check(`${tag}: a reused out-dir reports this run, not the stale one`,
+    reuseResult?.status === "failed" && reuseResult?.failureClass === "usage_limit");
+  h.check(`${tag}: a stale final report is not inherited`,
+    !JSON.stringify(reuseResult ?? {}).includes("STALE REPORT"));
+  h.check(`${tag}: the reused run still exits non-zero`, reuse.status !== 0);
+}

--- a/test/relay/usage-limit.mjs
+++ b/test/relay/usage-limit.mjs
@@ -144,10 +144,25 @@ async function runMatrix(h, entry) {
   }
 
   if (bundle.scenarios.usageLimitRetryAfter) {
+    const retryExpect = bundle.scenarios.usageLimitRetryAfter.expect;
+    const before = Date.now();
     const retry = run("usageLimitRetryAfter", { name: "retry" });
+    const after = Date.now();
     h.check(`${tag}: a stated duration becomes retryAt`,
       typeof retry.result?.limit?.retryAt === "string"
       && !Number.isNaN(Date.parse(retry.result.limit.retryAt)));
+    // "It parses as a date" would also pass for a timestamp the relay invented, so pin the
+    // value: retryAt must land the bundle's own stated retry_after ahead of the moment the
+    // relay read the event, which happened somewhere inside [before, after]. Bounding with
+    // that window rather than a fixed tolerance means a slow machine widens the bound
+    // instead of flaking. The duration comes from the bundle because each CLI states its
+    // own — codex's capture says 120s, OpenCode's says 600s.
+    if (Number.isFinite(retryExpect?.retryAfterSeconds)) {
+      const offset = retryExpect.retryAfterSeconds * 1000;
+      const parsed = Date.parse(retry.result?.limit?.retryAt ?? "");
+      h.check(`${tag}: retryAt is the stated ${retryExpect.retryAfterSeconds}s ahead, not a guess`,
+        Number.isFinite(parsed) && parsed >= before + offset - 2000 && parsed <= after + offset + 2000);
+    }
     // The kind comes from the bundle, not from this file: a CLI that surfaces transient
     // throttling reports "rate_limited" here, while one that only ever exposes hard
     // exhaustion (OpenCode retries a 429 forever and never forwards it) says so instead.
@@ -225,6 +240,12 @@ async function runMatrix(h, entry) {
   writeFileSync(join(reuseDir, "result.json"),
     JSON.stringify({ schema: "delegate-relay.result.v1", status: "completed", exitCode: 0, finalMessage: "STALE REPORT" }), "utf8");
   writeFileSync(join(reuseDir, "final.txt"), "STALE REPORT", "utf8");
+  // Seed a stale event stream too. events.jsonl is the artifact evidence.artifactLine indexes
+  // into, so leftover lines at the top would shift every offset by their count: the evidence
+  // would point at the wrong record while still looking auditable, which is worse than no
+  // evidence at all. The relays truncate it on reuse; nothing pinned that until now.
+  writeFileSync(join(reuseDir, "events.jsonl"),
+    '{"type":"stale","note":"STALE EVENT"}\n{"type":"stale","note":"STALE EVENT"}\n', "utf8");
   const reuse = spawnSync(process.execPath, [
     h.relayPath(entry.cli), "--brief", h.briefPath, "--cd", reuseRepo, "--out-dir", reuseDir,
     ...(EXTRA_ARGS[entry.cli] || []),
@@ -234,5 +255,12 @@ async function runMatrix(h, entry) {
     reuseResult?.status === "failed" && reuseResult?.failureClass === "usage_limit");
   h.check(`${tag}: a stale final report is not inherited`,
     !JSON.stringify(reuseResult ?? {}).includes("STALE REPORT"));
+  h.check(`${tag}: a reused out-dir does not keep the previous run's events`, (() => {
+    const reuseEventsPath = join(reuseDir, "events.jsonl");
+    if (!existsSync(reuseEventsPath)) return false;
+    return !readFileSync(reuseEventsPath, "utf8").includes("STALE EVENT");
+  })());
+  h.check(`${tag}: evidence.artifactLine still resolves to this run's terminal event`,
+    reuseResult?.limit?.evidence?.artifactLine === expected.artifactLine);
   h.check(`${tag}: the reused run still exits non-zero`, reuse.status !== 0);
 }

--- a/test/relay/usage-limit.mjs
+++ b/test/relay/usage-limit.mjs
@@ -99,10 +99,19 @@ async function runMatrix(h, entry) {
   })());
   h.check(`${tag}: evidence excerpt is bounded`,
     (limit.result?.limit?.evidence?.excerpt || "").length <= 401);
-  h.check(`${tag}: evidence.artifactLine points at a real events.jsonl line`, (() => {
+  // Bounds alone would pass on any line of a short bundle, so the check is against the
+  // bundle's own `artifactLine`: the 1-based events.jsonl line of the terminal event that
+  // CLI classifies on. That catches an off-by-one in a relay's object counter — evidence
+  // pointing at the wrong record is worse than none, because it reads as auditable.
+  // The file is read defensively: a relay that died before writing artifacts must fail
+  // this one check, not throw out of the matrix and skip every check after it.
+  h.check(`${tag}: evidence.artifactLine points at the terminal event in events.jsonl`, (() => {
     const line = limit.result?.limit?.evidence?.artifactLine;
-    const events = readFileSync(join(limit.outDir, "events.jsonl"), "utf8").split("\n").filter(Boolean);
-    return Number.isInteger(line) && line >= 1 && line <= events.length;
+    const eventsPath = join(limit.outDir, "events.jsonl");
+    if (!existsSync(eventsPath)) return false;
+    const events = readFileSync(eventsPath, "utf8").split("\n").filter(Boolean);
+    if (!Number.isInteger(line) || line < 1 || line > events.length) return false;
+    return line === expected.artifactLine;
   })());
   if (entry.resumeField) {
     // Partial work must stay resumable after the reset — for implementers that have a


### PR DESCRIPTION
## Summary

This PR introduces standardized usage-limit classification across multiple delegate skills (`agy`, `codex`, `cursor`, `grok`, `opencode`, `qoder`). It adds necessary fixtures and tests to ensure limit parsing parity for all supported implementers.

## What Changed

### Documentation
- Updated `AGENTS.md` and `README.md` to establish the vocabulary and rules for usage-limit classification.
- Updated `SKILL.md` and `references/dispatch-and-poll.md` for `agy`, `codex`, `cursor`, `grok`, `opencode`, and `qoder` to document the limits structure.

### Relay Implementations
- Implemented robust limit parsing in `scripts/relay.mjs` for:
  - `agy-delegate`
  - `codex-delegate`
  - `cursor-delegate`
  - `grok-delegate`
  - `opencode-delegate`
  - `qoder-delegate`
- Minor tweaks to `claude-delegate` and `kimi-delegate`.

### Testing
- Added `test/relay/usage-limit.mjs` to matrix-test the usage limit classification.
- Added live-captured usage limit fixtures under `test/fixtures/usage-limit/` for `codex`, `cursor`, `grok`, `opencode`, and `qoder`.
- Added mock logic in `test/fixtures/fake-cli.cjs` and `test/relay/agy.mjs`.

## Files Changed

- Numerous additions across `skills/*/scripts/relay.mjs` and documentation.
- New test fixtures in `test/fixtures/usage-limit/*.json`.

## Testing

- Unit/Integration tested through the newly added `test/relay/usage-limit.mjs` matrix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent usage-limit detection across supported relay integrations.
  * Added evidence, reset details, and recovery guidance while preserving failed status.
  * Added optional Antigravity preflight quota checks that block dispatch only when all quotas are exhausted.
  * Improved partial-work, session-resumption, and clean-tree re-dispatch handling.

* **Bug Fixes**
  * Prevented stale artifacts in reused output directories.
  * Avoided misclassifying ambiguous errors or recovered runs.

* **Documentation**
  * Documented usage-limit behavior, metadata, troubleshooting, and recovery workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->