### PR TITLE
feat: add freebuff-delegate implementer skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ jargon. Use these terms; don't invent synonyms.
 | `--prompt`, `--output` (`streaming`/`json`/`text`), `--agent` (`plan`/`accept-edits`/`auto-approve`), `--max-turns`, `--max-price`, `--max-tokens`, `--trust`, `--resume`, `--continue`, `--enabled-tools`, `--disabled-tools` | Mistral Vibe's own terms — use verbatim when discussing `vibe` | don't invent a Vibe sandbox enum; `--trust` is not a permission mode |
 | `session`, `--continue`, `--session`, `print mode`, `--mode json`, `tools`, `context files`, `project trust` | Pi's own terms — use verbatim when discussing `pi` | don't paraphrase them |
 | `--message-file`, `--yes-always`, `--suggest-shell-commands`, `--auto-commits`/`--dirty-commits`, `--dry-run`, `--edit-format`, `--architect`, `--file`/`--read`, `chat history` | Aider's own terms — use verbatim when discussing `aider` | Aider has no sandbox, no permission modes, and no session ids; don't imply any. `--file`/`--read` scope the chat context — never call them a boundary |
+| `--continue`, `--cwd`, interactive TUI, `login` | Freebuff's own terms — use them verbatim when discussing `freebuff` | don't invent a headless prompt flag, read-only mode, permission mode, or model flag |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`pi-delegate`](skills/pi-delegate/SKILL.md) | [Pi](https://github.com/earendil-works/pi-mono) (`pi`) | full local tools — no sandbox, no permission modes [^none]; project trust opt-in | `--read-only` (`read,grep,find,ls`) | `--resume-last`, `--session <id>` |
 | [`qoder-delegate`](skills/qoder-delegate/SKILL.md) | [Qoder](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` permission mode; bypass opt-in | `--permission-mode plan` | `--resume-last`, `--resume <id>` |
 | [`vibe-delegate`](skills/vibe-delegate/SKILL.md) | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits`; `--full-access` opt-in | `--plan-only` (`plan` agent) | `--resume-last`, `--session <id>` |
+| [`freebuff-delegate`](skills/freebuff-delegate/SKILL.md) | Freebuff (`freebuff`) | interactive, human-supervised; relay never commits | — | `--resume-last`, `--session <id>` |
 
 [^none]: No CLI-enforced read-only mode. `touchedFiles` and the diff, not a flag, are the guarantee.
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -16,7 +16,8 @@
         "vibe-delegate",
         "cursor-delegate",
         "pi-delegate",
-        "aider-delegate"
+        "aider-delegate",
+        "freebuff-delegate"
       ]
     },
     {

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -264,6 +264,22 @@ export const IMPLEMENTERS = Object.freeze([
     supports: ["model", "timeout", "readOnly"],
     winShell: false,
   },
+  {
+    key: "freebuff",
+    skill: "freebuff-delegate",
+    binary: "freebuff",
+    versionArgs: ["--version"],
+    // Freebuff exposes `login`, but no documented credential-free login-status probe.
+    authProbe: null,
+    // No documented model-list command that is safe to probe without invoking a task.
+    modelProbe: null,
+    // No documented session-store layout that can be inspected without opening conversation content.
+    usageProbe: null,
+    // Freebuff currently exposes no documented read-only/model/permission lane dials.
+    // `timeout` is enforced by the relay, not Freebuff.
+    supports: ["timeout"],
+    winShell: true,
+  },
 ]);
 
 /** Prototype-free map so names like "toString" cannot pass as implementers. */

