### PR TITLE
feat: add Command Code delegate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Twelve implementer skills ship today: `claude-delegate` (Claude Code),
-`cline-delegate` (Cline CLI), `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode),
+and land the result. Thirteen implementer skills ship today: `claude-delegate` (Claude Code),
+`cline-delegate` (Cline CLI), `commandcode-delegate` (Command Code), `codex-delegate` (OpenAI Codex),
+`opencode-delegate` (OpenCode),
 `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code),
 `qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI),
 `pi-delegate` (Pi CLI), and `aider-delegate` (Aider); siblings like `gemini-delegate` can be added
@@ -19,7 +20,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Aider) | "worker", "sub-agent", "executor" |
+| **implementer** | the separate agent (Claude, Cline, Command Code, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Aider) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -36,6 +37,7 @@ jargon. Use these terms; don't invent synonyms.
 | `session`, `--continue`, `--resume`, `plan mode`, `--force`, `--sandbox` (`enabled`/`disabled`), `--trust`, `models` | Cursor Agent's own terms — use verbatim when discussing `cursor-agent` | don't paraphrase them |
 | `session`, `--continue`, `--resume`, `permission mode` (`acceptEdits`/`plan`/`bypassPermissions`), `sandbox`, `subagents`, `agent teams`, `background sessions` | Claude Code's own terms — use verbatim when discussing Claude | never use `subagents` as a generic synonym for implementer |
 | `session`, `--json`, `-v` (verbose), `--auto-approve`, `--cwd`, `--model`, `--provider`, `--id` (unsupported by the JSON relay), `--plan`, `--data-dir` / `CLINE_SANDBOX` (sandbox), `-t`/`--timeout` (CLI's own flag) | Cline's own terms — use verbatim when discussing `cline`. The relay's `--timeout` watchdog is a different flag with the same spelling | don't invent a Cline permission-mode enum |
+| `-p` / `--print`, `--output-format json`, `--yolo` (bypass mode), `--plan`, `--continue`, `--resume`, `--model`, `--effort`, `--max-turns`, `--trust` | Command Code's own terms — use verbatim when discussing `command-code` | don't invent a Command Code sandbox enum; bypass mode is not a workspace sandbox |
 | `session`, `-c`, `--resume`, `permission mode` (`default`/`accept_edits`/`auto`/`bypass_permissions`/`dont_ask`/`plan`), `print mode`, `stream-json`, `model`, `context window` | Qoder CLI's own terms — use verbatim when discussing Qoder | don't paraphrase them |
 | `--prompt`, `--output` (`streaming`/`json`/`text`), `--agent` (`plan`/`accept-edits`/`auto-approve`), `--max-turns`, `--max-price`, `--max-tokens`, `--trust`, `--resume`, `--continue`, `--enabled-tools`, `--disabled-tools` | Mistral Vibe's own terms — use verbatim when discussing `vibe` | don't invent a Vibe sandbox enum; `--trust` is not a permission mode |
 | `session`, `--continue`, `--session`, `print mode`, `--mode json`, `tools`, `context files`, `project trust` | Pi's own terms — use verbatim when discussing `pi` | don't paraphrase them |
@@ -47,7 +49,8 @@ version-neutral) everywhere except the README's "Verification status" list, wher
 version a run was made against is what makes the claim checkable; and claims that can't be verified
 ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
-`cline` / `codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi` /
+`cline` / `command-code` / `codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` /
+`vibe` / `cursor-agent` / `pi` /
 `aider`) and the skill's `relay.mjs`.
 
 ## Conventions
@@ -90,7 +93,9 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   command string through the shell on win32 for the same shim reason; `agy`, `kimi`, current
   `qodercli`, `vibe`, and `aider` installs use native binaries (pip puts a real `aider.exe` in
   Scripts, so that launch needs no `shell:true`). Each changed launch still needs its own Windows
-  smoke before claiming support. Upstream Vibe works on Windows but officially supports and targets
+  smoke before claiming support. Command Code's npm `.cmd` shim is located through PATH, then its
+  package entrypoint is launched with the current Node executable; the brief stays on stdin and no
+  shell is used. Upstream Vibe works on Windows but officially supports and targets
   UNIX; this repository's native Windows Cline stdin launch and Vibe relay launch are unverified.
 - Keep the README's "Verification status" honest — claim only what's been run.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`agy-delegate`](skills/agy-delegate/SKILL.md) | Google Antigravity (`agy`) | Antigravity's own `permissions`; bypass opt-in | `--read-only` (`plan` mode) | `--resume-last`, `--conversation <id>` |
 | [`claude-delegate`](skills/claude-delegate/SKILL.md) | [Claude Code](https://code.claude.com/docs/en/overview) (`claude`) | `acceptEdits` + explicit tool surface | `--read-only` (`plan` mode) | `--resume-last`, `--session <id>` |
 | [`cline-delegate`](skills/cline-delegate/SKILL.md) | [Cline](https://github.com/cline/cline) (`cline`) | `--auto-approve true` in act mode; upstream sandbox not configured by the relay | `--plan` + `--auto-approve false` (relay-enforced pair) | — (headless JSON resume unsupported) |
-| [`commandcode-delegate`](skills/commandcode-delegate/SKILL.md) | [Command Code](https://commandcode.ai/docs) (`command-code`) | `--yolo` bypass mode; explicit deny/ask rules still apply | `--read-only` (`--plan`) | `--resume-last`, `--session <id>` |
+| [`commandcode-delegate`](skills/commandcode-delegate/SKILL.md) | [Command Code](https://commandcode.ai/docs) (`command-code`) | `--yolo` bypass mode; destructive or outside-workspace scope needs separate human approval | `--read-only` (`--plan`) | `--resume-last`, `--session <id>` |
 | [`codex-delegate`](skills/codex-delegate/SKILL.md) | [OpenAI Codex](https://github.com/openai/codex) (`codex`) | `--sandbox workspace-write` | `--read-only` | `--resume-last`, `--session <id>` |
 | [`cursor-delegate`](skills/cursor-delegate/SKILL.md) | [Cursor Agent](https://cursor.com/cli) (`cursor-agent`) | `--force`; `--no-force` withholds command approval | `--read-only` (plan mode) | `--resume-last`, `--session <id>` |
 | [`grok-delegate`](skills/grok-delegate/SKILL.md) | Grok Build (`grok`) | workspace-scoped; `--full-access` opt-in | `--read-only` — best-effort [^grok] | `--resume-last`, `--session <id>` |
@@ -226,7 +226,8 @@ Per skill — platform, CLI version, and what the run exercised:
   a nested `claude`, and a `$HOME` write.
 - `commandcode-delegate` — Windows, `command-code` 1.24.0: authenticated live no-write `--plan` run
   using the configured model, with the brief delivered on stdin, NDJSON result parsed to final text
-  `OK`, session and usage captured, and clean Git/read-only tripwires. Contract-tested against the
+  `OK`, session and usage captured, with `gitMutationViolation: false` and `readOnlyViolation: false`.
+  Contract-tested against the
   shared matrix for timeout bounds and whole-process-tree cleanup, bounded version preflight,
   atomic result publication, fleet lanes, exact/latest resume flags, and missing-binary handling.
   No live Command Code run is recorded on macOS or Linux.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`agy-delegate`](skills/agy-delegate/SKILL.md) | Google Antigravity (`agy`) | Antigravity's own `permissions`; bypass opt-in | `--read-only` (`plan` mode) | `--resume-last`, `--conversation <id>` |
 | [`claude-delegate`](skills/claude-delegate/SKILL.md) | [Claude Code](https://code.claude.com/docs/en/overview) (`claude`) | `acceptEdits` + explicit tool surface | `--read-only` (`plan` mode) | `--resume-last`, `--session <id>` |
 | [`cline-delegate`](skills/cline-delegate/SKILL.md) | [Cline](https://github.com/cline/cline) (`cline`) | `--auto-approve true` in act mode; upstream sandbox not configured by the relay | `--plan` + `--auto-approve false` (relay-enforced pair) | — (headless JSON resume unsupported) |
+| [`commandcode-delegate`](skills/commandcode-delegate/SKILL.md) | [Command Code](https://commandcode.ai/docs) (`command-code`) | `--yolo` bypass mode; explicit deny/ask rules still apply | `--read-only` (`--plan`) | `--resume-last`, `--session <id>` |
 | [`codex-delegate`](skills/codex-delegate/SKILL.md) | [OpenAI Codex](https://github.com/openai/codex) (`codex`) | `--sandbox workspace-write` | `--read-only` | `--resume-last`, `--session <id>` |
 | [`cursor-delegate`](skills/cursor-delegate/SKILL.md) | [Cursor Agent](https://cursor.com/cli) (`cursor-agent`) | `--force`; `--no-force` withholds command approval | `--read-only` (plan mode) | `--resume-last`, `--session <id>` |
 | [`grok-delegate`](skills/grok-delegate/SKILL.md) | Grok Build (`grok`) | workspace-scoped; `--full-access` opt-in | `--read-only` — best-effort [^grok] | `--resume-last`, `--session <id>` |
@@ -173,7 +174,7 @@ Full checklist: [CONTRIBUTING.md](CONTRIBUTING.md).
 - For a `*-delegate` skill, its implementer CLI authenticated as you would at the terminal. Each
   implementer skill's `SKILL.md` carries its own install and login commands.
 - `delegate-setup` requires no implementer CLI; it discovers whichever ones are available.
-- Node 18+ and `git`.
+- Node 18+ and `git`; `commandcode-delegate` follows Command Code's Node 22+ requirement.
 - An orchestrating agent that can run shell commands and read files.
 - Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
 
@@ -223,6 +224,12 @@ Per skill — platform, CLI version, and what the run exercised:
   `--session`/`--resume-last` resume; `claude_unavailable`/127 and usage errors exiting 2 without a
   result file; deny rules and the shell sandbox blocking `git commit`, `git push`, `git -C <dir> push`,
   a nested `claude`, and a `$HOME` write.
+- `commandcode-delegate` — Windows, `command-code` 1.24.0: authenticated live no-write `--plan` run
+  using the configured model, with the brief delivered on stdin, NDJSON result parsed to final text
+  `OK`, session and usage captured, and clean Git/read-only tripwires. Contract-tested against the
+  shared matrix for timeout bounds and whole-process-tree cleanup, bounded version preflight,
+  atomic result publication, fleet lanes, exact/latest resume flags, and missing-binary handling.
+  No live Command Code run is recorded on macOS or Linux.
 - `cursor-delegate` — Windows, `cursor-agent` 2026.07.23-e383d2b: write run under `--force`; plan-mode
   `--read-only` touching nothing; `--session <id>` resume applying a delta brief; usage errors exiting
   2. A maintainer-run native macOS plan-mode smoke against the same version captured model, session,

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -7,6 +7,7 @@
       "skills": [
         "claude-delegate",
         "cline-delegate",
+        "commandcode-delegate",
         "codex-delegate",
         "opencode-delegate",
         "agy-delegate",

--- a/skills/commandcode-delegate/SKILL.md
+++ b/skills/commandcode-delegate/SKILL.md
@@ -95,6 +95,10 @@ neutralize `--yolo`; then mutating calls fail or require policy changes rather t
 access. Read-only runs use `--plan` and never add `--yolo`; the relay rejects repositories containing
 submodules because its raw snapshot does not recurse into nested worktrees.
 
+General delegation approval covers ordinary scoped edits inside the target workspace. Before a brief
+authorizes destructive operations or any path outside that workspace, get separate explicit human
+approval and name that scope in the brief. The relay cannot enforce a workspace sandbox for `--yolo`.
+
 Detailed mechanics: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
 
 ### 3. Wait for completion

--- a/skills/commandcode-delegate/SKILL.md
+++ b/skills/commandcode-delegate/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: commandcode-delegate
+description: Use when the user wants to hand implementation, a fix, refactor, review, or a sequential coding queue to Command Code, Command Code CLI, `command-code`, or `cmdc`, including phrases such as "have Command Code do X", "delegate this to Command Code", or "run it through Command Code". Do not use for direct inline coding unless delegation was requested.
+license: MIT
+compatibility: Requires the npm `command-code` CLI with headless JSON support, Node 22+, and git. The CLI must be installed and authenticated. The orchestrating agent must be able to run shell commands and read files. Command Code supports macOS, Linux, WSL, and native Windows.
+metadata:
+  version: 0.4.2
+---
+
+# Command Code Delegate
+
+You are the **orchestrator**. Hand one bounded coding task to Command Code, then review its working-tree
+changes and land them yourself. You write the brief and own every judgment; Command Code does the
+typing in a separate headless session. The relay never commits.
+
+## When NOT to use this
+
+- The task is faster and safer to do inline.
+- `command-code` is unavailable or unauthenticated.
+- The user wants direct implementation and did not request Command Code.
+- A review is requested, but not specifically a review by Command Code.
+
+## Prerequisites
+
+1. `command-code --no-auto-update --version` and `command-code --help` succeed; help must list `-p`
+   plus `--output-format json`. Install with `npm i -g command-code` if needed.
+2. `command-code status --json` reports `"authenticated": true`; otherwise run `command-code login`.
+3. You are in, or will pass `--cd` for, the target git repository.
+4. Confirm candidates with `where.exe command-code` on native Windows or `command -v command-code` on
+   POSIX. The relay considers absolute PATH entries only, resolves the npm package entrypoint before
+   entering the repository, and runs it with the current Node executable. It records the shim,
+   entrypoint, Node, and git paths in `result.json`.
+5. Treat the repository as trusted even for read-only runs. Command Code loads project context, and
+   write-mode review metadata uses git status. Use an external OS/container sandbox for hostile repos.
+
+On native Windows, never substitute bare `cmd`; that launches `cmd.exe`. Command Code's short Windows
+alias is `cmdc`, while full `command-code` works everywhere and is what the relay uses.
+
+## Choose the model
+
+For fresh runs, the relay uses Command Code's configured model. Resumed sessions restore their stored
+model. Add `--model <id>` only when the human names that exact model or project policy names one. "Any
+model", "default", "model does not matter", or no preference means omit `--model`. The configured or
+resumed model is the selection. `command-code --list-models` prints valid ids. Do not guess a different
+model: model choice can change cost, limits, and behavior.
+
+## Quick reference
+
+| Intent | Relay option | Command Code mode |
+| --- | --- | --- |
+| Implement, edit, and test | default | `--yolo` bypass |
+| Review or diagnose without repo edits | `--read-only` | enforced `--plan` |
+| Continue latest headless session, or start fresh if none exists | `--resume-last` | `--continue` |
+| Continue exact session | `--session <id>` | `--resume <id>` |
+| Select model | `--model <id>` | `--model <id>` |
+| Use an approved fleet lane | `--lane <name>` | Lane dials; explicit flags win |
+| Bound dispatch time | `--timeout <dur>` | Relay watchdog; default `30m` |
+
+## The loop
+
+Run five steps for each task. Briefing, review, and landing remain orchestrator decisions.
+
+### 1. Write the brief
+
+The Command Code process does not receive orchestrator chat history. It receives the brief, normal
+Command Code taste/memory/config context, target workspace, and prior transcript when resumed. Include
+the goal, current state, exact scope, what must remain untouched, the repository's real gate commands,
+and a final report contract. Tell it not to stage, commit, or push. Keep one bounded task per brief.
+
+Use [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# use a fleet lane:                  add --lane <name>
+# choose a model:                   add --model <id>
+# read-only review or diagnosis:    add --read-only
+# continue latest headless session: add --resume-last
+# continue an exact session:        add --session <id>
+# change the 30m watchdog:          add --timeout <dur>
+# see every relay option:           node .../relay.mjs --help
+```
+
+The helper wraps `command-code -p`, sends the brief on stdin, requests NDJSON with
+`--output-format json`, and writes `result.json`, `events.jsonl`, `stderr.log`, and `final.txt` under a
+private temporary directory by default. An explicit `--out-dir` must also be outside the target
+workspace. Brief text never appears in the process argument list.
+
+Normal implementation runs use `--yolo`. This is Command Code bypass mode, not a workspace sandbox:
+ordinary edit, shell, and external-directory prompts are auto-approved. Explicit deny/ask rules and
+Command Code's root/home delete circuit breaker still apply. Use this only for trusted repositories
+after the human has opted into delegation. A user or managed `permissions.disableBypass` setting can
+neutralize `--yolo`; then mutating calls fail or require policy changes rather than silently gaining
+access. Read-only runs use `--plan` and never add `--yolo`; the relay rejects repositories containing
+submodules because its raw snapshot does not recurse into nested worktrees.
+
+Detailed mechanics: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until Command Code exits. Run it in the background only through the orchestrator's
+normal background facility. Completion requires both process exit and a written `result.json`; a
+progress line is not completion.
+
+Read `status`, `exitCode`, `finalMessage`, `sessionId`, and `touchedFiles`. A pre-run usage error exits
+2 and writes no result. Missing CLI exits 127 with `status: commandcode_unavailable`; watchdog expiry
+writes `status: timeout` and exits nonzero.
+
+### 4. Review, never trust the self-report
+
+- Inspect edits to existing tests before treating a green gate as evidence.
+- Re-run the repository's actual test, lint, build, and typecheck commands yourself.
+- Read the full diff against the brief for scope creep and scope shortfall.
+- Verify every new dependency, API, migration, removal, and generated artifact.
+- Run relevant guard skills for changed production code, tests, or docs.
+- Require `gitMutationViolation: false`; the final-state tripwire fails when HEAD or staged index
+  differs after the run. Permission deny rules remain necessary to block transient mutations or push.
+- For `--read-only`, require `readOnlyViolation: false`, then still inspect the tree if it was dirty.
+
+Use [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The orchestrator commits only reviewed, gate-passing files. Stage intended paths, inspect the staged
+diff, and commit. If corrections are needed, send a delta brief with `--session <id>` and repeat review.
+Never ask Command Code to commit for you.
+
+## Authorization model
+
+Delegation is human opt-in. After the human says to proceed, verified work may be committed as part of
+that mandate. Two limits remain:
+
+- **Surface, do not absorb:** report unasked design decisions and non-blocking deviations.
+- **Stop for scope changes:** ask before expanding beyond the approved brief.
+
+## Red flags
+
+| Wrong turn | Correct action |
+| --- | --- |
+| Treating Command Code as Claude Code | Use `command-code`; never substitute `claude`. |
+| Inventing `run`, `exec`, `--sandbox`, or `--prompt-file` | Use the bundled relay; Command Code headless mode is `-p`. |
+| Using bare `cmd` on native Windows | Use `command-code` or `cmdc`. |
+| Passing a long brief as an argument | Let the relay send it on stdin. |
+| Combining read-only intent with `--yolo` | Use relay `--read-only`, which maps to `--plan`. |
+| Choosing a model after "any model" | Omit `--model`; use fresh-run config or resumed-session model. |
+| Trusting reported tests or letting the implementer commit | Re-run gates, review diff, then commit as orchestrator. |
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - brief structure, constraints,
+  gate commands, and report contract.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - relay flags, artifacts,
+  `result.json`, waiting, and failures.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist and commit boundary.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues and exact-session
+  continuation.

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -93,8 +93,7 @@ Important fields:
 - `commandCodeShimPath`: absolute npm shim found through PATH/PATHEXT.
 - `commandCodePath`: canonical npm package entrypoint executed through `process.execPath`.
 - `nodePath`: Node executable used for the package entrypoint.
-- `gitPath`: canonical git executable used for HEAD, index, and raw worktree probes. Final
-  `touchedFiles` follows the shared relay helper's PATH lookup.
+- `gitPath`: canonical git executable used for every repository probe, including `touchedFiles`.
 - `commandCodeVersion`: executable version used.
 - `sessionId`: id returned by Command Code for exact continuation.
 - `requestedSessionId`: id supplied through relay `--session`, if any.
@@ -113,8 +112,8 @@ Important fields:
   and also fails completion.
 - `gitWorktreeHashBefore`, `gitWorktreeHashAfter`: read-only hashes of raw tracked files and
   nonignored untracked content, including assume-unchanged and skip-worktree paths.
-- `readOnlyViolation`: present for read-only runs; `true` or `false` when git can compare raw worktree
-  state, otherwise `null`.
+- `readOnlyViolation`: present for read-only runs; `true` means a change was detected, `false` means
+  before/after raw worktree state matched, and `null` means comparison was unavailable or incomplete.
 - `stderrTail`: last stderr lines on failed runs when stderr is nonempty.
 - `error`: launch, result, or missing-result error on failed runs.
 - `briefPath`, `eventsPath`, `stderrPath`, `finalPath`: artifact paths.

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,185 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the Command Code-specific transport. It validates options, sends the brief on
+stdin to `command-code -p`, captures NDJSON, and writes a stable result contract for the orchestrator.
+
+## Check installation and authentication
+
+```bash
+command-code --no-auto-update --version
+command-code status --json
+command-code --list-models
+```
+
+`status --json` must report `"authenticated": true`. On native Windows, use full `command-code` or
+the `cmdc` alias; bare `cmd` is Windows Command Prompt. The relay resolves an absolute
+`command-code` npm shim from absolute PATH entries before changing working directory, resolves its
+package entrypoint, then runs that entrypoint with the current Node executable for both version probe
+and dispatch. This prevents repository-local `command-code` or `node` shims from taking over.
+
+## Dispatch
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing `SKILL.md`. The skill loader normally prints its base
+directory when loading the skill.
+
+| Relay flag | Effect |
+| --- | --- |
+| `--brief <file>` | Read brief from file. Omit to read stdin. |
+| `--cd <dir>` | Target working directory; defaults to current directory. |
+| `--lane <name>` | Resolve model, effort, timeout, and read-only dials from `delegate-setup`; explicit flags win. |
+| `--model <id>` | Requested model override; otherwise use fresh-run config or resumed-session model. |
+| `--effort <level>` | Optional reasoning effort. |
+| `--max-turns <n>` | Positive maximum agent-turn count. |
+| `--read-only` | Use enforced Command Code plan mode; never add bypass. |
+| `--resume-last` | Use `--continue`; Command Code starts fresh if no headless session exists. |
+| `--session <id>` | Resume exact session id; mutually exclusive with `--resume-last`. |
+| `--timeout <dur>` | Relay watchdog; defaults to `30m`, using positive `h`/`m`/`s` strings. |
+| `--out-dir <dir>` | Artifact directory; must be outside target workspace. |
+| `-h`, `--help` | Print relay help. |
+
+Dynamic model, effort, and session values are restricted to token-shaped selectors. The relay locates
+the npm shim but executes the package entrypoint with the current Node executable, without a shell.
+Brief content is never a command-line value.
+
+## Permission behavior
+
+Default write dispatch adds `--yolo`. Command Code headless mode otherwise denies edits and arbitrary
+shell commands, so it could not implement and run project gates unattended. `--yolo` is bypass mode,
+not workspace sandboxing: use it only in trusted repositories. Explicit `deny` and `ask` rules plus
+the root/home delete circuit breaker still outrank bypass.
+
+If `permissions.disableBypass` is enabled in managed or user settings, Command Code neutralizes
+`--yolo` to default mode. A headless write run can then fail on permissions. Do not remove policy
+blindly; inspect the rule and ask the human before changing it.
+
+The relay detects staging and local HEAD changes, but cannot prove that no remote push occurred. For a
+hard guard, keep user or project deny rules such as `Shell(git commit:*)`, `Shell(git push:*)`,
+`Shell(git reset:*)`, and `Shell(git clean:*)`. Explicit deny rules still apply under bypass. The relay
+does not rewrite Command Code permission policy.
+
+`--read-only` adds `--plan` instead. Plan mode blocks repository edits and mutating shell commands.
+The relay compares raw tracked files and nonignored untracked files before and after, including file
+type and mode, and records `readOnlyViolation`. Ignored files and transient changes remain outside this
+final-state proof. Repositories containing submodules are rejected rather than falsely treating gitlink
+directories as fully hashed nested worktrees.
+
+## Artifacts
+
+Artifacts are required outside the repository so they do not pollute `touchedFiles`. Default runs use
+a private randomly named directory directly under canonical system temp. Explicit `--out-dir` is
+canonicalized before creation, and any path resolving inside the target workspace is rejected:
+
+- `brief.txt`: exact brief sent on stdin.
+- `events.jsonl`: raw Command Code NDJSON stdout.
+- `stderr.log`: complete raw stderr from the Command Code child.
+- `final.txt`: final assistant text when a result frame exists.
+- `result.json`: normalized relay result.
+
+## `result.json`
+
+Important fields:
+
+- `schema`: `delegate-relay.result.v1`.
+- `tool`: `commandcode`.
+- `status`: `completed`, `failed`, `timeout`, `aborted`, or `commandcode_unavailable`.
+- `exitCode`: Command Code exit code; 127 when unavailable; 124 for a preflight timeout; 128 plus the
+  signal number when aborted; or synthetic 1 when output is incomplete.
+- `signal`: terminating signal, otherwise `null`.
+- `resultSubtype`: Command Code final subtype such as `success`, `error`, or `max_turns`.
+- `commandCodeShimPath`: absolute npm shim found through PATH/PATHEXT.
+- `commandCodePath`: canonical npm package entrypoint executed through `process.execPath`.
+- `nodePath`: Node executable used for the package entrypoint.
+- `gitPath`: canonical git executable used for HEAD, index, and raw worktree probes. Final
+  `touchedFiles` follows the shared relay helper's PATH lookup.
+- `commandCodeVersion`: executable version used.
+- `sessionId`: id returned by Command Code for exact continuation.
+- `requestedSessionId`: id supplied through relay `--session`, if any.
+- `stopReason`: final model stop reason when supplied.
+- `finalMessage`: Command Code's final report from `finalText`.
+- `usage`: token usage object from Command Code.
+- `durationMs`: Command Code-reported duration.
+- `lane`, `laneSource`: selected fleet lane and config scope, or `null` without `--lane`.
+- `timeout`: selected relay watchdog duration.
+- `initialTouchedFiles`: pre-dispatch porcelain lines for write runs; `null` for read-only raw snapshots.
+- `touchedFiles`: final porcelain lines for write runs; for read-only runs, raw file changes during the
+  run. `null` when state cannot be established.
+- `gitHeadBefore`, `gitHeadAfter`, `gitHeadChanged`: final commit-history tripwire.
+- `gitIndexChanged`: final staged-index tripwire.
+- `gitMutationViolation`: final-state HEAD/index comparison; `true` fails the run, `null` means unknown
+  and also fails completion.
+- `gitWorktreeHashBefore`, `gitWorktreeHashAfter`: read-only hashes of raw tracked files and
+  nonignored untracked content, including assume-unchanged and skip-worktree paths.
+- `readOnlyViolation`: present for read-only runs; `true` or `false` when git can compare raw worktree
+  state, otherwise `null`.
+- `stderrTail`: last stderr lines on failed runs when stderr is nonempty.
+- `error`: launch, result, or missing-result error on failed runs.
+- `briefPath`, `eventsPath`, `stderrPath`, `finalPath`: artifact paths.
+- `workdir`, `autonomy`, `model`, `effort`, `maxTurns`, `resumeLast`, timestamps: requested run
+  metadata. Null model/effort/max-turn values mean no relay override, not that the CLI used none.
+
+A successful process is not enough. Relay status becomes `completed` only when Command Code exits 0,
+emits a valid final NDJSON success result, has explicit `gitMutationViolation: false`, and, for
+read-only runs, has explicit `readOnlyViolation: false`.
+
+Git and read-only fields are complete on dispatched runs. `commandcode_unavailable` and early
+preflight failures can omit those fields because no Command Code run occurred.
+
+## Waiting
+
+The relay blocks. In an orchestrator with background jobs, start the relay as a background command and
+wait for process completion. Else run it in the foreground. A run is complete only when the process
+has exited and `result.json` exists.
+
+Catchable POSIX signals and console interrupts produce `status: aborted` and terminate the child
+process group. Windows force-termination APIs cannot be intercepted; when canceling there, terminate
+the relay process tree through the orchestrator's job facility. Killing only the relay process can
+leave a CLI descendant running.
+
+A validation error such as unknown options, empty brief, or conflicting resume flags exits 2 before
+creating artifacts. Missing CLI writes `result.json` with `commandcode_unavailable` and exits 127.
+
+## Failure handling
+
+- `commandcode_unavailable`: no supported npm `command-code` entrypoint was resolved from absolute PATH
+  entries. Install with `npm i -g command-code`, or fix PATH/install layout.
+- Version preflight failure: status is `failed`, not unavailable; a hung probe is `timeout`. Inspect
+  the reported path, Node version, stderr, and installation.
+- Exit 3: authentication failed; log in again.
+- Exit 4: permission denied; inspect project rules rather than blindly removing them.
+- Exit 5: rate limit; wait or choose a human-approved alternative.
+- Exit 6 or 7: network or service failure; retry only after identifying the cause.
+- Exit 8 or `max_turns`: split the task or raise `--max-turns` deliberately.
+- Exit 10: insufficient credits; stop and ask the human.
+- Empty or missing final result: inspect `events.jsonl` and `stderr.log`; do not treat partial edits as
+  complete.
+
+Relay-generated exit 1 also covers invalid success frames, unknown/failing git tripwires, read-only
+violations, and version preflight failure; it is not always a Command Code exit code.
+
+## Underlying commands
+
+The relay executes these shapes and sends the brief on stdin:
+
+```bash
+# write-capable run
+command-code -p --output-format json --skip-onboarding --no-auto-update --trust --yolo
+
+# read-only run
+command-code -p --output-format json --skip-onboarding --no-auto-update --trust --plan
+
+# exact continuation adds
+--resume <session-id>
+
+# latest continuation adds
+--continue
+```
+
+Do not replace these with invented `run`, `exec`, `--sandbox`, or `--prompt-file` forms.
+
+## Commit boundary
+
+The relay does not stage, commit, push, reset, or clean. Review and landing remain orchestrator work.

--- a/skills/commandcode-delegate/references/multi-task-queues.md
+++ b/skills/commandcode-delegate/references/multi-task-queues.md
@@ -1,0 +1,73 @@
+# Multi-task queues
+
+Run dependent Command Code tasks sequentially. One task gets one brief, one run, one review, and one
+commit before the next task starts. This keeps failure recovery and rollback clear.
+
+## Queue contract
+
+For each task:
+
+1. Confirm prerequisites from earlier tasks are present in the working tree or committed history.
+2. Write a fresh bounded brief with current repository state and real gates.
+3. Dispatch and wait for `result.json`.
+4. Review the diff and rerun gates independently.
+5. Commit verified work before starting the next task, unless the human explicitly requested one
+   atomic final commit and the tasks cannot be reviewed independently.
+
+Stop the queue on failure, scope expansion, ambiguous output, or a gate regression. Do not let a later
+task hide or compensate for an earlier failure.
+
+## Continue exact context
+
+The first completed result contains `sessionId`. Prefer exact continuation for dependent work:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-1.txt --cd /path/to/repo --out-dir /tmp/task-1
+
+node "<skill-dir>/scripts/relay.mjs" --brief task-2.txt --cd /path/to/repo \
+  --session <sessionId-from-task-1> --out-dir /tmp/task-2
+```
+
+Use `--resume-last` only when no other headless Command Code run can become "latest" in that working
+directory and starting fresh when none exists is acceptable. Exact session ids avoid both fallback
+and resuming the wrong queue after concurrent or manual runs.
+
+Send only the delta in resumed briefs. The session already carries prior conversation, but the brief
+must still state current goal, scope, gates, no-commit rule, and output contract.
+
+## Carry constraints forward
+
+Later briefs must preserve constraints established earlier:
+
+- Public API and compatibility decisions.
+- Files or subsystems left intentionally untouched.
+- Migration and generated-code ordering.
+- Repository gate commands.
+- Human decisions made during review.
+
+Do not rely on model memory for a load-bearing constraint; restate it.
+
+## Model handling
+
+A resumed Command Code session remembers its model. Pass `--model` only when the human names an exact
+model or project policy requires one. "Any model" or "model does not matter" means omit the flag. Let
+the configured model handle a fresh run and the session retain its model on continuation.
+
+## Independent tasks
+
+Do not share a session merely to save setup when tasks are unrelated. Separate sessions reduce context
+contamination. Do not run write-capable tasks concurrently in the same working tree; use isolated git
+worktrees when true parallelism is required and the human approved it.
+
+## Final coherence check
+
+After the queue:
+
+- Run aggregate repository gates.
+- Search for stale names and dangling references across task boundaries.
+- Confirm docs and examples match final behavior.
+- Inspect commit order and working-tree status.
+- Report any decisions or deviations surfaced during individual reviews.
+
+Queue completion means the combined repository state is coherent, not merely that every relay exited
+zero.

--- a/skills/commandcode-delegate/references/review-and-land.md
+++ b/skills/commandcode-delegate/references/review-and-land.md
@@ -1,0 +1,123 @@
+# Review and land
+
+Command Code did the typing; the orchestrator owns correctness. Treat `finalMessage` as a claim and
+the working tree as evidence.
+
+## Inspect test changes first
+
+Before trusting any green result, inspect edits to existing tests:
+
+- New skips, disabled cases, or commented assertions make the gate weaker.
+- Relaxed exact assertions, broader exception checks, and wider tolerances change the contract.
+- Deleted tests or fixtures can hide a regression.
+- Unbriefed test rewrites are scope changes, not implementation details.
+
+If the yardstick changed without approval, stop and resolve that before interpreting gate results.
+
+## Re-run gates yourself
+
+Run the exact test, lint, format-check, build, and typecheck commands named in the brief. Do not copy
+the implementer's claim into your final response. Read your own command output and exit codes.
+
+Use stronger checks where the change demands them:
+
+- Migrations: apply, reverse, and reapply on a disposable target.
+- Removals or renames: search for dangling references and stale docs.
+- Generated files: regenerate from source and confirm a clean second run.
+- Stateful behavior: exercise the actual state transition or failure path.
+- Security and money paths: inspect validation, authorization, amounts, rounding, and error handling.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, then inspect the complete diff:
+
+```bash
+git status --short
+git diff --check
+git diff
+git diff --cached --check
+git diff --cached
+```
+
+Inspect every untracked path listed by status. Compare `gitHeadBefore` with `gitHeadAfter`, require
+`gitHeadChanged: false`, `gitIndexChanged: false`, and `gitMutationViolation: false`. These are
+final-state tripwires: stage-then-unstage, commit-then-reset, side refs, pushes, and other transient git
+operations require permission deny rules and independent review. A clean final porcelain status alone
+does not prove their absence.
+
+Check:
+
+- Scope creep: unrelated cleanup, refactors, renames, dependencies, or formatting.
+- Scope shortfall: missing callers, error paths, docs, tests, or cleanup required by the task.
+- Quiet decisions: defaults or behavior choices the brief did not authorize.
+- Git mutations: new commits, branches, staged files, or history changes the implementer was told not
+  to make.
+
+Do not revert unrelated pre-existing work. Separate the implementer's edits from dirt that existed
+before dispatch.
+
+## Generated-code sweep
+
+Green tests can miss systematic generated-code failures. Check every changed path for:
+
+- Hardcoded success values or fixture data on production paths.
+- Catch-all error handling that hides failure behind a default result.
+- Plausible but nonexistent imports, methods, flags, or config keys.
+- New dependencies that duplicate standard library or installed functionality.
+- Placeholder branches, TODO implementations, dead feature flags, or speculative abstractions.
+- Secrets, credentials, local absolute paths, machine-specific state, or generated artifacts that do
+  not belong in source control.
+- Comments and docs that describe intended behavior instead of actual behavior.
+
+Run applicable clean-code, test, docs, security, or domain guard skills after this manual sweep.
+
+## Read-only runs
+
+For `--read-only`, require all four:
+
+1. Relay `autonomy` is `read-only`.
+2. Relay `status` is `completed` and `readOnlyViolation` is `false`.
+3. `gitMutationViolation` is `false`.
+4. Independent repository inspection shows no new changes attributable to the run.
+
+For read-only runs, the relay hashes raw tracked files and nonignored untracked content, including
+assume-unchanged and skip-worktree paths. Ignored files and transient changes remain outside that
+proof. Preserve independent snapshots when forensic assurance matters. Never reset or clean to make
+comparison easier.
+
+## Rework
+
+If the result is close but wrong, write a delta brief containing only:
+
+- What failed review, with file and line evidence.
+- Required correction.
+- Gates to rerun.
+- Scope that must remain unchanged.
+
+Resume the exact `sessionId`:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief correction.txt --cd /path/to/repo --session <id>
+```
+
+Then repeat the full review. Do not accept "fixed" without new evidence.
+
+## Land
+
+After diff review and independent gates pass:
+
+1. Confirm the index has no unrelated staged changes. If it does, use an isolated worktree or stop and
+   ask; plain `git commit` would include them.
+2. Stage intended files only: `git add -- <paths>`.
+3. Inspect `git diff --cached --check` and `git diff --cached`.
+4. Commit with a message matching repository convention.
+5. Confirm final status and report any unrelated pre-existing changes separately.
+
+Do not commit if tests fail, scope is unresolved, output is partial, or Command Code made an unapproved
+decision. Never ask Command Code to make the commit; verification and commit stay with the same party.
+
+## Authorization limits
+
+Human approval to delegate covers the brief and verified landing, not silent scope expansion. Surface
+defensible but unasked choices. Stop and ask when correct completion requires a new subsystem,
+dependency, public API change, destructive operation, or other material expansion.

--- a/skills/commandcode-delegate/references/writing-the-brief.md
+++ b/skills/commandcode-delegate/references/writing-the-brief.md
@@ -1,0 +1,91 @@
+# Writing the brief
+
+The brief carries the task from the orchestrator into Command Code. Command Code has no orchestrator
+chat history, but it does retain its normal taste, memory, configuration, workspace context, and a
+prior Command Code transcript when resumed. Any constraint that exists only in orchestrator chat must
+be repeated in the brief. Missing context produces guesses, scope creep, or an incomplete result.
+
+## Recommended shape
+
+Use compact XML blocks. Add only blocks the task needs.
+
+```xml
+<task>
+State the concrete goal and location. Describe current behavior, required behavior, and exact scope.
+Name files or subsystems that must remain untouched when that boundary matters.
+</task>
+
+<verification_loop>
+Run these commands before finishing and fix failures rather than only reporting them:
+  <the repository's real focused test command>
+  <the repository's real lint or format check>
+  <the repository's real build or typecheck command>
+Confirm the working tree contains only intended changes.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated cleanup, renames, dependency updates, or refactors.
+Do not run git add, git commit, or git push. Leave changes uncommitted for orchestrator review.
+</action_safety>
+
+<structured_output_contract>
+End with:
+1. What changed and why
+2. Files touched
+3. Gate outcomes with useful counts
+4. Deviations, open risks, or decisions needed
+</structured_output_contract>
+```
+
+## Conditional blocks
+
+- Debugging: add `<completeness_contract>` requiring root-cause tracing and a regression check.
+- Missing repository facts: add `<missing_context_gating>` requiring inspection instead of guessing.
+- Read-only review: add `<grounding_rules>` requiring file and line evidence, state "do not edit", and
+  dispatch with relay `--read-only`.
+- Research: add `<research_mode>` separating observed facts, inferences, and open questions.
+
+## Use real gates
+
+Read repository instructions and build metadata before drafting. Copy exact commands from files such as
+`AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or language-specific project configuration. Do not
+write "run tests" and leave Command Code to guess. If no gate exists, say so explicitly.
+
+## Preserve repository conventions
+
+Restate load-bearing constraints even when they also live in the repo: forbidden files, test style,
+generated-code rules, compatibility targets, and the no-commit boundary. Do not paste general style
+guides into every brief.
+
+## One task per brief
+
+One brief should produce one reviewable change. Split "fix, refactor, update docs, and propose a
+roadmap" into dependent runs. This keeps the diff, failure recovery, and commit boundary clear.
+
+## Example
+
+```xml
+<task>
+In services/billing/refund.py, retrying a refund after a network timeout can submit the same refund
+twice because the idempotency key is not checked before submission. Make refund submission idempotent
+and add one focused regression test. Touch only refund handling and its tests. Leave charge creation,
+API routes, and data models unchanged.
+</task>
+
+<verification_loop>
+Run and make green:
+  pytest tests/billing/test_refund.py -q
+  ruff check services/billing/refund.py tests/billing/test_refund.py
+Confirm git status shows only the intended implementation and test files.
+</verification_loop>
+
+<action_safety>
+No unrelated cleanup or dependency changes. Do not stage, commit, or push.
+</action_safety>
+
+<structured_output_contract>
+Report the root cause, fix, files touched, exact pytest and ruff outcomes, and anything left open.
+</structured_output_contract>
+```
+
+Send the brief through `scripts/relay.mjs`; do not place it directly on the command line.

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -315,9 +315,10 @@ function runGit(gitPath, cwd, args) {
   );
 }
 
-function gitTouchedFiles(cwd) {
+function gitTouchedFiles(gitPath, cwd) {
+  if (!gitPath) return null;
   try {
-    const output = execFileSync("git", ["status", "--porcelain"], {
+    const output = execFileSync(gitPath, ["status", "--porcelain"], {
       cwd,
       encoding: "utf8",
       timeout: 10_000,
@@ -346,14 +347,19 @@ function updateFileHash(hash, path) {
 
 function pathHash(path) {
   const hash = createHash("sha256");
-  const stat = lstatSync(path);
-  if (stat.isSymbolicLink()) {
-    hash.update(`type:symlink\0mode:${stat.mode}\0target:${readlinkSync(path)}`);
-  } else if (stat.isFile()) {
-    hash.update(`type:file\0mode:${stat.mode}\0size:${stat.size}\0`);
-    updateFileHash(hash, path);
-  } else {
-    hash.update(`type:other\0mode:${stat.mode}\0size:${stat.size}`);
+  try {
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      hash.update(`type:symlink\0mode:${stat.mode}\0target:${readlinkSync(path)}`);
+    } else if (stat.isFile()) {
+      hash.update(`type:file\0mode:${stat.mode}\0size:${stat.size}\0`);
+      updateFileHash(hash, path);
+    } else {
+      hash.update(`type:other\0mode:${stat.mode}\0size:${stat.size}`);
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    hash.update("missing");
   }
   return hash.digest("hex");
 }
@@ -422,7 +428,7 @@ function gitState(gitPath, cwd, includeWorktreeHash = false) {
     return {
       head,
       indexHash,
-      touchedFiles: includeWorktreeHash ? null : gitTouchedFiles(cwd),
+      touchedFiles: includeWorktreeHash ? null : gitTouchedFiles(gitPath, cwd),
       worktreeHash: workspace?.hash ?? null,
       workspace,
       unsupportedReason: null,
@@ -677,7 +683,7 @@ function preflightFailure(opts, run, error) {
     finalMessage: "",
     usage: null,
     durationMs: null,
-    touchedFiles: gitTouchedFiles(opts.cd),
+    touchedFiles: gitTouchedFiles(opts.gitPath, opts.cd),
     stderrTail: stderr ? stderr.split(/\r?\n/).slice(-20) : [],
     error: message,
   });
@@ -936,6 +942,13 @@ if (isInside(opts.cd, opts.commandCodePath)) {
   preflightFailure(opts, run, new Error("resolved Command Code entrypoint is inside target workspace"));
 }
 opts.gitPath = resolveExecutable("git");
+if (opts.gitPath) {
+  try {
+    opts.gitPath = realpathSync(opts.gitPath);
+  } catch {
+    opts.gitPath = null;
+  }
+}
 if (!opts.gitPath || isInside(opts.cd, opts.gitPath)) {
   opts.gitPath = null;
   preflightFailure(opts, run, new Error("trusted git executable not found outside target workspace"));

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -1,0 +1,950 @@
+#!/usr/bin/env node
+/**
+ * commandcode-delegate relay
+ *
+ * Sends one self-contained brief to Command Code headless mode, captures its
+ * NDJSON stream, and writes a stable result.json for the orchestrator.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   Get-Content brief.txt -Raw | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>    Brief file. Omit to read stdin.
+ *   --cd <dir>        Command Code working directory (default: current directory).
+ *   --lane <name>     Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <id>      Optional override; fresh/resumed defaults stay with Command Code.
+ *   --effort <level>  Optional reasoning effort.
+ *   --max-turns <n>   Maximum agent turns.
+ *   --read-only       Enforced plan mode; no repository edits.
+ *   --resume-last     Continue latest headless session, or start fresh if none exists.
+ *   --session <id>    Resume one explicit headless session id.
+ *   --timeout <dur>   Relay watchdog (default: 30m; h/m/s syntax).
+ *   --out-dir <dir>   External artifact directory (default: private system temp directory).
+ *   -h, --help        Show this help.
+ *
+ * Write runs use --yolo because Command Code headless mode otherwise denies
+ * edits and shell commands. Command Code's explicit deny/ask rules and its
+ * root/home delete circuit breaker still apply. Read-only runs use --plan and
+ * never combine it with --yolo.
+ *
+ * The relay never stages, commits, or pushes. The orchestrator reviews the
+ * diff, reruns project gates, and owns the commit.
+ */
+
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  accessSync,
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readlinkSync,
+  readSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { constants as osConstants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const VERSION_TIMEOUT_MS = 10_000;
+const IMPLEMENTER_KEY = "commandcode";
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    maxTurns: null,
+    readOnly: false,
+    resumeLast: false,
+    session: null,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(helpText());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--effort": opts.effort = next(); flagged.add("effort"); break;
+      case "--max-turns": opts.maxTurns = next(); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default: fail(`unknown option: ${arg}`);
+    }
+  }
+
+  applyFleetLane(opts, flagged);
+  opts.autonomy = opts.readOnly ? "read-only" : "bypass";
+
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive");
+  }
+
+  // Keep ids within Command Code's documented token shape and reject values
+  // that could be misread as another option. The brief always travels on stdin.
+  const safeToken = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+  for (const name of ["model", "effort", "session"]) {
+    if (opts[name] !== null && !safeToken.test(opts[name])) {
+      fail(`--${name} contains unsupported characters`);
+    }
+  }
+  if (opts.maxTurns !== null && !/^[1-9]\d*$/.test(opts.maxTurns)) {
+    fail("--max-turns must be a positive integer");
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+
+  return opts;
+}
+
+function helpText() {
+  const source = readFileSync(new URL(import.meta.url), "utf8");
+  const block = source.match(/\/\*\*([\s\S]*?)\*\//);
+  return block
+    ? `${block[1].replace(/^\s*\* ?/gm, "").trim()}\n`
+    : "commandcode-delegate relay\n";
+}
+
+function readBrief(opts) {
+  let brief;
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    brief = readFileSync(opts.brief, "utf8");
+  } else {
+    if (process.stdin.isTTY) {
+      fail("pass --brief <file> or pipe a brief on stdin");
+    }
+    try {
+      brief = readFileSync(0, "utf8");
+    } catch {
+      brief = "";
+    }
+  }
+
+  if (!brief.trim()) fail("brief is empty");
+  return brief;
+}
+
+function resolveExecutable(name) {
+  const pathEntries = (process.env.PATH ?? "")
+    .split(delimiter)
+    .map((entry) => entry.replace(/^"|"$/g, ""))
+    .filter((entry) => entry && isAbsolute(entry));
+
+  if (process.platform === "win32") {
+    const extensions = (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+      .split(";")
+      .filter(Boolean);
+    for (const directory of pathEntries) {
+      for (const extension of extensions) {
+        const candidate = join(directory, `${name}${extension.toLowerCase()}`);
+        try {
+          if (statSync(candidate).isFile()) return resolve(candidate);
+        } catch {
+          // Try the next PATH candidate.
+        }
+      }
+    }
+    return null;
+  }
+
+  for (const directory of pathEntries) {
+    const candidate = join(directory, name);
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      if (statSync(candidate).isFile()) return resolve(candidate);
+    } catch {
+      // Try the next PATH candidate.
+    }
+  }
+  return null;
+}
+
+function resolveCommandCode() {
+  const shimPath = resolveExecutable("command-code");
+  if (!shimPath) return null;
+
+  const packagePath = join(dirname(shimPath), "node_modules", "command-code");
+  const packageJsonPath = join(packagePath, "package.json");
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    const binPath = typeof packageJson.bin === "string"
+      ? packageJson.bin
+      : packageJson.bin?.["command-code"];
+    if (packageJson.name === "command-code" && typeof binPath === "string") {
+      const entrypointPath = realpathSync(resolve(packagePath, binPath));
+      if (isInside(realpathSync(packagePath), entrypointPath)) {
+        return { shimPath, entrypointPath };
+      }
+    }
+  } catch {
+    // POSIX npm shims are often symlinks directly to the package entrypoint.
+  }
+
+  try {
+    const entrypointPath = realpathSync(shimPath);
+    if (/\.(?:mjs|cjs|js)$/i.test(entrypointPath)) {
+      return { shimPath, entrypointPath };
+    }
+  } catch {
+    // Unsupported or broken installation.
+  }
+  return null;
+}
+
+function commandCodeVersion(entrypointPath, timeoutMs) {
+  return execFileSync(
+    process.execPath,
+    [entrypointPath, "--no-auto-update", "--version"],
+    {
+      encoding: "utf8",
+      timeout: Math.min(timeoutMs, VERSION_TIMEOUT_MS),
+      killSignal: "SIGKILL",
+    },
+  ).trim();
+}
+
+function runGit(gitPath, cwd, args) {
+  return execFileSync(
+    gitPath,
+    ["-c", "core.fsmonitor=false", "-c", "core.untrackedCache=false", ...args],
+    {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function updateFileHash(hash, path) {
+  const file = openSync(path, "r");
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  try {
+    let bytesRead;
+    while ((bytesRead = readSync(file, buffer, 0, buffer.length, null)) > 0) {
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    closeSync(file);
+  }
+}
+
+function pathHash(path) {
+  const hash = createHash("sha256");
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink()) {
+    hash.update(`type:symlink\0mode:${stat.mode}\0target:${readlinkSync(path)}`);
+  } else if (stat.isFile()) {
+    hash.update(`type:file\0mode:${stat.mode}\0size:${stat.size}\0`);
+    updateFileHash(hash, path);
+  } else {
+    hash.update(`type:other\0mode:${stat.mode}\0size:${stat.size}`);
+  }
+  return hash.digest("hex");
+}
+
+function worktreeSnapshot(gitPath, cwd) {
+  const tracked = runGit(gitPath, cwd, ["ls-files", "--cached", "-z"])
+    .split("\0").filter(Boolean);
+  const untracked = runGit(gitPath, cwd, [
+    "ls-files", "--others", "--exclude-standard", "-z",
+  ]).split("\0").filter(Boolean);
+  const kinds = new Map([
+    ...tracked.map((path) => [path, "tracked"]),
+    ...untracked.map((path) => [path, "untracked"]),
+  ]);
+  const files = new Map();
+  const aggregate = createHash("sha256");
+  for (const relativePath of [...kinds.keys()].sort()) {
+    if (relativePath.includes("\uFFFD")) throw new Error("git path is not valid UTF-8");
+    const state = `${kinds.get(relativePath)}:${pathHash(join(cwd, relativePath))}`;
+    files.set(relativePath, state);
+    aggregate.update(relativePath).update("\0").update(state).update("\0");
+  }
+  return { hash: aggregate.digest("hex"), files };
+}
+
+function changedFiles(before, after) {
+  const paths = new Set([...before.files.keys(), ...after.files.keys()]);
+  const changes = [];
+  for (const path of [...paths].sort()) {
+    if (before.files.get(path) === after.files.get(path)) continue;
+    if (!before.files.has(path)) changes.push(`?? ${path}`);
+    else if (!after.files.has(path)) changes.push(` D ${path}`);
+    else changes.push(` M ${path}`);
+  }
+  return changes;
+}
+
+function gitState(gitPath, cwd, includeWorktreeHash = false) {
+  if (!gitPath) return null;
+  try {
+    const inside = runGit(gitPath, cwd, ["rev-parse", "--is-inside-work-tree"]).trim();
+    if (inside !== "true") return null;
+
+    let head = null;
+    try {
+      head = runGit(gitPath, cwd, ["rev-parse", "HEAD"]).trim();
+    } catch {
+      // An unborn repository is valid and has no HEAD yet.
+    }
+    const indexEntries = runGit(gitPath, cwd, ["ls-files", "--stage", "-z"]);
+    const hasSubmodules = indexEntries
+      .split("\0")
+      .some((entry) => entry.startsWith("160000 "));
+    const indexHash = createHash("sha256").update(indexEntries).digest("hex");
+    if (includeWorktreeHash && hasSubmodules) {
+      return {
+        head,
+        indexHash,
+        touchedFiles: null,
+        worktreeHash: null,
+        workspace: null,
+        unsupportedReason: "read-only snapshot does not support repositories containing submodules",
+      };
+    }
+    const workspace = includeWorktreeHash ? worktreeSnapshot(gitPath, cwd) : null;
+    return {
+      head,
+      indexHash,
+      touchedFiles: includeWorktreeHash ? null : gitTouchedFiles(cwd),
+      worktreeHash: workspace?.hash ?? null,
+      workspace,
+      unsupportedReason: null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isInside(parent, candidate) {
+  const pathFromParent = relative(resolve(parent), resolve(candidate));
+  return pathFromParent === ""
+    || (!isAbsolute(pathFromParent)
+      && pathFromParent !== ".."
+      && !pathFromParent.startsWith(`..${sep}`));
+}
+
+function canonicalForCreation(path) {
+  let existingPath = resolve(path);
+  const missingParts = [];
+  while (!existsSync(existingPath)) {
+    const parent = dirname(existingPath);
+    if (parent === existingPath) throw new Error(`cannot resolve path: ${path}`);
+    missingParts.unshift(basename(existingPath));
+    existingPath = parent;
+  }
+  return resolve(realpathSync(existingPath), ...missingParts);
+}
+
+function prepareRun(opts, brief) {
+  try {
+    opts.cd = realpathSync(opts.cd);
+  } catch {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+  let outDir = opts.outDir;
+  if (outDir) {
+    outDir = canonicalForCreation(outDir);
+    if (isInside(opts.cd, outDir)) {
+      fail("--out-dir must be outside the Command Code working directory");
+    }
+    mkdirSync(outDir, { recursive: true, mode: 0o700 });
+  } else {
+    const tempRoot = realpathSync(tmpdir());
+    if (isInside(opts.cd, tempRoot)) {
+      fail("system temp directory is inside the Command Code working directory; pass external --out-dir");
+    }
+    outDir = mkdtempSync(join(tempRoot, "commandcode-delegate-"));
+  }
+  chmodSync(outDir, 0o700);
+
+  const run = {
+    outDir,
+    startedAt: new Date().toISOString(),
+    briefPath: join(outDir, "brief.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.log"),
+    finalPath: join(outDir, "final.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  const privateText = { encoding: "utf8", mode: 0o600 };
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, privateText);
+  writeFileSync(run.eventsPath, "", privateText);
+  writeFileSync(run.stderrPath, "", privateText);
+  return run;
+}
+
+function buildArgv(opts) {
+  const argv = [
+    "-p",
+    "--output-format", "json",
+    "--skip-onboarding",
+    "--no-auto-update",
+    "--trust",
+  ];
+
+  argv.push(opts.autonomy === "read-only" ? "--plan" : "--yolo");
+  if (opts.resumeLast) argv.push("--continue");
+  else if (opts.session) argv.push("--resume", opts.session);
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.effort) argv.push("--effort", opts.effort);
+  if (opts.maxTurns) argv.push("--max-turns", opts.maxTurns);
+  return argv;
+}
+
+function spawnCommandCode(entrypointPath, argv, options) {
+  return spawn(process.execPath, [entrypointPath, ...argv], options);
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function signalExitCode(signal) {
+  return 128 + (osConstants.signals[signal] ?? 0);
+}
+
+function stderrTail(stderr) {
+  return stderr.trim().split(/\r?\n/).slice(-20);
+}
+
+function validSuccessFrame(frame) {
+  return frame?.subtype === "success"
+    && typeof frame.finalText === "string"
+    && frame.usage !== null
+    && typeof frame.usage === "object"
+    && !Array.isArray(frame.usage)
+    && Number.isFinite(frame.durationMs);
+}
+
+function resultError(frame) {
+  if (!frame) return "Command Code emitted no final result frame";
+  if (frame.subtype === "success") return "Command Code emitted an invalid success result frame";
+  if (typeof frame.error === "string" && frame.error) return frame.error;
+  return `Command Code result subtype: ${frame.subtype ?? "unknown"}`;
+}
+
+function dispatchFailure(context) {
+  if (context.abortSignal) {
+    return `relay interrupted by ${context.abortSignal}; Command Code process tree terminated`;
+  }
+  if (context.watchdogFired) {
+    return `Command Code did not finish within --timeout ${context.timeout}; killed by the relay watchdog`;
+  }
+  if (context.launchError) return context.launchError.message;
+  if (context.runtimeError) return context.runtimeError.message;
+  if (context.cliExitCode !== 0) return `Command Code exited with code ${context.cliExitCode}`;
+  if (context.gitMutationViolation === true) {
+    return "Command Code changed git HEAD or the staged index";
+  }
+  if (context.gitMutationViolation === null) {
+    return "relay could not verify final git HEAD and index state";
+  }
+  if (context.readOnlyViolation === true) {
+    return "Command Code changed the working tree during a read-only run";
+  }
+  if (context.readOnly && context.readOnlyViolation === null) {
+    return "relay could not verify read-only working-tree state";
+  }
+  return resultError(context.resultFrame);
+}
+
+function writeResult(opts, version, run, extra) {
+  const result = {
+    schema: "delegate-relay.result.v1",
+    lane: opts.lane,
+    laneSource: opts.laneSource,
+    tool: "commandcode",
+    workdir: opts.cd,
+    autonomy: opts.autonomy,
+    model: opts.model,
+    effort: opts.effort,
+    maxTurns: opts.maxTurns ? Number(opts.maxTurns) : null,
+    timeout: opts.timeout,
+    resumeLast: opts.resumeLast,
+    requestedSessionId: opts.session,
+    commandCodeShimPath: opts.commandCodeShimPath ?? null,
+    commandCodePath: opts.commandCodePath ?? null,
+    nodePath: process.execPath,
+    gitPath: opts.gitPath ?? null,
+    commandCodeVersion: version,
+    startedAt: run.startedAt,
+    finishedAt: new Date().toISOString(),
+    briefPath: run.briefPath,
+    eventsPath: run.eventsPath,
+    stderrPath: run.stderrPath,
+    finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+    ...extra,
+  };
+  const temporary = `${run.resultPath}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  renameSync(temporary, run.resultPath);
+  return result;
+}
+
+function printSummary(result, resultPath) {
+  process.stdout.write([
+    "=== Command Code delegate result ===",
+    `status: ${result.status}`,
+    `exitCode: ${result.exitCode}`,
+    `sessionId: ${result.sessionId ?? "none"}`,
+    `result: ${resultPath}`,
+  ].join("\n") + "\n");
+
+  if (result.finalMessage) {
+    process.stdout.write(
+      `--- BEGIN IMPLEMENTER REPORT ---\n${result.finalMessage}\n--- END IMPLEMENTER REPORT ---\n`,
+    );
+  }
+}
+
+function unavailable(opts, run) {
+  const result = writeResult(opts, null, run, {
+    status: "commandcode_unavailable",
+    exitCode: 127,
+    signal: null,
+    resultSubtype: null,
+    sessionId: null,
+    stopReason: null,
+    finalMessage: "",
+    usage: null,
+    durationMs: null,
+    touchedFiles: null,
+    error: "supported `command-code` npm entrypoint not found on absolute PATH entries",
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(
+    "relay: supported `command-code` npm entrypoint not found. Install with `npm i -g command-code` and run `command-code login`.\n",
+  );
+  process.exit(127);
+}
+
+function preflightFailure(opts, run, error) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = typeof error?.stderr === "string" ? error.stderr.trim() : "";
+  const detail = stderr || error?.message || "unknown error";
+  const message = timedOut
+    ? `Command Code version preflight timed out after ${Math.min(parseDuration(opts.timeout), VERSION_TIMEOUT_MS)}ms; Command Code was not dispatched`
+    : `Command Code version preflight failed; Command Code was not dispatched: ${detail}`;
+  const result = writeResult(opts, null, run, {
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    resultSubtype: null,
+    sessionId: null,
+    stopReason: null,
+    finalMessage: "",
+    usage: null,
+    durationMs: null,
+    touchedFiles: gitTouchedFiles(opts.cd),
+    stderrTail: stderr ? stderr.split(/\r?\n/).slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatch(opts, brief, version, run) {
+  const maxNdjsonLineChars = 16 * 1024 * 1024;
+  const readOnly = opts.autonomy === "read-only";
+  const beforeGit = gitState(opts.gitPath, opts.cd, readOnly);
+  const gitPreflightError = beforeGit?.unsupportedReason
+    ?? (!beforeGit ? "target must be a readable git working tree" : null);
+  if (gitPreflightError) {
+    const result = writeResult(opts, version, run, {
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      resultSubtype: null,
+      sessionId: null,
+      stopReason: null,
+      finalMessage: "",
+      usage: null,
+      durationMs: null,
+      initialTouchedFiles: null,
+      touchedFiles: null,
+      gitHeadBefore: null,
+      gitHeadAfter: null,
+      gitHeadChanged: null,
+      gitIndexChanged: null,
+      gitMutationViolation: null,
+      ...(readOnly ? { readOnlyViolation: null } : {}),
+      error: gitPreflightError,
+    });
+    printSummary(result, run.resultPath);
+    process.exitCode = 1;
+    return;
+  }
+  const beforeTree = beforeGit?.touchedFiles ?? null;
+  const argv = buildArgv(opts);
+  const child = spawnCommandCode(opts.commandCodePath, argv, {
+    cwd: opts.cd,
+    env: process.env,
+    stdio: ["pipe", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+  });
+
+  let resultFrame = null;
+  let stdoutBuffer = "";
+  let stderrBuffer = "";
+  let launchError = null;
+  let runtimeError = null;
+  let abortSignal = null;
+  let watchdogFired = false;
+  let forceKillTimer = null;
+  const decoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+  const signalHandlers = new Map();
+
+  const terminateForError = (error) => {
+    if (runtimeError || abortSignal) return;
+    runtimeError = error instanceof Error ? error : new Error(String(error));
+    killChild(child);
+    forceKillTimer = setTimeout(() => killChild(child, "SIGKILL"), 2_000);
+    forceKillTimer.unref();
+  };
+
+  for (const signalName of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (abortSignal) return;
+      abortSignal = signalName;
+      killChild(child);
+      forceKillTimer = setTimeout(() => killChild(child, "SIGKILL"), 2_000);
+      forceKillTimer.unref();
+    };
+    signalHandlers.set(signalName, handler);
+    process.once(signalName, handler);
+  }
+
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    killChild(child);
+    forceKillTimer = setTimeout(() => killChild(child, "SIGKILL"), 10_000);
+  }, parseDuration(opts.timeout));
+
+  const consumeLine = (line) => {
+    if (!line.trim()) return;
+    try {
+      const frame = JSON.parse(line);
+      if (frame?.type === "result") resultFrame = frame;
+    } catch {
+      // Preserve unknown output in events.jsonl; absence of a result frame
+      // turns the run into a failure below.
+    }
+  };
+
+  child.stdout.on("data", (chunk) => {
+    if (runtimeError) return;
+    try {
+      const text = decoder.write(chunk);
+      appendFileSync(run.eventsPath, chunk);
+      stdoutBuffer += text;
+      let newline;
+      while ((newline = stdoutBuffer.indexOf("\n")) !== -1) {
+        consumeLine(stdoutBuffer.slice(0, newline).replace(/\r$/, ""));
+        stdoutBuffer = stdoutBuffer.slice(newline + 1);
+      }
+      if (stdoutBuffer.length > maxNdjsonLineChars) {
+        terminateForError(new Error("Command Code NDJSON line exceeded 16 MiB"));
+      }
+    } catch (error) {
+      terminateForError(new Error(`failed to capture Command Code stdout: ${error.message}`));
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    if (runtimeError) return;
+    try {
+      appendFileSync(run.stderrPath, chunk);
+      stderrBuffer = `${stderrBuffer}${stderrDecoder.write(chunk)}`.slice(-16_384);
+    } catch (error) {
+      terminateForError(new Error(`failed to capture Command Code stderr: ${error.message}`));
+    }
+  });
+
+  child.stdout.on("error", (error) => {
+    terminateForError(new Error(`Command Code stdout stream failed: ${error.message}`));
+  });
+
+  child.stderr.on("error", (error) => {
+    terminateForError(new Error(`Command Code stderr stream failed: ${error.message}`));
+  });
+
+  child.on("error", (error) => {
+    launchError = error;
+  });
+
+  child.stdin.on("error", (error) => {
+    terminateForError(new Error(`stdin delivery failed: ${error.code ?? error.message}`));
+  });
+  try {
+    child.stdin.end(brief);
+  } catch (error) {
+    terminateForError(new Error(`stdin delivery failed: ${error.code ?? error.message}`));
+  }
+
+  child.on("close", (code, signal) => {
+    clearTimeout(watchdogTimer);
+    if (forceKillTimer) clearTimeout(forceKillTimer);
+    if (watchdogFired || abortSignal || runtimeError) killChild(child, "SIGKILL");
+    for (const [signalName, handler] of signalHandlers) {
+      process.removeListener(signalName, handler);
+    }
+    const tail = decoder.end();
+    if (tail) {
+      appendFileSync(run.eventsPath, tail, "utf8");
+      stdoutBuffer += tail;
+    }
+    if (stdoutBuffer) consumeLine(stdoutBuffer.replace(/\r$/, ""));
+    stderrBuffer = `${stderrBuffer}${stderrDecoder.end()}`.slice(-16_384);
+
+    const finalMessage = typeof resultFrame?.finalText === "string"
+      ? resultFrame.finalText
+      : "";
+    if (resultFrame) {
+      writeFileSync(run.finalPath, finalMessage, { encoding: "utf8", mode: 0o600 });
+    }
+
+    const cliExitCode = abortSignal
+      ? signalExitCode(abortSignal)
+      : signal
+        ? signalExitCode(signal)
+        : (code ?? 1);
+    const afterGit = gitState(opts.gitPath, opts.cd, readOnly);
+    const touchedFiles = readOnly && beforeGit.workspace && afterGit?.workspace
+      ? changedFiles(beforeGit.workspace, afterGit.workspace)
+      : readOnly ? null : afterGit?.touchedFiles ?? null;
+    const gitHeadChanged = beforeGit && afterGit
+      ? beforeGit.head !== afterGit.head
+      : null;
+    const gitIndexChanged = beforeGit && afterGit
+      ? beforeGit.indexHash !== afterGit.indexHash
+      : null;
+    const gitMutationViolation = gitHeadChanged === null || gitIndexChanged === null
+      ? null
+      : gitHeadChanged || gitIndexChanged;
+    const readOnlyViolation = opts.autonomy === "read-only"
+      ? beforeGit.worktreeHash === null
+        || afterGit === null
+        || afterGit.worktreeHash === null
+        ? null
+        : beforeGit.worktreeHash !== afterGit.worktreeHash
+      : undefined;
+    const completed = !abortSignal
+      && !watchdogFired
+      && !launchError
+      && !runtimeError
+      && cliExitCode === 0
+      && validSuccessFrame(resultFrame)
+      && gitMutationViolation === false
+      && (!readOnly || readOnlyViolation === false);
+    const exitCode = completed ? 0 : (cliExitCode || 1);
+
+    const extra = {
+      status: abortSignal ? "aborted" : watchdogFired ? "timeout" : completed ? "completed" : "failed",
+      exitCode,
+      signal: abortSignal ?? signal,
+      resultSubtype: resultFrame?.subtype ?? null,
+      sessionId: resultFrame?.sessionId ?? null,
+      stopReason: resultFrame?.stopReason ?? null,
+      finalMessage,
+      usage: resultFrame?.usage ?? null,
+      durationMs: resultFrame?.durationMs ?? null,
+      initialTouchedFiles: beforeTree,
+      touchedFiles,
+      gitHeadBefore: beforeGit?.head ?? null,
+      gitHeadAfter: afterGit?.head ?? null,
+      gitHeadChanged,
+      gitIndexChanged,
+      gitMutationViolation,
+      gitWorktreeHashBefore: beforeGit.worktreeHash,
+      gitWorktreeHashAfter: afterGit?.worktreeHash ?? null,
+      ...(opts.autonomy === "read-only" ? { readOnlyViolation } : {}),
+      ...(!completed && stderrBuffer.trim() ? { stderrTail: stderrTail(stderrBuffer) } : {}),
+      ...(!completed ? {
+        error: dispatchFailure({
+          abortSignal,
+          watchdogFired,
+          timeout: opts.timeout,
+          cliExitCode,
+          launchError,
+          runtimeError,
+          gitMutationViolation,
+          readOnly,
+          readOnlyViolation,
+          resultFrame,
+        }),
+      } : {}),
+    };
+
+    const result = writeResult(opts, version, run, extra);
+    printSummary(result, run.resultPath);
+    process.exitCode = exitCode;
+  });
+}
+
+const opts = parseArgs(process.argv.slice(2));
+const brief = readBrief(opts);
+const run = prepareRun(opts, brief);
+const commandCode = resolveCommandCode();
+if (!commandCode) unavailable(opts, run);
+opts.commandCodeShimPath = commandCode.shimPath;
+opts.commandCodePath = commandCode.entrypointPath;
+if (isInside(opts.cd, opts.commandCodePath)) {
+  preflightFailure(opts, run, new Error("resolved Command Code entrypoint is inside target workspace"));
+}
+opts.gitPath = resolveExecutable("git");
+if (!opts.gitPath || isInside(opts.cd, opts.gitPath)) {
+  opts.gitPath = null;
+  preflightFailure(opts, run, new Error("trusted git executable not found outside target workspace"));
+}
+let version;
+try {
+  version = commandCodeVersion(opts.commandCodePath, parseDuration(opts.timeout));
+  if (!version) throw new Error("Command Code version probe returned empty output");
+} catch (error) {
+  preflightFailure(opts, run, error);
+}
+dispatch(opts, brief, version, run);

--- a/skills/delegate-setup/references/schema.md
+++ b/skills/delegate-setup/references/schema.md
@@ -48,6 +48,7 @@ later-edited project config fails closed until it is reviewed and written again 
 | --- | --- | --- | --- |
 | `claude` | claude-delegate | `claude` | model, effort, timeout, readOnly |
 | `cline` | cline-delegate | `cline` | provider, model, timeout |
+| `commandcode` | commandcode-delegate | `command-code` | model, effort, timeout, readOnly |
 | `codex` | codex-delegate | `codex` | model, effort, sandbox, timeout, readOnly |
 | `opencode` | opencode-delegate | `opencode` | model, **variant**, timeout, readOnly |
 | `agy` | agy-delegate | `agy` | model, effort, timeout, readOnly |

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -79,6 +79,18 @@ export const IMPLEMENTERS = Object.freeze([
     winShell: true,
   },
   {
+    key: "commandcode",
+    skill: "commandcode-delegate",
+    binary: "command-code",
+    versionArgs: ["--no-auto-update", "--version"],
+    authProbe: { args: ["status", "--json"], jsonField: "authenticated" },
+    modelProbe: null,
+    // No documented stable session-store path; usage stays unknown rather than guessed.
+    usageProbe: null,
+    supports: ["model", "effort", "timeout", "readOnly"],
+    winShell: true,
+  },
+  {
     key: "codex",
     skill: "codex-delegate",
     binary: "codex",

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -83,7 +83,7 @@ export const IMPLEMENTERS = Object.freeze([
     skill: "commandcode-delegate",
     binary: "command-code",
     versionArgs: ["--no-auto-update", "--version"],
-    authProbe: { args: ["status", "--json"], jsonField: "authenticated" },
+    authProbe: { args: ["--no-auto-update", "status", "--json"], jsonField: "authenticated" },
     modelProbe: null,
     // No documented stable session-store path; usage stays unknown rather than guessed.
     usageProbe: null,

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -140,7 +140,24 @@ if (process.env.SMOKE_MODE === "grok-read-only") {
   console.log(JSON.stringify({ type: "end", sessionId: "grok-session-1" }));
   process.exit(0);
 }
-if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
+if (["commandcode-success", "commandcode-read-only"].includes(process.env.SMOKE_MODE)) {
+  let brief = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => { brief += chunk; });
+  process.stdin.on("end", () => {
+    fs.writeFileSync(process.env.SMOKE_CAPTURE_FILE, JSON.stringify({ args, brief }));
+    console.log(JSON.stringify({ type: "event", event: { type: "tool_running", toolName: "read_file" } }));
+    console.log(JSON.stringify({
+      type: "result",
+      subtype: "success",
+      sessionId: "commandcode-session-1",
+      stopReason: "end_turn",
+      usage: { inputTokens: 7, outputTokens: 2, totalTokens: 9 },
+      durationMs: 42,
+      finalText: "fake command code completed",
+    }));
+  });
+} else if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
   let brief = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (chunk) => { brief += chunk; });

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -50,6 +50,7 @@ if (process.env.SMOKE_MODE === "capture") {
 if (process.env.SMOKE_WRITE_FILE) {
   fs.writeFileSync(process.env.SMOKE_WRITE_FILE, "written by fake cli\n");
 }
+if (process.env.SMOKE_DELETE_FILE) fs.unlinkSync(process.env.SMOKE_DELETE_FILE);
 if (process.env.SMOKE_APPEND_INVALID_UTF8) {
   fs.appendFileSync(Buffer.from(process.env.SMOKE_APPEND_INVALID_UTF8, "hex"), "appended by fake cli\n");
 }

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,10 +1,11 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
+export const SKILLS = ["claude", "cline", "commandcode", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
 
 export const EXTRA_ARGS = {
   claude: [],
   cline: [],
+  commandcode: [],
   codex: [],
   opencode: ["--model", "fake/model"],
   agy: [],
@@ -20,7 +21,7 @@ export const EXTRA_ARGS = {
 export const WIN = process.platform === "win32";
 
 export const binaryName = (skill) =>
-  skill === "qoder" ? "qodercli" : skill === "cursor" ? "cursor-agent" : skill;
+  skill === "qoder" ? "qodercli" : skill === "cursor" ? "cursor-agent" : skill === "commandcode" ? "command-code" : skill;
 
 export const relayPath = (testDir, skill) =>
   join(testDir, "..", "skills", `${skill}-delegate`, "scripts", "relay.mjs");

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { copyFileSync, readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from "node:fs";
+import { copyFileSync, readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, symlinkSync } from "node:fs";
 import { join, delimiter } from "node:path";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
@@ -13,9 +13,21 @@ export function installShim(h) {
   mkdirSync(shimDir);
   copyFileSync(join(fixturesDir, "fake-cli.cjs"), join(shimDir, "fake-cli.cjs"));
 
+  const commandCodePackage = join(shimDir, "node_modules", "command-code");
+  mkdirSync(commandCodePackage, { recursive: true });
+  copyFileSync(join(fixturesDir, "fake-cli.cjs"), join(commandCodePackage, "index.cjs"));
+  chmodSync(join(commandCodePackage, "index.cjs"), 0o755);
+  writeFileSync(join(commandCodePackage, "package.json"), JSON.stringify({
+    name: "command-code",
+    version: "0.0.0-smoke",
+    bin: { "command-code": "index.cjs" },
+  }));
+
   if (WIN) {
-    for (const skill of ["claude", "cline", "codex", "opencode", "grok", "cursor", "pi"]) {
-      writeFileSync(join(shimDir, `${binaryName(skill)}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
+    for (const skill of ["claude", "cline", "commandcode", "codex", "opencode", "grok", "cursor", "pi"]) {
+      writeFileSync(join(shimDir, `${binaryName(skill)}.cmd`), skill === "commandcode"
+        ? "@exit /b 99\r\n"
+        : `@node "%~dp0fake-cli.cjs" %*\r\n`);
     }
     const windir = process.env.WINDIR || "C:\\Windows";
     const csc = [
@@ -42,7 +54,8 @@ export function installShim(h) {
   } else {
     for (const skill of SKILLS) {
       const shim = join(shimDir, binaryName(skill));
-      writeFileSync(shim, `#!/bin/sh\nexec node "$(dirname "$0")/fake-cli.cjs" "$@"\n`);
+      if (skill === "commandcode") symlinkSync(join(commandCodePackage, "index.cjs"), shim);
+      else writeFileSync(shim, `#!/bin/sh\nexec node "$(dirname "$0")/fake-cli.cjs" "$@"\n`);
       chmodSync(shim, 0o755);
     }
   }

--- a/test/relay-isolated.mjs
+++ b/test/relay-isolated.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
+const RELAYS = ["claude", "cline", "commandcode", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
 let failed = 0;
 const check = (name, condition) => {
   console.log(`${condition ? "  ok " : "  FAIL"}  ${name}`);

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
+const RELAYS = ["claude", "cline", "commandcode", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
 const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -5,12 +5,13 @@ import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const RELAYS = ["claude", "cline", "commandcode", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
+const SHARED_GIT_LOOKUP_RELAYS = RELAYS.filter((relay) => relay !== "commandcode");
 const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],
   ["parseDuration", "function", RELAYS],
   ["killChild", "function", RELAYS],
-  ["gitTouchedFiles", "function", RELAYS],
+  ["gitTouchedFiles", "function", SHARED_GIT_LOOKUP_RELAYS],
   ["FINGERPRINT_UNREADABLE", "const", READ_ONLY_TRIPWIRE_RELAYS],
   ["FINGERPRINT_DIRECTORY", "const", READ_ONLY_TRIPWIRE_RELAYS],
   ["gitRepoRoot", "function", READ_ONLY_TRIPWIRE_RELAYS],

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -7,7 +7,7 @@
  * not complete:
  *
  *   1. timeout  — the watchdog kills the implementer's WHOLE process tree and
- *                 result.json reports status "timeout". Driven for all twelve
+ *                 result.json reports status "timeout". Driven for all thirteen
  *                 relays on both platforms. On Windows, claude and cursor
  *                 launch a .cmd shim through a serialized cmd.exe invocation,
  *                 while codex/opencode/grok/pi/cline use shell:true. These are exactly the
@@ -23,7 +23,7 @@
  *   2. aborted  — killing the relay itself still produces result.json with
  *                 status "aborted", and files the implementer flushes during
  *                 the shutdown grace window appear in the refreshed
- *                 touchedFiles. Driven for all twelve relays on POSIX; Windows
+ *                 touchedFiles. Driven for all thirteen relays on POSIX; Windows
  *                 delivers no catchable SIGTERM, so the scenario cannot be
  *                 driven there (the skill docs carry the same caveat).
  *
@@ -31,7 +31,7 @@
  * `changelog`), and can be told to hang or fail that probe by mode name, so a
  * relay whose preflight is unbounded — wedging before any result.json exists —
  * or which reports a broken CLI as a missing one is caught here.
- * A shared matrix also drives all twelve through the --timeout values no
+ * A shared matrix also drives all thirteen through the --timeout values no
  * watchdog can honour — malformed, zero, and past Node's timer ceiling — each of
  * which would otherwise fire on the next tick as a silent instant "timeout".
  * Quick Claude, Cline, Cursor, Qoder, Vibe, and Pi success cases verify brief

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -1,0 +1,140 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export async function runCommandCode(h) {
+  {
+    const outDir = join(h.scratch, "out-success-commandcode");
+    const workDir = h.freshRepo("work-success-commandcode");
+    const captureFile = join(h.scratch, "capture-success-commandcode.json");
+    const run = spawnSync(process.execPath, [
+      h.relayPath("commandcode"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", outDir,
+      "--model", "fake/model",
+      "--effort", "high",
+      "--max-turns", "7",
+      "--timeout", "5s",
+    ], {
+      env: { ...h.baseEnv, SMOKE_MODE: "commandcode-success", SMOKE_CAPTURE_FILE: captureFile },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    h.check("commandcode success: relay exits zero", run.status === 0);
+    h.check("commandcode success: unborn HEAD probe stays quiet", run.stderr === "");
+    h.check("commandcode success: result.json exists", existsSync(join(outDir, "result.json")));
+    h.check("commandcode success: fake captured the launch", existsSync(captureFile));
+    if (existsSync(captureFile)) {
+      const capture = JSON.parse(readFileSync(captureFile, "utf8"));
+      h.check("commandcode success: brief delivered through stdin",
+        capture.brief === "smoke brief: run until killed.");
+      h.check("commandcode success: print JSON launch selected",
+        capture.args.includes("-p") &&
+        h.pair(capture.args, "--output-format", "json") &&
+        capture.args.includes("--skip-onboarding") &&
+        capture.args.includes("--no-auto-update") &&
+        !capture.args.includes("smoke brief: run until killed."));
+      h.check("commandcode success: trust and write autonomy selected",
+        capture.args.includes("--trust") && capture.args.includes("--yolo") && !capture.args.includes("--plan"));
+      h.check("commandcode success: model, effort, and turn cap forwarded",
+        h.pair(capture.args, "--model", "fake/model") &&
+        h.pair(capture.args, "--effort", "high") &&
+        h.pair(capture.args, "--max-turns", "7"));
+    }
+    if (existsSync(join(outDir, "result.json"))) {
+      const result = h.result(outDir);
+      h.check("commandcode success: status and tool are normalized",
+        result.status === "completed" && result.tool === "commandcode");
+      h.check("commandcode success: session and final message parsed",
+        result.sessionId === "commandcode-session-1" && result.finalMessage === "fake command code completed");
+      h.check("commandcode success: usage and duration parsed",
+        result.usage?.totalTokens === 9 && result.durationMs === 42);
+      h.check("commandcode success: watchdog recorded", result.timeout === "5s");
+    }
+    if (run.status !== 0) console.error(`commandcode success relay stderr:\n${run.stderr}\n${run.stdout}\n${existsSync(join(outDir, "result.json")) ? readFileSync(join(outDir, "result.json"), "utf8") : ""}`);
+  }
+
+  {
+    const outDir = join(h.scratch, "out-read-only-commandcode");
+    const workDir = h.freshRepo("work-read-only-commandcode");
+    const captureFile = join(h.scratch, "capture-read-only-commandcode.json");
+    const run = spawnSync(process.execPath, [
+      h.relayPath("commandcode"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", outDir,
+      "--read-only",
+      "--session", "commandcode-session-1",
+    ], {
+      env: { ...h.baseEnv, SMOKE_MODE: "commandcode-read-only", SMOKE_CAPTURE_FILE: captureFile },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    h.check("commandcode read-only: relay exits zero", run.status === 0);
+    h.check("commandcode read-only: result.json exists", existsSync(join(outDir, "result.json")));
+    h.check("commandcode read-only: fake captured the launch", existsSync(captureFile));
+    if (existsSync(captureFile)) {
+      const capture = JSON.parse(readFileSync(captureFile, "utf8"));
+      h.check("commandcode read-only: plan and exact-session flags selected",
+        capture.args.includes("--plan") && h.pair(capture.args, "--resume", "commandcode-session-1"));
+      h.check("commandcode read-only: bypass and model override omitted",
+        !capture.args.includes("--yolo") && !capture.args.includes("--model"));
+    }
+    if (existsSync(join(outDir, "result.json"))) {
+      const result = h.result(outDir);
+      h.check("commandcode read-only: clean tripwire passes",
+        result.status === "completed" &&
+        result.autonomy === "read-only" &&
+        result.requestedSessionId === "commandcode-session-1" &&
+        result.readOnlyViolation === false);
+    }
+    if (run.status !== 0) console.error(`commandcode read-only relay stderr:\n${run.stderr}\n${run.stdout}\n${existsSync(join(outDir, "result.json")) ? readFileSync(join(outDir, "result.json"), "utf8") : ""}`);
+  }
+
+  {
+    const outDir = join(h.scratch, "out-read-only-write-commandcode");
+    const workDir = h.freshRepo("work-read-only-write-commandcode");
+    const run = spawnSync(process.execPath, [
+      h.relayPath("commandcode"), "--brief", h.briefPath, "--cd", workDir,
+      "--out-dir", outDir, "--read-only",
+    ], {
+      env: {
+        ...h.baseEnv,
+        SMOKE_MODE: "commandcode-read-only",
+        SMOKE_CAPTURE_FILE: join(h.scratch, "capture-read-only-write-commandcode.json"),
+        SMOKE_WRITE_FILE: join(workDir, "violation.txt"),
+      },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    const result = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+    h.check("commandcode read-only violation: relay fails closed",
+      run.status === 1 && result.status === "failed" && result.readOnlyViolation === true);
+  }
+
+  {
+    const outDir = join(h.scratch, "out-staged-commandcode");
+    const workDir = h.freshRepo("work-staged-commandcode");
+    const tracked = join(workDir, "index-dirty.txt");
+    writeFileSync(tracked, "base\n");
+    spawnSync("git", ["-C", workDir, "add", "index-dirty.txt"]);
+    spawnSync("git", ["-C", workDir, "-c", "user.name=Smoke", "-c", "user.email=smoke@example.invalid", "commit", "-qm", "fixture"]);
+    writeFileSync(tracked, "worktree content\n");
+    const run = spawnSync(process.execPath, [
+      h.relayPath("commandcode"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir,
+    ], {
+      env: {
+        ...h.baseEnv,
+        SMOKE_MODE: "commandcode-success",
+        SMOKE_CAPTURE_FILE: join(h.scratch, "capture-staged-commandcode.json"),
+        SMOKE_INDEX_ONLY_FILE: "index-dirty.txt",
+      },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    const result = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+    h.check("commandcode staged-index violation: relay fails closed",
+      run.status === 1 && result.status === "failed" && result.gitMutationViolation === true);
+  }
+}

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -137,4 +137,29 @@ export async function runCommandCode(h) {
     h.check("commandcode staged-index violation: relay fails closed",
       run.status === 1 && result.status === "failed" && result.gitMutationViolation === true);
   }
+
+  {
+    const outDir = join(h.scratch, "out-read-only-delete-commandcode");
+    const workDir = h.freshRepo("work-read-only-delete-commandcode");
+    const tracked = join(workDir, "deleted.txt");
+    writeFileSync(tracked, "tracked\n");
+    spawnSync("git", ["-C", workDir, "add", "deleted.txt"]);
+    spawnSync("git", ["-C", workDir, "-c", "user.name=Smoke", "-c", "user.email=smoke@example.invalid", "commit", "-qm", "fixture"]);
+    const run = spawnSync(process.execPath, [
+      h.relayPath("commandcode"), "--brief", h.briefPath, "--cd", workDir,
+      "--out-dir", outDir, "--read-only",
+    ], {
+      env: {
+        ...h.baseEnv,
+        SMOKE_MODE: "commandcode-read-only",
+        SMOKE_CAPTURE_FILE: join(h.scratch, "capture-read-only-delete-commandcode.json"),
+        SMOKE_DELETE_FILE: tracked,
+      },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    const result = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+    h.check("commandcode tracked deletion: read-only violation remains explicit",
+      run.status === 1 && result.status === "failed" && result.readOnlyViolation === true);
+  }
 }

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -27,7 +27,7 @@ export function runDelegateSetup(h) {
   h.check("discover reports version", report?.version === "delegate-discover.v1");
   h.check("discover lists discovered or missing", Array.isArray(report?.discovered) && Array.isArray(report?.missing));
   h.check(
-    "discover covers all twelve implementers",
+    "discover covers all thirteen implementers",
     Array.isArray(report?.discovered) &&
       Array.isArray(report?.missing) &&
       report.discovered.length + report.missing.length === h.SKILLS.length,
@@ -155,6 +155,7 @@ if (observation === "models") {
         feature: { implementer: "opencode", model: "opencode/grok", variant: "high" },
         tests: { implementer: "grok", effort: "medium" },
         "codex-review": { implementer: "codex", readOnly: true },
+        "commandcode-review": { implementer: "commandcode", model: "fake/model", effort: "high", timeout: "5s", readOnly: true },
         "opencode-review": { implementer: "opencode", model: "opencode/grok", readOnly: true },
       },
     };
@@ -534,6 +535,37 @@ if (observation === "models") {
       encoding: "utf8",
       env: process.env,
     });
+
+    const commandCodeLaneOut = join(h.scratch, "out-lane-commandcode");
+    const commandCodeLaneCapture = join(h.scratch, "capture-lane-commandcode.json");
+    const commandCodeLane = spawnSync(process.execPath, [
+      h.relayPath("commandcode"),
+      "--brief", laneBrief,
+      "--cd", cfgRepo,
+      "--out-dir", commandCodeLaneOut,
+      "--lane", "commandcode-review",
+      "--resume-last",
+    ], {
+      encoding: "utf8",
+      env: {
+        ...fleetEnv,
+        SMOKE_MODE: "commandcode-read-only",
+        SMOKE_CAPTURE_FILE: commandCodeLaneCapture,
+      },
+    });
+    const commandCodeLaneArgs = existsSync(commandCodeLaneCapture)
+      ? JSON.parse(readFileSync(commandCodeLaneCapture, "utf8")).args
+      : [];
+    h.check("relay --lane: Command Code applies model, effort, timeout, and readOnly dials",
+      commandCodeLane.status === 0 &&
+        h.pair(commandCodeLaneArgs, "--model", "fake/model") &&
+        h.pair(commandCodeLaneArgs, "--effort", "high") &&
+        commandCodeLaneArgs.includes("--plan") &&
+        commandCodeLaneArgs.includes("--continue") &&
+        !commandCodeLaneArgs.includes("--yolo") &&
+        h.result(commandCodeLaneOut).timeout === "5s" &&
+        h.result(commandCodeLaneOut).lane === "commandcode-review" &&
+        h.result(commandCodeLaneOut).laneSource === "global");
 
     const laneDispatch = spawnSync(
       process.execPath,

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -2,6 +2,7 @@ import { runPackageShape } from "./package-shape.mjs";
 import { runSyntax } from "./syntax.mjs";
 import { runCodex } from "./codex.mjs";
 import { runCline } from "./cline.mjs";
+import { runCommandCode } from "./commandcode.mjs";
 import { runAgy } from "./agy.mjs";
 import { runCursor } from "./cursor.mjs";
 import { runVibe } from "./vibe.mjs";
@@ -22,6 +23,7 @@ export const runners = [
   ["syntax", runSyntax],
   ["codex", runCodex],
   ["cline", runCline],
+  ["commandcode", runCommandCode],
   ["agy", runAgy],
   ["cursor", runCursor],
   ["vibe", runVibe],

--- a/test/relay/preflight.mjs
+++ b/test/relay/preflight.mjs
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { join } from "node:path";
 
 export async function runPreflight(h) {
-for (const skill of ["codex", "opencode", "grok", "kimi"]) {
+for (const skill of ["commandcode", "codex", "opencode", "grok", "kimi"]) {
   const workDir = h.freshRepo(`work-preflight-${skill}`);
   for (const [suffix, expectedStatus, expectedExit] of [
     ["version-hang", "timeout", 124],

--- a/test/relay/timeout-tree.mjs
+++ b/test/relay/timeout-tree.mjs
@@ -6,6 +6,7 @@ export async function runTimeoutTree(h) {
 const TIMEOUT_CASES = [
   { skill: "claude", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "cline", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "commandcode", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "codex", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "opencode", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "grok", flags: ["--timeout", "6s"], exitDeadline: 45_000 },


### PR DESCRIPTION
**Claim:** #84

**What ran:** Windows 10 Enterprise LTSC 10.0.19044, native `command-code` 1.24.0. A live authenticated `--read-only` run used the configured model, delivered the brief on stdin, parsed the NDJSON result (`OK`), captured session/usage data, and left Git/read-only tripwires clean. `node test/relay-smoke.mjs` completed all green; `node test/relay-parity.mjs` and `node test/relay-isolated.mjs` passed; `npx skills add . --list` found all 14 skills; direct `relay.mjs --help` passed. No live Command Code run was made on macOS or Linux, and no real-CLI write-mode run is claimed.

## Summary

- Add `commandcode-delegate` with four references and a Node-builtins-only relay.
- Register Command Code in fleet setup, package metadata, docs, and shared matrices.
- Cover stdin/NDJSON transport, exact/latest resume, read-only and Git mutation tripwires, bounded preflight/watchdog, atomic results, and process-tree cleanup.

No existing open or closed Command Code pull request was found before submission.

Prepared with OpenCode using `openai/gpt-5.6-sol`; the human submitter reviewed and explicitly approved the complete staged diff before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Command Code as a delegation option for coding, review, and diagnostic tasks.
  * Added configurable model, effort, timeout, read-only execution, session continuation, and structured result capture.
  * Added safety checks, repository mutation detection, and Windows support.

* **Documentation**
  * Documented setup, CLI usage, task workflows, safeguards, review, and completion requirements.

* **Tests**
  * Added coverage for execution, read-only enforcement, timeouts, session handling, argument forwarding, and mutation detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->