### PR TITLE
feat(agy): strengthen edit-only delegation coverage

### DIFF
--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -56,8 +56,9 @@ Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are 
 
 Antigravity sees only the text you send plus what it can inspect in the workspace - no chat history, no
 shared context. Everything the task needs goes in the brief: the goal, the current state, what to
-change, what to leave untouched, the project's **actual** gate commands, and a report contract. Tell
-Antigravity it will **not** commit (you will). Keep one task per brief. Full guidance and a template:
+change, what to leave untouched, and a report contract. For an edit-only implementer, explicitly reserve
+shell commands, tests, lint, typecheck, and builds for the orchestrator. Tell Antigravity it will
+**not** commit (you will). Keep one task per brief. Full guidance and a template:
 [references/writing-the-brief.md](references/writing-the-brief.md).
 
 ### 2. Dispatch
@@ -98,7 +99,8 @@ the `finalMessage` field in `result.json` (also printed in full on stdout betwee
 Antigravity's `result.json` includes its own final message and any gate claims. **Re-verify, don't
 accept:**
 
-- **Re-run the project's gates yourself** (the test/lint/build commands from step 1).
+- **Run the project's gates yourself** after the edit-only implementer returns; do not delegate validation
+  commands to Antigravity.
 - **Read the diff** against the brief: did Antigravity do what was asked, nothing more and nothing less?
   `touchedFiles` in the result is your starting point.
 - **Run the relevant guard skills** on the diff if you have them installed.
@@ -142,7 +144,7 @@ going beyond the brief, ask - don't expand the mandate yourself). The full treat
 ## References
 
 - [references/writing-the-brief.md](references/writing-the-brief.md) - how to write a brief Antigravity
-  can execute blind: structure, XML blocks, the report contract, and real gate commands.
+  can execute blind: structure, XML blocks, the edit-only boundary, and the report contract.
 - [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - `relay.mjs` flags, the
   `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
 - [references/review-and-land.md](references/review-and-land.md) - the review checklist, the commit

--- a/skills/agy-delegate/references/writing-the-brief.md
+++ b/skills/agy-delegate/references/writing-the-brief.md
@@ -26,13 +26,10 @@ change, and explicitly what to leave untouched. The "leave untouched" list is wh
 from wandering into unrelated refactors.
 </task>
 
-<verification_loop>
-Run these before finishing and fix anything they surface, don't just report it:
-  <the project's real test command>
-  <the project's real lint/format command>
-  <the project's real build/typecheck command>
-Confirm the working tree shows only the intended changes afterward.
-</verification_loop>
+<edit_only>
+Edit files only. Do not run shell commands, tests, lint, formatters, typecheck, builds, package managers,
+Git commands, or other executables. The orchestrator owns all validation after the edit returns.
+</edit_only>
 
 <action_safety>
 Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
@@ -44,7 +41,7 @@ work uncommitted in the working tree.
 End with a report in this exact shape:
   1. What changed and why
   2. Files touched
-  3. Gate outcomes (paste the test/lint counts)
+  3. Validation not run by design (the orchestrator owns it)
   4. Anything you deviated on, left open, or want a decision on
 </structured_output_contract>
 ```
@@ -64,12 +61,12 @@ The relay captures `agy --print` stdout as `finalMessage`. If Antigravity finish
 summary, the result is not useful to review. The `<structured_output_contract>` block is what guarantees
 a report you can read.
 
-## Discover the real gates
+## Keep validation with the orchestrator
 
-`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
-`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
-`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
-naming them gets you an implementer that guesses - or skips.
+Do not copy test, lint, typecheck, build, package-manager, or other shell commands into an edit-only
+brief. Discover the project's real gates yourself, run them after Antigravity returns, and repair
+confirmed in-scope findings by resuming the same conversation with another edit-only delta brief.
+This keeps the edit-only implementer focused on file edits and makes validation evidence the orchestrator's own.
 
 ## Honor the repo's conventions
 
@@ -102,12 +99,11 @@ key before creating a new one. Touch only services/billing/refund.py and its tes
 path, API routes, and data models untouched.
 </task>
 
-<verification_loop>
-Run and make green before finishing:
-  pytest tests/billing/ -q
-  ruff check services/billing/
-Confirm git status shows only refund.py and its test file changed.
-</verification_loop>
+<edit_only>
+Edit files only. Do not run shell commands, tests, lint, formatters, typecheck, builds, package managers,
+Git commands, or other executables. The orchestrator will inspect the diff and run the real project
+gates after you return.
+</edit_only>
 
 <action_safety>
 Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
@@ -115,7 +111,7 @@ changes in the working tree for review.
 </action_safety>
 
 <structured_output_contract>
-Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+Report: (1) the root cause and your fix, (2) files touched, (3) validation not run by design,
 (4) anything you left open or want decided.
 </structured_output_contract>
 ```

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -90,6 +90,10 @@ if (process.env.SMOKE_MODE === "agy-permission-denied") {
   console.error('jetski: no output produced — a tool required the "write_file" permission that headless\nmode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow\nin settings.json (e.g. write_file(<target>)). Alternatively, re-run with\n--dangerously-skip-permissions to auto-approve all tools.');
   process.exit(0);
 }
+if (process.env.SMOKE_MODE === "agy-error") {
+  console.error("fake agy provider failure");
+  process.exit(7);
+}
 if (process.env.SMOKE_MODE === "agy-analysis") {
   if (process.env.SMOKE_ARGS_FILE) fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
   const logAt = args.indexOf("--log-file");

--- a/test/fixtures/fake-cli.cs
+++ b/test/fixtures/fake-cli.cs
@@ -49,6 +49,10 @@ class FakeCli {
       Console.Error.WriteLine("jetski: no output produced — a tool required the \"write_file\" permission that headless\nmode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow\nin settings.json (e.g. write_file(<target>)). Alternatively, re-run with\n--dangerously-skip-permissions to auto-approve all tools.");
       return 0;
     }
+    if (mode == "agy-error") {
+      Console.Error.WriteLine("fake agy provider failure");
+      return 7;
+    }
     if (mode == "agy-analysis") {
       var argsFile = Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE");
       if (!String.IsNullOrEmpty(argsFile)) File.WriteAllLines(argsFile, args);

--- a/test/relay/agy.mjs
+++ b/test/relay/agy.mjs
@@ -48,6 +48,95 @@ export async function runAgy(h) {
     return { result, value: existsSync(join(outDir, "result.json")) ? h.result(outDir) : {} };
   };
 
+  const freshWorkDir = h.freshRepo("fresh-args-agy");
+  const extraWorkspace = join(h.scratch, "extra-workspace-agy");
+  mkdirSync(extraWorkspace);
+  const freshOutDir = join(h.scratch, "out-fresh-args-agy");
+  const freshArgsFile = join(h.scratch, "args-fresh-args-agy");
+  const freshDispatch = spawnSync(process.execPath, [
+    h.relayPath("agy"),
+    "--brief", h.briefPath,
+    "--cd", freshWorkDir,
+    "--out-dir", freshOutDir,
+    "--model", "fixture-model",
+    "--effort", "high",
+    "--add-dir", extraWorkspace,
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "agy-analysis", SMOKE_ARGS_FILE: freshArgsFile },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  const freshArgs = readArgs(freshArgsFile);
+  const freshValue = existsSync(join(freshOutDir, "result.json")) ? h.result(freshOutDir) : {};
+  const freshAddDirs = freshArgs.flatMap((arg, index) => arg === "--add-dir" ? [freshArgs[index + 1]] : []);
+  h.check("agy fresh dispatch: relay exits successfully", freshDispatch.status === 0);
+  h.check("agy fresh dispatch: model and effort are forwarded",
+    h.pair(freshArgs, "--model", "fixture-model") &&
+    h.pair(freshArgs, "--effort", "high"));
+  h.check("agy fresh dispatch: repository and extra workspace are pinned",
+    freshAddDirs.length === 2 &&
+    freshAddDirs[0] === freshWorkDir &&
+    freshAddDirs[1] === extraWorkspace);
+  h.check("agy fresh dispatch: starts a project and delivers the brief without bypass",
+    freshArgs.includes("--new-project") &&
+    freshArgs.some((arg) => arg.startsWith("--print=")) &&
+    !freshArgs.includes("--dangerously-skip-permissions"));
+  h.check("agy fresh dispatch: captures a completed result", freshValue.status === "completed");
+
+  const conversationOutDir = join(h.scratch, "out-conversation-agy");
+  const conversationArgsFile = join(h.scratch, "args-conversation-agy");
+  const conversationDispatch = spawnSync(process.execPath, [
+    h.relayPath("agy"),
+    "--brief", h.briefPath,
+    "--cd", freshWorkDir,
+    "--out-dir", conversationOutDir,
+    "--conversation", "conversation-1",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "agy-analysis", SMOKE_ARGS_FILE: conversationArgsFile },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  const conversationArgs = readArgs(conversationArgsFile);
+  const conversationValue = existsSync(join(conversationOutDir, "result.json")) ? h.result(conversationOutDir) : {};
+  h.check("agy conversation resume: preserves conversation and omits fresh workspace flags",
+    conversationDispatch.status === 0 &&
+    h.pair(conversationArgs, "--conversation", "conversation-1") &&
+    !conversationArgs.includes("--new-project") &&
+    !conversationArgs.includes("--add-dir") &&
+    conversationValue.resumed === true);
+
+  const latestOutDir = join(h.scratch, "out-resume-last-agy");
+  const latestArgsFile = join(h.scratch, "args-resume-last-agy");
+  const latestDispatch = spawnSync(process.execPath, [
+    h.relayPath("agy"),
+    "--brief", h.briefPath,
+    "--cd", freshWorkDir,
+    "--out-dir", latestOutDir,
+    "--resume-last",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "agy-analysis", SMOKE_ARGS_FILE: latestArgsFile },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  const latestArgs = readArgs(latestArgsFile);
+  h.check("agy resume-last: uses --continue without fresh workspace flags",
+    latestDispatch.status === 0 &&
+    latestArgs.includes("--continue") &&
+    !latestArgs.includes("--add-dir"));
+
+  const unsupportedOutDir = join(h.scratch, "out-exclude-path-agy");
+  const unsupportedExclude = spawnSync(process.execPath, [
+    h.relayPath("agy"),
+    "--brief", h.briefPath,
+    "--cd", freshWorkDir,
+    "--out-dir", unsupportedOutDir,
+    "--exclude-path", "protected.txt",
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("agy unsupported --exclude-path: rejected instead of presented as protection",
+    unsupportedExclude.status === 2 &&
+    !existsSync(join(unsupportedOutDir, "result.json")) &&
+    unsupportedExclude.stderr.includes("unknown option: --exclude-path"));
+
   const denied = run("permission-denied", "agy-permission-denied");
   h.check("agy permission denial: exit-zero no-op is reported as failed with diagnostics",
     denied.result.status === 1 &&
@@ -55,6 +144,13 @@ export async function runAgy(h) {
     denied.value.exitCode === 1 &&
     denied.value.error?.includes("headless --print") &&
     denied.value.stderrTail?.some((line) => line.includes("auto-denied")));
+
+  const providerError = run("provider-error", "agy-error");
+  h.check("agy provider error: non-zero exit and stderr are captured deterministically",
+    providerError.result.status === 7 &&
+    providerError.value.status === "failed" &&
+    providerError.value.exitCode === 7 &&
+    providerError.value.stderrTail?.some((line) => line.includes("fake agy provider failure")));
 
   const silent = run("silent-noop", "agy-silent-noop");
   h.check("agy silent no-op: no final message or edits cannot report completed",


### PR DESCRIPTION
## Summary

Improves generic AGY delegation guidance and deterministic relay coverage for edit-only implementer workflows.

## What changed

- Clarified edit-only Writer/implementer briefing and orchestrator-owned validation.
- Expanded native AGY relay tests for fresh dispatch, conversation resume, `--resume-last`, and workspace pinning.
- Added plan/read-only, permission-denial, provider-error, deterministic result, and `readOnlyViolation` coverage.
- Confirmed unsupported `--exclude-path` is rejected.

## Why

Delegated coding is more reliable when the implementer owns file edits while the orchestrator owns shell execution and validation.

## Validation

```text
node test/relay-smoke.mjs --only agy
node test/relay-smoke.mjs --only syntax
```

`git diff --check`: PASS

## Scope

- No new provider dependency.
- No dangerous permission bypass is enabled.
- No repository-specific behavior is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Implementer runs now focus on edits, while validation and project checks are performed afterward for clearer workflow separation.
  * Workspace setup, conversation resumption, and resume-last behavior are more consistently supported.
  * Unsupported path-exclusion options are now rejected clearly.
  * Provider failures report an appropriate failure status, exit code, and diagnostic message.

* **Documentation**
  * Updated guidance and examples to reflect the edit-only workflow and post-edit validation process.

* **Tests**
  * Added coverage for dispatch, workspace handling, resumption, unsupported options, and provider-error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->