--- a/skills/freebuff-delegate/SKILL.md
+++ b/skills/freebuff-delegate/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: freebuff-delegate
+description: >-
+  Delegate a coding task to the Freebuff CLI as an interactive implementer, then review its Git diff and
+  land it yourself. Use this when the user explicitly wants Freebuff to implement a bounded coding task,
+  continue a Freebuff conversation, or run a queue where each task is reviewed before commit. Freebuff is
+  an interactive TUI: this skill never injects prompts, simulates keystrokes, or claims headless execution.
+license: MIT
+compatibility: Requires the `freebuff` CLI installed and authenticated, Node 18+, git, and a real interactive terminal. Freebuff's own CLI currently exposes `--continue` and `--cwd`; it does not expose a documented headless prompt or read-only flag.
+metadata:
+  version: 0.1.0
+---
+
+# Freebuff Delegate
+
+You are the **orchestrator**. This skill lets you prepare a bounded coding task for the **Freebuff** CLI,
+open Freebuff in the target repository, and then review the resulting working-tree diff yourself.
+
+Freebuff is intentionally treated as an **interactive TUI implementer**. The relay does not type into the
+TUI, paste the brief on the user's behalf, scrape conversation content, or call Freebuff's backend directly.
+The human must remain present and start/drive the Freebuff session through the normal CLI.
+
+## When to use this
+
+Use this skill when the user explicitly asks for Freebuff to implement or continue a coding task and the
+result will be reviewed from the Git working tree.
+
+Do not use it for:
+
+- headless/CI execution: Freebuff does not expose a documented non-interactive prompt interface;
+- read-only review: Freebuff does not expose a documented read-only mode;
+- API/server automation: the relay has no network client and must not bypass the official CLI;
+- tasks small enough that delegation overhead is not worthwhile.
+
+## Prerequisites
+
+1. `freebuff --version` succeeds.
+2. Freebuff is authenticated through its normal login flow.
+3. The target directory is a Git working tree.
+4. The orchestrator is running in a terminal with stdin/stdout attached to a TTY.
+
+## The loop
+
+### 1. Write the brief
+
+The brief must be self-contained. Include the goal, current state, exact scope, what must remain untouched,
+project gates, and the report you want Freebuff to give the human at the end of the session.
+
+The relay writes the brief to `handoff.md`. It does **not** paste or type it into Freebuff.
+
+### 2. Dispatch — human-driven
+
+Run:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo --confirm-human
+```
+
+The relay will:
+
+- validate the brief and repository;
+- write a durable handoff copy into its output directory;
+- print the exact handoff instructions;
+- launch `freebuff --cwd <repo>` with inherited terminal I/O;
+- optionally add `--continue` or `--continue <conversation-id>` when requested;
+- never inject the brief into the TUI.
+
+Resume the latest conversation:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief delta.txt --cd /path/to/repo --resume-last --confirm-human
+```
+
+Resume a known conversation id:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief delta.txt --cd /path/to/repo --session <id> --confirm-human
+```
+
+The relay requires `--confirm-human` so an orchestrator cannot silently turn an interactive product into an
+unattended automation path.
+
+### 3. Review
+
+When Freebuff exits, the relay records `touchedFiles` from Git and writes `result.json`. Do not trust a
+human summary as proof of correctness. Re-run the project's actual gates yourself and inspect the diff.
+
+Freebuff has no relay-enforced read-only mode, so every implementation run should be treated as write-capable.
+
+### 4. Land
+
+Only after the gates pass and the diff matches the brief, commit the verified changes yourself.
+The relay never commits.
+
+## Result contract
+
+The relay writes `delegate-relay.result.v1` with:
+
+- `status` — `completed`, `failed`, `timeout`, `aborted`, `freebuff_unavailable`, or `handoff_error`;
+- `exitCode` and `signal`;
+- `freebuffVersion` when the version probe succeeds;
+- `finalMessage` — a factual relay-generated completion note. Freebuff does not expose a machine-readable
+  final report through the documented CLI surface, so the relay never fabricates one;
+- `touchedFiles` — Git porcelain paths, `[]` when clean, or `null` if Git cannot report them;
+- `sessionId` when the user supplied a known conversation id. The relay does not read Freebuff's private
+  conversation store to discover ids.
+
+## Trust boundary
+
+`relay.mjs` uses Node built-ins only. It makes no network calls, reads or writes no credentials, sends no
+telemetry, and only launches `freebuff` and `git` plus the platform process launcher required for Windows
+process-tree termination. Freebuff itself performs its normal authentication and service communication.

--- a/skills/freebuff-delegate/references/dispatch-and-poll.md
+++ b/skills/freebuff-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,38 @@
+# Dispatch and poll
+
+Freebuff is an interactive terminal product. This reference intentionally documents a human-driven dispatch,
+not a headless automation mechanism.
+
+## Dispatch
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo --confirm-human
+```
+
+The relay verifies that stdin/stdout are TTYs, saves `handoff.md`, prints the handoff location, and launches:
+
+```text
+freebuff --cwd <repo>
+```
+
+For continuation, the relay maps the project's neutral terms to Freebuff's own CLI terms:
+
+```text
+--resume-last       -> freebuff --continue
+--session <id>      -> freebuff --continue <id>
+```
+
+No other Freebuff CLI flag is invented by this skill.
+
+## Completion
+
+The relay waits for the Freebuff process to exit. It then records the Git-visible working-tree state in
+`result.json`. This is the source of truth for whether the work left a diff.
+
+The relay does not scrape the TUI, inspect private conversation files, or claim a machine-readable final
+message that the CLI does not expose.
+
+## Timeouts
+
+`--timeout 2h` is a relay-side watchdog. On timeout the child process is terminated and the result status is
+`timeout`.

--- a/skills/freebuff-delegate/references/multi-task-queues.md
+++ b/skills/freebuff-delegate/references/multi-task-queues.md
@@ -1,0 +1,14 @@
+# Multi-task queues
+
+Freebuff is interactive, so a queue is sequential and human-supervised.
+
+For each task:
+
+1. Write a fresh self-contained brief.
+2. Run `relay.mjs` with `--confirm-human`.
+3. Work the task in the Freebuff TUI.
+4. Review the resulting diff and re-run the project's gates.
+5. Land or reject the diff before moving to the next task.
+
+Do not batch unrelated tasks into one Freebuff conversation. A delta brief is appropriate only when correcting
+or completing the same bounded task.

--- a/skills/freebuff-delegate/references/review-and-land.md
+++ b/skills/freebuff-delegate/references/review-and-land.md
@@ -1,0 +1,26 @@
+# Review and land
+
+Treat Freebuff's work exactly like any other untrusted implementation diff.
+
+## Review order
+
+1. Read `result.json` and note the relay status.
+2. Run `git status --short` and inspect the full diff.
+3. Compare every touched file to the brief.
+4. Re-run the project's actual gates yourself.
+5. Check for unrelated edits, generated files, credential material, and accidental commits.
+6. If the task is incomplete, prepare a delta brief and resume the same Freebuff conversation when you know
+   its conversation id.
+
+## Commit boundary
+
+Freebuff is told not to commit, but the relay does not enforce that policy by parsing Freebuff's chat.
+Before landing, verify:
+
+```bash
+git status --short
+git diff --stat
+git log -1 --oneline
+```
+
+Then commit the verified diff yourself.

--- a/skills/freebuff-delegate/references/writing-the-brief.md
+++ b/skills/freebuff-delegate/references/writing-the-brief.md
@@ -1,0 +1,40 @@
+# Writing the brief
+
+Freebuff is interactive, but the brief still follows the same contract as every other implementer.
+A human will paste it into the TUI, so make it easy to copy as one block.
+
+Use this shape:
+
+```text
+GOAL
+One sentence describing the desired outcome.
+
+CONTEXT
+What exists today and why the change is needed.
+
+SCOPE
+- Files/components that may change.
+- Behaviors that must be preserved.
+
+OUT OF SCOPE
+Explicitly name nearby work that must not be touched.
+
+GATES
+Use the commands discovered from AGENTS.md/CLAUDE.md/package scripts/Makefile.
+Do not invent project commands.
+
+IMPLEMENTATION NOTES
+Constraints, compatibility requirements, and edge cases.
+
+REPORT
+Before ending the session, summarize:
+- what changed;
+- files touched;
+- gates run and their results;
+- known limitations or follow-up work.
+
+COMMIT BOUNDARY
+Do not commit. Leave the verified changes in the working tree for the reviewer.
+```
+
+Keep one task per brief. A second task should be a new brief or a delta brief for the same conversation.

--- a/skills/freebuff-delegate/scripts/relay.mjs
+++ b/skills/freebuff-delegate/scripts/relay.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · freebuff-delegate · relay.mjs
+ *
+ * Human-supervised bridge to the Freebuff interactive CLI.
+ *
+ * Freebuff does not expose a documented headless prompt flag. This relay therefore
+ * never pastes or types the brief into the TUI. It saves the brief as handoff.md,
+ * prints the handoff instructions, launches Freebuff with inherited terminal I/O,
+ * and records the resulting Git worktree state after the user exits Freebuff.
+ *
+ * Trust posture: Node built-ins only. No network calls, credentials, telemetry,
+ * prompt injection, private conversation scraping, or commits.
+ */
+
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const RESULT_VERSION = "delegate-relay.result.v1";
+const MAX_TIMER_MS = 2_147_483_647;
+const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const DUR_RE = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/;
+
+function usage() {
+  return `Usage: node relay.mjs --brief <file> [options]
+
+Options:
+  --brief <file>       Self-contained task brief; stdin is accepted when omitted.
+  --cd <dir>           Target Git working tree (default: current directory).
+  --lane <name>        Fleet lane name; Freebuff currently has no documented lane dials.
+  --resume-last        Start Freebuff with --continue.
+  --session <id>       Start Freebuff with --continue <id>.
+  --timeout <dur>      Relay watchdog: 30m, 2h, 90s, etc.
+  --confirm-human      Explicitly confirm a human will stay present and operate Freebuff.
+  --skip-git-repo-check  Allow a non-Git directory (not recommended).
+  --out-dir <dir>      Output directory for handoff.md and result.json.
+  -h, --help           Show this help.
+
+Important: Freebuff is interactive. This relay never injects the brief into Freebuff or provides a headless mode.
+`;
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`freebuff relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(value) {
+  const m = DUR_RE.exec(value);
+  if (!m || (!m[1] && !m[2] && !m[3])) return null;
+  const seconds = BigInt(m[1] || 0) * 3600n + BigInt(m[2] || 0) * 60n + BigInt(m[3] || 0);
+  const ms = seconds * 1000n;
+  if (ms <= 0n || ms > BigInt(MAX_TIMER_MS)) return null;
+  return Number(ms);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    brief: null,
+    cd: process.cwd(),
+    lane: null,
+    resumeLast: false,
+    session: null,
+    timeout: null,
+    confirmHuman: false,
+    skipGitRepoCheck: false,
+    outDir: null,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      if (argv[i + 1] === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return argv[i];
+    };
+
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(usage());
+        process.exit(0);
+        break;
+      case "--brief":
+        opts.brief = next();
+        break;
+      case "--cd":
+        opts.cd = resolve(next());
+        break;
+      case "--lane":
+        opts.lane = next();
+        break;
+      case "--resume-last":
+        opts.resumeLast = true;
+        break;
+      case "--session":
+        opts.session = next();
+        break;
+      case "--timeout":
+        opts.timeout = next();
+        break;
+      case "--confirm-human":
+        opts.confirmHuman = true;
+        break;
+      case "--skip-git-repo-check":
+        opts.skipGitRepoCheck = true;
+        break;
+      case "--out-dir":
+        opts.outDir = resolve(next());
+        break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+
+  if (opts.resumeLast && opts.session) fail("--resume-last and --session are mutually exclusive");
+  if (opts.session && !SAFE_SESSION.test(opts.session)) fail("--session contains unsupported characters");
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`invalid --timeout ${opts.timeout}`);
+  }
+  if (!opts.confirmHuman) {
+    fail("Freebuff is interactive; pass --confirm-human to explicitly confirm human supervision");
+  }
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    fail("Freebuff requires an interactive TTY; piped/headless execution is intentionally unsupported");
+  }
+  return opts;
+}
+
+function readBrief(file) {
+  if (file) {
+    if (!existsSync(file)) fail(`brief file not found: ${file}`);
+    return readFileSync(file, "utf8");
+  }
+  if (process.stdin.isTTY) fail("no --brief given; pass --brief <file> (stdin is reserved for Freebuff's TUI)");
+  const value = readFileSync(0, "utf8");
+  if (!value.trim()) fail("brief is empty");
+  return value;
+}
+
+function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function isGitRepo(cwd) {
+  try {
+    git(cwd, ["rev-parse", "--show-toplevel"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function touchedFiles(cwd) {
+  try {
+    const raw = git(cwd, ["status", "--porcelain=v1", "-z"]);
+    if (!raw) return [];
+    const fields = raw.split("\0").filter(Boolean);
+    return fields.map((field) => {
+      const value = field.slice(3);
+      if (value.includes(" -> ")) return value.split(" -> ")[1];
+      return value;
+    });
+  } catch {
+    return null;
+  }
+}
+
+function freebuffVersion(env) {
+  try {
+    const result = spawnSync("freebuff", ["--version"], {
+      cwd: process.cwd(),
+      env,
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      timeout: 10_000,
+    });
+    if (result.status === 0) return (result.stdout || result.stderr || "").trim() || null;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function outputDir(requested) {
+  const dir = requested || join(tmpdir(), `delegate-freebuff-${Date.now()}-${process.pid}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeResult(dir, result) {
+  const target = join(dir, "result.json");
+  const tmp = `${target}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  renameSync(tmp, target);
+}
+
+function killChild(child) {
+  if (!child?.pid) return;
+  if (process.platform === "win32") {
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+    } catch {}
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch {
+    try { child.kill("SIGTERM"); } catch {}
+  }
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts.brief);
+  if (!brief.trim()) fail("brief is empty");
+
+  if (!existsSync(opts.cd)) fail(`working directory not found: ${opts.cd}`);
+  if (!opts.skipGitRepoCheck && !isGitRepo(opts.cd)) fail(`not a Git working tree: ${opts.cd}`);
+
+  const outDir = outputDir(opts.outDir);
+  const handoff = join(outDir, "handoff.md");
+  writeFileSync(handoff, brief, "utf8");
+
+  const env = process.env;
+  const version = freebuffVersion(env);
+  if (!version) {
+    const unavailable = {
+      schema: RESULT_VERSION,
+      status: "freebuff_unavailable",
+      exitCode: 127,
+      signal: null,
+      freebuffVersion: null,
+      sessionId: opts.session || null,
+      finalMessage: "Freebuff was not found or did not answer `freebuff --version`.",
+      touchedFiles: touchedFiles(opts.cd),
+      handoffFile: handoff,
+    };
+    writeResult(outDir, unavailable);
+    process.stderr.write(`freebuff relay: Freebuff unavailable. See ${handoff}\n`);
+    process.exit(127);
+  }
+
+  if (opts.lane) {
+    process.stderr.write(`freebuff relay: lane ${opts.lane} selected; Freebuff currently exposes no documented lane dials.\n`);
+  }
+
+  process.stdout.write(`\n=== Freebuff handoff ===\n`);
+  process.stdout.write(`Brief saved to: ${handoff}\n`);
+  process.stdout.write(`Before continuing, read/copy that brief into the Freebuff TUI yourself.\n`);
+  process.stdout.write(`Human supervision is required for the entire Freebuff session.\n`);
+  process.stdout.write(`Do not ask Freebuff to commit; the reviewer owns the commit.\n`);
+  process.stdout.write(`========================\n\n`);
+
+  const args = ["--cwd", opts.cd];
+  if (opts.resumeLast) args.push("--continue");
+  if (opts.session) args.push("--continue", opts.session);
+
+  const child = spawn("freebuff", args, {
+    cwd: opts.cd,
+    env,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32",
+  });
+
+  let timedOut = false;
+  let abortSignal = null;
+  let timer = null;
+  if (opts.timeout) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child);
+    }, parseDuration(opts.timeout));
+  }
+
+  const finish = (code, signal) => {
+    if (timer) clearTimeout(timer);
+    const status = timedOut ? "timeout" : (code === 0 ? "completed" : "failed");
+    const result = {
+      schema: RESULT_VERSION,
+      status,
+      exitCode: code,
+      signal: signal || abortSignal || null,
+      freebuffVersion: version,
+      sessionId: opts.session || null,
+      finalMessage: status === "completed"
+        ? "Freebuff interactive session exited successfully. Review the Git diff; no machine-readable Freebuff final report was available to the relay."
+        : `Freebuff interactive session exited with code ${code ?? "null"}. Review the Git diff and terminal output.`,
+      touchedFiles: touchedFiles(opts.cd),
+      handoffFile: handoff,
+    };
+    writeResult(outDir, result);
+    process.stdout.write(`\nFreebuff relay result: ${join(outDir, "result.json")}\n`);
+    process.exit(code ?? (signal ? 1 : 0));
+  };
+
+  process.on("SIGINT", () => {
+    abortSignal = "SIGINT";
+    killChild(child);
+  });
+  process.on("SIGTERM", () => {
+    abortSignal = "SIGTERM";
+    killChild(child);
+  });
+  child.on("exit", finish);
+  child.on("error", (error) => {
+    if (timer) clearTimeout(timer);
+    const result = {
+      schema: RESULT_VERSION,
+      status: "freebuff_unavailable",
+      exitCode: 127,
+      signal: null,
+      freebuffVersion: version,
+      sessionId: opts.session || null,
+      finalMessage: `Failed to launch Freebuff: ${error.message}`,
+      touchedFiles: touchedFiles(opts.cd),
+      handoffFile: handoff,
+    };
+    writeResult(outDir, result);
+    process.exit(127);
+  });
+}
+
+main();

--- a/test/freebuff-delegate/relay-contract.mjs
+++ b/test/freebuff-delegate/relay-contract.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const relay = join(root, "skills/freebuff-delegate/scripts/relay.mjs");
+
+function run(args, input = "") {
+  return spawnSync(process.execPath, [relay, ...args], {
+    input,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+}
+
+const missing = run(["--confirm-human", "--brief", "/definitely/missing/brief.txt"]);
+if (missing.status !== 2) {
+  throw new Error(`expected validation/TTY fail-closed exit 2, got ${missing.status}`);
+}
+
+const temp = mkdtempSync(join(tmpdir(), "freebuff-relay-test-"));
+const brief = join(temp, "brief.txt");
+writeFileSync(brief, "test brief\n", "utf8");
+const noTty = run(["--confirm-human", "--brief", brief, "--cd", temp]);
+if (noTty.status !== 2) {
+  throw new Error(`expected non-TTY execution to fail closed with 2, got ${noTty.status}`);
+}
+
+console.log("freebuff-delegate relay contract checks passed");

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
+export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "freebuff"];
 
 export const EXTRA_ARGS = {
   claude: [],
@@ -15,6 +15,7 @@ export const EXTRA_ARGS = {
   cursor: [],
   pi: [],
   aider: [],
+  freebuff: [],
 };
 
 export const WIN = process.platform === "win32";


### PR DESCRIPTION
## Summary

Adds `freebuff-delegate`, an interactive, human-supervised Implementer integration for the Freebuff CLI.

## Changes

- Adds `skills/freebuff-delegate/` with `SKILL.md`, four references, and a Node built-ins-only relay.
- Adds a relay contract test and registers Freebuff in the relay harness.
- Registers `freebuff` in `delegate-setup` discovery/lane vocabulary.
- Registers `freebuff-delegate` in `skills.sh.json` and documents it in README/AGENTS.
- Preserves the `delegate-relay.result.v1` result contract and review-first workflow.

## Freebuff compatibility boundary

Freebuff is treated as an interactive TUI implementer. The relay does not inject prompts, simulate keystrokes, scrape private conversations, call a backend directly, or commit changes. The brief is saved to `handoff.md` for the human to use in the TUI.

The integration only documents CLI capabilities verified/documented for Freebuff, including `--continue` and `--cwd`. It does not invent a headless prompt, read-only mode, permission mode, or model flag.

## Verification

- `node --check skills/freebuff-delegate/scripts/relay.mjs`
- `node test/freebuff-delegate/relay-contract.mjs`
- `node --check skills/delegate-setup/scripts/implementers.mjs`
- `node --check test/harness/constants.mjs`
- `git diff --check`

Live Freebuff TTY execution remains environment-dependent and is not claimed as verified by this PR.

Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for delegating bounded coding tasks to the interactive Freebuff CLI with explicit human supervision.
  * Added options to resume sessions, select working directories, enforce timeouts, and capture touched files and completion status.
  * Added guidance for task handoffs, multi-task workflows, review, validation, and manual commits.
* **Documentation**
  * Documented supported Freebuff terminology, usage, limitations, and trust boundaries.
  * Added Freebuff to the available CLI delegation skills.
* **Tests**
  * Added checks for missing task briefs and non-interactive execution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->