### PR TITLE
feat(copilot-delegate): add GitHub Copilot CLI delegate skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Twelve implementer skills ship today: `claude-delegate` (Claude Code),
+and land the result. Thirteen implementer skills ship today: `claude-delegate` (Claude Code),
 `cline-delegate` (Cline CLI), `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode),
 `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code),
 `qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI),
-`pi-delegate` (Pi CLI), and `aider-delegate` (Aider); siblings like `gemini-delegate` can be added
+`pi-delegate` (Pi CLI), `aider-delegate` (Aider), and `copilot-delegate` (GitHub Copilot CLI); siblings like `gemini-delegate` can be added
 later without renaming the repo. One **utility** skill
 ships alongside them: `delegate-setup` (configure fleet lanes — setup only, never dispatches).
 
@@ -19,7 +19,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Aider) | "worker", "sub-agent", "executor" |
+| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Aider, Copilot) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -40,6 +40,7 @@ jargon. Use these terms; don't invent synonyms.
 | `--prompt`, `--output` (`streaming`/`json`/`text`), `--agent` (`plan`/`accept-edits`/`auto-approve`), `--max-turns`, `--max-price`, `--max-tokens`, `--trust`, `--resume`, `--continue`, `--enabled-tools`, `--disabled-tools` | Mistral Vibe's own terms — use verbatim when discussing `vibe` | don't invent a Vibe sandbox enum; `--trust` is not a permission mode |
 | `session`, `--continue`, `--session`, `print mode`, `--mode json`, `tools`, `context files`, `project trust` | Pi's own terms — use verbatim when discussing `pi` | don't paraphrase them |
 | `--message-file`, `--yes-always`, `--suggest-shell-commands`, `--auto-commits`/`--dirty-commits`, `--dry-run`, `--edit-format`, `--architect`, `--file`/`--read`, `chat history` | Aider's own terms — use verbatim when discussing `aider` | Aider has no sandbox, no permission modes, and no session ids; don't imply any. `--file`/`--read` scope the chat context — never call them a boundary |
+| `session`, `-p`/`--prompt`, `--output-format json` (JSONL), `tools`, `--allow-all-tools`, `mode plan`, `--resume`/`--continue`, `--model`, `--effort`, `copilot login` / env tokens, `sandbox` (experimental, MXC) | GitHub Copilot CLI's own terms — use verbatim when discussing `copilot` | don't paraphrase them |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -48,7 +49,7 @@ version a run was made against is what makes the claim checkable; and claims tha
 ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
 `cline` / `codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi` /
-`aider`) and the skill's `relay.mjs`.
+`aider` / `copilot`) and the skill's `relay.mjs`.
 
 ## Conventions
 
@@ -83,7 +84,7 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - Smoke-test any changed script directly (e.g. `node skills/<skill>/scripts/relay.mjs --help`, and a
   no-write or read-only run against a throwaway repo) before relying on it.
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
-  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, `grok`, `pi`, and `cline` launches
+  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, `grok`, `pi`, `cline`, and `copilot` launches
   need `shell:true` on win32 to resolve the `.cmd` shim. Cline streams its brief on stdin and uses the
   child process cwd; the other launches quote spaceable args, and all value flags are token-validated.
   The `claude` and `cursor-agent` launches serialize a pre-joined

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`pi-delegate`](skills/pi-delegate/SKILL.md) | [Pi](https://github.com/earendil-works/pi-mono) (`pi`) | full local tools — no sandbox, no permission modes [^none]; project trust opt-in | `--read-only` (`read,grep,find,ls`) | `--resume-last`, `--session <id>` |
 | [`qoder-delegate`](skills/qoder-delegate/SKILL.md) | [Qoder](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` permission mode; bypass opt-in | `--permission-mode plan` | `--resume-last`, `--resume <id>` |
 | [`vibe-delegate`](skills/vibe-delegate/SKILL.md) | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits`; `--full-access` opt-in | `--plan-only` (`plan` agent) | `--resume-last`, `--session <id>` |
+| [`copilot-delegate`](skills/copilot-delegate/SKILL.md) | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli) (`copilot`) | `--allow-all-tools` opt-in; headless auto-deny otherwise | `--read-only` (`--mode plan`) | `--resume-last`, `--session <id>` |
 
 [^none]: No CLI-enforced read-only mode. `touchedFiles` and the diff, not a flag, are the guarantee.
 
@@ -247,6 +248,14 @@ Per skill — platform, CLI version, and what the run exercised:
   `sessionId`/`finalPath`, bounded version preflight, missing binary, result parsing, and whole-process-tree
   timeout/abort cleanup. The contributor also reported a native Windows 3.0.51 edit run against the
   earlier positional-brief commit; that does not verify this exact stdin-based head on Windows.
+- `copilot-delegate` — Windows, `copilot` 1.0.78: `--read-only` plan-mode run completed with a clean
+  tree and captured session id; `--allow-all-tools` edit run created the requested file; the headless
+  auto-deny path was exercised live (denial detected from the data-wrapped event shape, run reported
+  failed with the `--allow-all-tools` hint); `--session <id>` and `--resume-last` resume runs executed
+  their delta briefs via the directive-wrapped `-p @<file>` prompt. Contract-tested: argv exactness
+  (including the resume directive), denial shape, `--read-only`/`--allow-all-tools` conflict
+  validation, bounded version preflight, missing binary, result parsing, and whole-process-tree
+  timeout/abort cleanup.
 - `delegate-setup` — contract-tested: discover JSON shape, config validate/write/load, whole-lane
   project overlay, global write without creating `.delegate/`, and `--lane` resolve / wrong-skill /
   flag-override against relays. The smoke suite runs live discovery against installed CLIs

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -16,7 +16,8 @@
         "vibe-delegate",
         "cursor-delegate",
         "pi-delegate",
-        "aider-delegate"
+        "aider-delegate",
+        "copilot-delegate"
       ]
     },
     {

--- a/skills/copilot-delegate/SKILL.md
+++ b/skills/copilot-delegate/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   coding tasks through Copilot while staying the reviewer. DO NOT USE for tasks small enough to do
   inline, or when the user wants the code written directly without delegating.
 license: MIT
-compatibility: Requires the `copilot` CLI installed and authenticated (`copilot login`), Node 18+, and git. The orchestrator must be able to run shell commands and read files.
+compatibility: Requires the `copilot` CLI installed and authenticated (`copilot login`), Node 18+ to run the relay (the copilot CLI itself requires Node 22+), and git. The orchestrator must be able to run shell commands and read files.
 metadata:
   version: 0.4.2
 ---
@@ -28,11 +28,12 @@ The loop needs only a shell command and file access, so any comparable orchestra
 - The `copilot` CLI is not installed or authenticated.
 - You need a hard sandbox. Copilot exposes sandbox controls, but they are upstream-experimental
   (MXC-based, controlled via the `/sandbox` command and settings, disabled by default) — this relay
-  does not configure them. Use `--read-only` when the run must be read-only.
+  does not configure them. Use `--read-only` when the run must not edit project files.
 
 ## Prerequisites (check once)
 
-1. Install `copilot` (`npm install -g @github/copilot`; the relay probes `copilot version`).
+1. Install `copilot` (`npm install -g @github/copilot`; the CLI requires Node 22+, the relay
+   itself runs on Node 18+ — the relay probes `copilot version`).
 2. Authenticate: run `copilot login` (interactive web/device flow), or set
    `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` in the environment.
 3. Confirm `copilot version` succeeds.
@@ -111,8 +112,9 @@ message and a hint to pass `--allow-all-tools`. This is the honest default — t
 the failure rather than a silent no-op.
 
 `--allow-all-tools` explicitly grants full tool autonomy. `--read-only` selects `--mode plan`,
-which is genuinely read-only and works without `--allow-all-tools`. The two flags are mutually
-exclusive.
+which disables edit tools so project files can't be changed by direct edits; it works without
+`--allow-all-tools`. Shell commands still run in plan mode, so it guards against edits, not
+against everything. The two flags are mutually exclusive.
 
 Copilot also exposes sandbox controls, but they are upstream-experimental (MXC-based, controlled
 via the `/sandbox` command and settings, disabled by default). This relay does not configure them.

--- a/skills/copilot-delegate/SKILL.md
+++ b/skills/copilot-delegate/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: copilot-delegate
+description: >-
+  Delegate a coding task to the GitHub Copilot CLI (`copilot`) as a background implementer, then
+  review its diff and land it yourself. Use this whenever the user wants to delegate implementation
+  work to Copilot - phrasings like "have Copilot implement X", "delegate this to copilot", "run it
+  through Copilot CLI", or "use copilot to implement/fix/refactor" - or wants to run a queue of
+  coding tasks through Copilot while staying the reviewer. DO NOT USE for tasks small enough to do
+  inline, or when the user wants the code written directly without delegating.
+license: MIT
+compatibility: Requires the `copilot` CLI installed and authenticated (`copilot login`), Node 18+, and git. The orchestrator must be able to run shell commands and read files.
+metadata:
+  version: 0.4.2
+---
+
+# Copilot Delegate
+
+You are the **orchestrator**. Delegate a bounded coding task to a separate **implementer** — the
+GitHub Copilot CLI — then review what it produced and land it yourself. You write the brief and own
+the judgment; the implementer makes changes in its own session in a clean working tree; you verify
+and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `copilot` CLI is not installed or authenticated.
+- You need a hard sandbox. Copilot exposes sandbox controls, but they are upstream-experimental
+  (MXC-based, controlled via the `/sandbox` command and settings, disabled by default) — this relay
+  does not configure them. Use `--read-only` when the run must be read-only.
+
+## Prerequisites (check once)
+
+1. Install `copilot` (`npm install -g @github/copilot`; the relay probes `copilot version`).
+2. Authenticate: run `copilot login` (interactive web/device flow), or set
+   `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` in the environment.
+3. Confirm `copilot version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model (optional)
+
+Copilot picks a default model (`auto`). To choose another, pass `--model <name>`.
+The relay accepts letters, digits, and `. _ : / -` only (the value reaches a shell on Windows).
+
+## Choose the effort (optional)
+
+Copilot supports a reasoning effort dial: `--effort <level>` with values
+`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write a brief
+
+Copilot sees only the text you send. It cannot read your conversation: the brief must stand alone
+with the goal, current state, what to change, what to leave untouched, the project's **real**
+gates, and a report contract. Keep each brief to a single task. Write it to a file and pass it as
+the relay's `--brief`. See [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled relay. It runs `copilot -p` with `--output-format json --no-color --stream off`,
+captures the JSONL event stream, and writes `result.json`.
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model:                    add --model <name>
+# set reasoning effort:              add --effort <level>
+# read-only planning pass:           add --read-only  (forces --mode plan)
+# full tool autonomy:                add --allow-all-tools
+# hard time limit (watchdog):        add --timeout 2h   (the 30m default suits brief runs)
+# resume a session:                  add --session <id>  or  --resume-last
+# see all options:                   node .../relay.mjs --help
+```
+
+The child's cwd pins the workspace. The relay writes artifacts under the system temp dir by
+default and never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until copilot finishes. Run it with the orchestrator's background-command
+facility, or background it in the shell and poll for `result.json`. A pre-run usage error exits 2
+and writes no result; a missing `copilot` exits 127 and writes `status: "copilot_unavailable"`.
+
+Completion means the process exited and `result.json` exists — trust process state and the
+working tree, not the progress display. Copilot's final assistant message is the `finalMessage`
+field of `result.json`.
+
+### 4. Review — do not trust the self-report
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+If the work is good, commit it. The relay never commits — the diff and `result.json` are the
+record; run `git status` and `git diff` first to confirm exactly what changed. If the group has a
+PR flow, make the commit and push a branch; let human review happen. If the diff is wrong or
+incomplete, re-dispatch a corrected brief in a fresh run and review again.
+
+## Autonomy and permissions
+
+Without `--allow-all-tools`, copilot auto-denies tool calls in headless mode: the process exits 0
+but the relay detects the denial events and reports `status: "failed"` with the CLI's own error
+message and a hint to pass `--allow-all-tools`. This is the honest default — the orchestrator sees
+the failure rather than a silent no-op.
+
+`--allow-all-tools` explicitly grants full tool autonomy. `--read-only` selects `--mode plan`,
+which is genuinely read-only and works without `--allow-all-tools`. The two flags are mutually
+exclusive.
+
+Copilot also exposes sandbox controls, but they are upstream-experimental (MXC-based, controlled
+via the `/sandbox` command and settings, disabled by default). This relay does not configure them.
+
+## Authorization model
+
+Delegation is something the human opts into. Once briefed, copilot works as a tool you approved use
+of. The boundary is: **do not accept conclusions from the self-report**; verify everything on
+disk. For anything touching credentials, production data, or irreversible operations, stop and ask
+the human first instead of encoding it in a brief.
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — structure, scope, gates,
+  brief delivery.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — flags, artifacts,
+  `result.json`, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) — what to verify before calling
+  the diff done, at the end of a run.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — sequential queues,
+  constraint carry-forward, progress tracking, and the final coherence pass.

--- a/skills/copilot-delegate/SKILL.md
+++ b/skills/copilot-delegate/SKILL.md
@@ -28,7 +28,8 @@ The loop needs only a shell command and file access, so any comparable orchestra
 - The `copilot` CLI is not installed or authenticated.
 - You need a hard sandbox. Copilot exposes sandbox controls, but they are upstream-experimental
   (MXC-based, controlled via the `/sandbox` command and settings, disabled by default) — this relay
-  does not configure them. Use `--read-only` when the run must not edit project files.
+  does not configure them. `--read-only` only disables edit tools (`--mode plan`); shell commands
+  still run. If project files must not change at all, dispatch against a clean or isolated worktree.
 
 ## Prerequisites (check once)
 
@@ -47,7 +48,8 @@ The relay accepts letters, digits, and `. _ : / -` only (the value reaches a she
 ## Choose the effort (optional)
 
 Copilot supports a reasoning effort dial: `--effort <level>` with values
-`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
+`low`, `medium`, `high`, `xhigh`, or `max`. The relay rejects any other value
+before dispatch.
 
 ## The loop
 

--- a/skills/copilot-delegate/references/dispatch-and-poll.md
+++ b/skills/copilot-delegate/references/dispatch-and-poll.md
@@ -30,7 +30,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 | `--cd <dir>` | Working root and child process cwd (default: current directory). |
 | `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
 | `--model <name>` | Copilot model (default: copilot's own default, `auto`). Token-validated: letters, digits, `. _ : / -`. |
-| `--effort <level>` | Reasoning effort (`none`\|`minimal`\|`low`\|`medium`\|`high`\|`xhigh`\|`max`). Token-validated. |
+| `--effort <level>` | Reasoning effort (`low`\|`medium`\|`high`\|`xhigh`\|`max`). Rejected before dispatch if unknown. |
 | `--read-only` | Read-only plan mode (`--mode plan`); works without `--allow-all-tools`. Mutually exclusive with `--allow-all-tools`. |
 | `--allow-all-tools` | Full tool autonomy. Without this, headless tool calls are auto-denied and the relay reports `status: "failed"`. Mutually exclusive with `--read-only`. |
 | `--resume-last` | Resume the most recent session (`--continue`). |

--- a/skills/copilot-delegate/references/dispatch-and-poll.md
+++ b/skills/copilot-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,142 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps copilot's headless JSONL mode, captures its event stream, and writes
+a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v copilot
+copilot version
+```
+
+Install `copilot` (`npm install -g @github/copilot`); on Windows it installs as an npm `.cmd` shim
+(the relay launches it with `shell:true`). Authenticate with `copilot login` or set
+`COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`. A headless run that is not authenticated
+fails with `status: "failed"` (exit 1).
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Copilot model (default: copilot's own default, `auto`). Token-validated: letters, digits, `. _ : / -`. |
+| `--effort <level>` | Reasoning effort (`none`\|`minimal`\|`low`\|`medium`\|`high`\|`xhigh`\|`max`). Token-validated. |
+| `--read-only` | Read-only plan mode (`--mode plan`); works without `--allow-all-tools`. Mutually exclusive with `--allow-all-tools`. |
+| `--allow-all-tools` | Full tool autonomy. Without this, headless tool calls are auto-denied and the relay reports `status: "failed"`. Mutually exclusive with `--read-only`. |
+| `--resume-last` | Resume the most recent session (`--continue`). |
+| `--session <id>` | Resume a specific session (`--resume=<id>`). Mutually exclusive with `--resume-last`. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Copilot has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+The child cwd pins the workspace. The relay does not pass copilot's `--add-dir`.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an
+`--out-dir` inside the worktree can make the artifacts appear there:
+
+- `brief.txt` — the exact brief.
+- `events.jsonl` — raw copilot stdout events (every JSONL event copilot emitted).
+- `final.txt` — the last non-ephemeral `assistant.message` content; absent if none was emitted.
+- `stderr.txt` — complete stderr.
+- `result.json` — the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"copilot"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `copilot_unavailable`), `exitCode`, and `signal` (`null` unless the child died on a signal).
+- `workdir`, `model`, `effort`, `readOnly`, `allowAllTools`, `resumed`, `copilotVersion`,
+  `startedAt`, and `finishedAt`.
+- `sessionId` — parsed from the `result` event's `sessionId` field; available for resume.
+- `finalMessage` — text of the last non-ephemeral `assistant.message` event.
+- `touchedFiles` — `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of copilot's edits: anything already dirty before dispatch shows up too.
+  Dispatch from a clean tree when you want the list to read as "what copilot changed". `null` means
+  git could not report; `[]` means git ran and the tree is clean.
+- `briefPath`, nullable `finalPath`, `eventsPath`, and `stderrPath`. `finalPath` is `null` when
+  copilot emitted no non-ephemeral assistant message and `final.txt` was not created.
+- `stderrTail` — the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`).
+- `error` — present on denial failures (with the CLI's own denial message plus a hint to pass
+  `--allow-all-tools`), preflight failures, when the relay watchdog fires (`timeout`), and on an
+  `aborted` run.
+
+## Waiting for completion
+
+The relay blocks. Use the orchestrator's background-command facility, or background it in a shell
+and poll for `result.json`. The run is done only when the process exits and the file contains a
+`status`. The result file is written atomically, so a partial read is impossible.
+
+A pre-run usage error exits 2 and writes no result. A missing `copilot` exits 127 and writes
+`status: "copilot_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "copilot_unavailable"` (exit 127):** copilot is not on PATH. Install it, authenticate,
+  and re-dispatch.
+- **`status: "failed"` with a denial error:** copilot auto-denied a tool call in headless mode.
+  The error message includes the CLI's own denial text and a hint to pass `--allow-all-tools`.
+  Re-dispatch with `--allow-all-tools` to grant full tool permissions.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
+  causes: an unknown `--model`, expired credentials, or a provider error.
+- **`status: "failed"` with an `error` mentioning `version preflight`:** the bounded
+  `copilot version` probe failed or hung, so copilot was never dispatched. Check the install
+  (`copilot version` yourself).
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to copilot. The result is written before the relay exits;
+  inspect the working tree before re-dispatching.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `copilot did not finish within --timeout <dur>; killed by the relay watchdog`. Increase
+  `--timeout` or split the task.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every JSONL event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing.
+
+## What the relay runs
+
+The launch is equivalent to:
+
+```bash
+copilot --output-format json --no-color --stream off \
+  [--mode plan] [--allow-all-tools] \
+  [--continue | --resume=<id>] \
+  [--model <name>] [--effort <level>] \
+  -p @<brief.txt>
+```
+
+The child process cwd pins the workspace. Only token-validated model/effort/session values and
+fixed text reach the `shell:true` launch on native Windows; the brief is delivered via `-p @<file>`
+(the CLI's @-prefixed file prompt channel), with the brief path quoted for the shell on Windows.
+On resume (`--continue` / `--resume=<id>`) the relay wraps the reference in a fixed directive —
+`Execute the instructions in the referenced file, then report what you did. Do not just summarize
+the file: @<file>` — because a bare `@<file>` reference in a resumed session is echoed back instead
+of executed (verified on copilot 1.0.78). The directive is relay-authored fixed text, so no user
+content ever reaches the shell-quoted value on Windows. Fresh runs deliver the bare `@<file>`,
+which copilot executes correctly.
+Before dispatch the relay runs a bounded `copilot version` preflight (10s cap) so a
+hung or crashing CLI fails fast and explicitly instead of hanging the run.
+
+Copilot's JSONL events include ephemeral events (mcp status, skills_loaded, etc.) which the relay
+skips, `assistant.message` events whose `data.content` becomes `finalMessage`, and a final
+`result` event carrying `sessionId` and `usage.codeChanges`. Tool execution events with
+`success: false` and `error.code: "denied"` trigger the denial-detection path.
+
+## The commit boundary
+
+The relay never commits. Copilot edits the working tree; the orchestrator reviews, re-runs the
+gates, and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/copilot-delegate/references/dispatch-and-poll.md
+++ b/skills/copilot-delegate/references/dispatch-and-poll.md
@@ -10,7 +10,8 @@ command -v copilot
 copilot version
 ```
 
-Install `copilot` (`npm install -g @github/copilot`); on Windows it installs as an npm `.cmd` shim
+Install `copilot` (`npm install -g @github/copilot`; the CLI requires Node 22+, the relay itself
+runs on Node 18+); on Windows it installs as an npm `.cmd` shim
 (the relay launches it with `shell:true`). Authenticate with `copilot login` or set
 `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`. A headless run that is not authenticated
 fails with `status: "failed"` (exit 1).

--- a/skills/copilot-delegate/references/multi-task-queues.md
+++ b/skills/copilot-delegate/references/multi-task-queues.md
@@ -1,0 +1,58 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo --allow-all-tools
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is
+the default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh copilot sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture
+location, or interface that task 5 needs, write that fact into task 5's brief.
+
+Use `--session <id>` to resume a previous session with a delta brief when continuity matters.
+`--resume-last` resumes the most recent session.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** — queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** — what landed, what you verified, and gate outcomes.
+- **Needs your eyes** — design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** — the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/copilot-delegate/references/review-and-land.md
+++ b/skills/copilot-delegate/references/review-and-land.md
@@ -1,0 +1,80 @@
+# Review and land
+
+The implementer made the changes; you own the judgment. Verify against reality, never the
+self-report, and read the diff as generated code because a green gate cannot catch every failure
+mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened
+  error types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries copilot's claims, not evidence. Re-run the project's actual test, lint, and
+build commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** — changes the brief excluded.
+- **Scope shortfall** — missed behavior, edges, or cleanup.
+- **Quiet judgment calls** — defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to copilot as a delta brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer.
+Write a clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`,
+`git diff --cached` for anything the implementer staged (plain `git diff` is blind to the index),
+and commit the intended files explicitly.
+
+## Rework: re-dispatch a corrected brief
+
+Re-dispatch the correction with the needed context:
+
+```bash
+echo "The fix is right, but the tests mock the DB session: use the real migrated fixture and
+remove the unused import." | node "<skill-dir>/scripts/relay.mjs" --cd /path/to/repo --allow-all-tools
+```
+
+Use `--session <id>` from the previous run's `result.json` to resume the session with the delta
+brief, or dispatch a fresh run. Each correction gets the same test review, diff review, and
+implementer sweep.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep
+them in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/copilot-delegate/references/writing-the-brief.md
+++ b/skills/copilot-delegate/references/writing-the-brief.md
@@ -56,7 +56,8 @@ Add extra blocks only when the task needs them:
   unknown).
 - **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences,
   and open questions), and dispatch with `--read-only`; copilot runs in `--mode plan`, which
-  disables edit tools so project files can't be changed by direct edits (shell commands still run).
+  disables edit tools so project files can't be changed by direct edits (shell commands still
+  run). If the repository must not change at all, dispatch against a clean or isolated worktree.
 
 ## Always ask for the report explicitly
 
@@ -121,12 +122,13 @@ Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outco
 
 The relay hands the brief to copilot via `-p @<brief.txt>` — the CLI's
 `@`-prefixed file prompt channel (verified on copilot 1.0.78), the same shape
-grok's relay uses with `--prompt-file`. The brief never rides argv: it stays
-out of the host process list, isn't bounded by the OS arg-length cap, and a
-brief that starts with "-" cannot be misread as a flag. On a shared machine
-keep secrets out of the brief anyway — reference them by a path or environment
-variable the workspace can read. The brief is also preserved in the run's
-`brief.txt` artifact.
+grok's relay uses with `--prompt-file`. The brief content never rides argv —
+only the `@<brief.txt>` reference does, plus a fixed execution directive on
+resume. The content stays out of the host process list, isn't bounded by the
+OS arg-length cap, and a brief that starts with "-" cannot be misread as a
+flag. On a shared machine keep secrets out of the brief anyway — reference
+them by a path or environment variable the workspace can read. The brief is
+also preserved in the run's `brief.txt` artifact.
 
 On resume (`--session` / `--resume-last` with a delta brief) the relay wraps
 the reference in a fixed directive so the resumed session executes it rather

--- a/skills/copilot-delegate/references/writing-the-brief.md
+++ b/skills/copilot-delegate/references/writing-the-brief.md
@@ -1,0 +1,138 @@
+# Writing the brief
+
+A brief is the entire task as copilot will see it. It runs in a separate process with **no memory of
+your conversation and no shared context** — only the text you send and whatever it can inspect in
+the workspace. If a constraint is not in the brief or discoverable in the repo, it does not exist
+for copilot.
+
+Copilot can auto-discover the workspace's `AGENTS.md`. Still restate load-bearing repo constraints in
+the brief so the implementer does not have to infer which rules matter for this task.
+
+## Model and effort choice
+
+Copilot picks a default model when `--model` is omitted, so a fresh dispatch does not require it.
+Pass `--model <name>` only when the human asked for a specific model. `--effort <level>` sets the
+reasoning effort (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). The relay forwards
+model and effort values made of letters, digits, `. _ : / -` only.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report copilot must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** — add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences,
+  and open questions), and dispatch with `--read-only`; copilot runs in `--mode plan`, genuinely
+  read-only.
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from the last non-ephemeral `assistant.message` event. Without a
+closing summary, the edits may exist but the result is hard to review. The
+`<structured_output_contract>` block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy
+the actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Copilot can inspect the workspace, but the
+important constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one copilot run -> one reviewed commit keeps the diff and
+rollback clean. Split mixed implementation, review, documentation, and roadmap requests into
+separate dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; inspect the working tree and reconcile any
+partial or premise-contaminated edits — keep or revert them — before the re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Brief delivery
+
+The relay hands the brief to copilot via `-p @<brief.txt>` — the CLI's
+`@`-prefixed file prompt channel (verified on copilot 1.0.78), the same shape
+grok's relay uses with `--prompt-file`. The brief never rides argv: it stays
+out of the host process list, isn't bounded by the OS arg-length cap, and a
+brief that starts with "-" cannot be misread as a flag. On a shared machine
+keep secrets out of the brief anyway — reference them by a path or environment
+variable the workspace can read. The brief is also preserved in the run's
+`brief.txt` artifact.
+
+On resume (`--session` / `--resume-last` with a delta brief) the relay wraps
+the reference in a fixed directive so the resumed session executes it rather
+than echoing the file back (see [dispatch-and-poll.md](dispatch-and-poll.md)).
+The delta brief itself is unchanged; write it exactly as you would for a fresh
+dispatch.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/copilot-delegate/references/writing-the-brief.md
+++ b/skills/copilot-delegate/references/writing-the-brief.md
@@ -55,8 +55,8 @@ Add extra blocks only when the task needs them:
   first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
   unknown).
 - **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences,
-  and open questions), and dispatch with `--read-only`; copilot runs in `--mode plan`, genuinely
-  read-only.
+  and open questions), and dispatch with `--read-only`; copilot runs in `--mode plan`, which
+  disables edit tools so project files can't be changed by direct edits (shell commands still run).
 
 ## Always ask for the report explicitly
 

--- a/skills/copilot-delegate/references/writing-the-brief.md
+++ b/skills/copilot-delegate/references/writing-the-brief.md
@@ -12,8 +12,8 @@ the brief so the implementer does not have to infer which rules matter for this 
 
 Copilot picks a default model when `--model` is omitted, so a fresh dispatch does not require it.
 Pass `--model <name>` only when the human asked for a specific model. `--effort <level>` sets the
-reasoning effort (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). The relay forwards
-model and effort values made of letters, digits, `. _ : / -` only.
+reasoning effort (`low`, `medium`, `high`, `xhigh`, `max`). The relay rejects any other effort
+value before dispatch. Model values still accept letters, digits, and `. _ : / -` only.
 
 ## The shape that works
 

--- a/skills/copilot-delegate/scripts/relay.mjs
+++ b/skills/copilot-delegate/scripts/relay.mjs
@@ -372,7 +372,7 @@ function copilotVersion(timeoutMs) {
 }
 
 function buildArgv(opts, briefPath) {
-  // ponytail: shell:true on win32 (needed for the copilot.cmd shim) doesn't quote
+  // shell:true on win32 (needed for the copilot.cmd shim) doesn't quote
   // args, so a path with spaces splits. Quote the spaceable path args;
   // --model/--effort/--session are already restricted to safe tokens at parse time.
   const quotePath = (p) => (process.platform === "win32" ? `"${p}"` : p);

--- a/skills/copilot-delegate/scripts/relay.mjs
+++ b/skills/copilot-delegate/scripts/relay.mjs
@@ -27,7 +27,8 @@
  * auto-denied by copilot, and the relay detects denial events and reports
  * `status: "failed"` with the CLI's own error message plus a hint to pass
  * `--allow-all-tools`. `--allow-all-tools` explicitly opts in to full tool
- * autonomy. `--read-only` selects `--mode plan`, which is genuinely read-only
+ * autonomy. `--read-only` selects `--mode plan`, which disables edit tools so
+ * project files can't be changed by direct edits (shell commands still run),
  * and works without `--allow-all-tools`. `--read-only` and `--allow-all-tools`
  * are mutually exclusive.
  *
@@ -170,7 +171,7 @@ function applyFleetLane(opts, flagged) {
     if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
     if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
     if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
-    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "readOnly" && (flagged.has("readOnly") || flagged.has("allowAllTools"))) continue;
     if (field === "force" && flagged.has("force")) continue;
     opts[field] = value;
   }

--- a/skills/copilot-delegate/scripts/relay.mjs
+++ b/skills/copilot-delegate/scripts/relay.mjs
@@ -47,7 +47,7 @@
  *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
  *   --model <name>          Copilot model (default: copilot's own default, `auto`).
  *                           Letters, digits, and . _ : / - only.
- *   --effort <level>        Reasoning effort for this run (none|minimal|low|medium|high|xhigh|max).
+ *   --effort <level>        Reasoning effort for this run (low|medium|high|xhigh|max).
  *   --read-only             Read-only plan mode (`--mode plan`); works without
  *                           `--allow-all-tools`. Mutually exclusive with
  *                           `--allow-all-tools`.
@@ -106,8 +106,10 @@ const MAX_TIMER_MS = 2_147_483_647;
 const PROBE_TIMEOUT_MS = 10_000;
 
 // --model and --effort values reach a shell on win32 (shell:true for the .cmd
-// shim), so they are restricted to safe tokens.
+// shim), so they are restricted to safe tokens. Effort is then checked against
+// Copilot's documented enum (low|medium|high|xhigh|max).
 const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+const EFFORT_LEVELS = new Set(["low", "medium", "high", "xhigh", "max"]);
 
 const IMPLEMENTER_KEY = "copilot";
 
@@ -239,6 +241,9 @@ function parseArgs(argv) {
     if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
       fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
     }
+  }
+  if (opts.effort !== null && !EFFORT_LEVELS.has(opts.effort)) {
+    fail(`invalid --effort "${opts.effort}" (expected: ${[...EFFORT_LEVELS].join(", ")})`);
   }
   if (parseDuration(opts.timeout) === null) {
     fail(`--timeout "${opts.timeout}" is not a positive schedulable duration; use h/m/s strings like 30m, 90s, or 1h30m (maximum ~24.8 days)`);

--- a/skills/copilot-delegate/scripts/relay.mjs
+++ b/skills/copilot-delegate/scripts/relay.mjs
@@ -1,0 +1,776 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · copilot-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the GitHub Copilot CLI (`copilot -p`),
+ * capture the JSONL event stream, and write a structured result the
+ * orchestrating agent can review. The orchestrator runs this one command and
+ * reads the result JSON — every copilot-specific mechanic lives in here, which
+ * keeps the skill orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `copilot`, `git`, and Windows `taskkill` for
+ * process-tree termination. The `copilot` process it launches does
+ * authenticate — exactly as you do at the terminal. Read this file before you
+ * run it.
+ *
+ * The brief is handed to copilot via `-p @<file>` (the CLI's @-prefixed file
+ * prompt channel, verified on copilot 1.0.78), never argv: it stays out of
+ * the host process list, isn't bounded by the OS arg-length cap, and a brief
+ * that begins with "-" can't be misread as a flag.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Default mode runs without `--allow-all-tools`: headless tool calls are
+ * auto-denied by copilot, and the relay detects denial events and reports
+ * `status: "failed"` with the CLI's own error message plus a hint to pass
+ * `--allow-all-tools`. `--allow-all-tools` explicitly opts in to full tool
+ * autonomy. `--read-only` selects `--mode plan`, which is genuinely read-only
+ * and works without `--allow-all-tools`. `--read-only` and `--allow-all-tools`
+ * are mutually exclusive.
+ *
+ * On native Windows `copilot` is an npm-installed `.cmd` shim this relay
+ * launches with shell:true. Model and effort values therefore accept only
+ * shell-safe tokens; the working directory is the child process cwd; and the
+ * brief path is quoted for the shell.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for copilot (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Copilot model (default: copilot's own default, `auto`).
+ *                           Letters, digits, and . _ : / - only.
+ *   --effort <level>        Reasoning effort for this run (none|minimal|low|medium|high|xhigh|max).
+ *   --read-only             Read-only plan mode (`--mode plan`); works without
+ *                           `--allow-all-tools`. Mutually exclusive with
+ *                           `--allow-all-tools`.
+ *   --allow-all-tools       Pass copilot's `--allow-all-tools` for full tool
+ *                           autonomy in headless mode. Without this, headless
+ *                           tool calls are auto-denied. Mutually exclusive with
+ *                           `--read-only`.
+ *   --resume-last           Continue the most recent copilot session for this
+ *                           cwd (`--continue`); send only the delta brief.
+ *   --session <id>          Continue a specific session id (`--resume=<id>`);
+ *                           send only the delta brief. Mutually exclusive with
+ *                           --resume-last.
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). Copilot has no
+ *                           timeout flag; durations use h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, copilotVersion, model, effort, readOnly,
+ *   allowAllTools, resumed, sessionId, finalMessage (the last non-ephemeral
+ *   assistant message), touchedFiles (git porcelain, null if git cannot
+ *   report), and paths to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `copilot` binary exits
+ * 127; otherwise the exit code mirrors copilot's own (0 success, non-zero
+ * failure), except a run whose event stream contains a tool denial exits 1
+ * even if copilot exits 0. If the child dies on a signal, the exit code is 128
+ * plus the signal number and `result.json` records the signal. Once the brief
+ * validates, `result.json` is written on every outcome — completed, failed,
+ * timeout (the --timeout watchdog fired), aborted (the relay itself was killed
+ * and forwarded the kill to copilot), or copilot_unavailable.
+ */
+
+import { spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const PROBE_TIMEOUT_MS = 10_000;
+
+// --model and --effort values reach a shell on win32 (shell:true for the .cmd
+// shim), so they are restricted to safe tokens.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "copilot";
+
+// On resume (--resume=<id> / --continue), a bare @file reference in the resumed
+// session is echoed back instead of executed (verified on copilot 1.0.78); the
+// relay wraps the reference in this fixed directive so the delta is acted on.
+// The directive is relay-authored text, so the win32 value has no user content
+// to mangle inside its shell quotes. Deliberately not appended on fresh runs,
+// which execute a bare @file reference correctly.
+const RESUME_DIRECTIVE =
+  "Execute the instructions in the referenced file, then report what you did. Do not just summarize the file: ";
+
+function makeLineScanner(onObject) {
+  let buf = "";
+  return (chunk) => {
+    if (!chunk) return;
+    let start = 0;
+    for (;;) {
+      const end = chunk.indexOf("\n", start);
+      if (end === -1) break;
+      const line = buf + chunk.slice(start, end);
+      buf = "";
+      const trimmed = line.trim();
+      if (trimmed) {
+        try { onObject(JSON.parse(trimmed)); } catch { /* skip non-JSON lines */ }
+      }
+      start = end + 1;
+    }
+    buf += chunk.slice(start);
+    if (buf.length > MAX_BUFFERED_CHARS) buf = "";
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    readOnly: false,
+    allowAllTools: false,
+    resumeLast: false,
+    session: null,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--effort": opts.effort = next(); flagged.add("effort"); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--allow-all-tools": opts.allowAllTools = true; flagged.add("allowAllTools"); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.readOnly && opts.allowAllTools) {
+    fail("--read-only and --allow-all-tools are mutually exclusive; plan mode works without tool permissions");
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  if (opts.session !== null && !opts.session.trim()) fail("--session must not be empty");
+  for (const flag of ["model", "effort", "session"]) {
+    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a positive schedulable duration; use h/m/s strings like 30m, 90s, or 1h30m (maximum ~24.8 days)`);
+  }
+  try {
+    if (!statSync(opts.cd).isDirectory()) fail(`--cd is not a directory: ${opts.cd}`);
+  } catch {
+    fail(`--cd directory not found: ${opts.cd}`);
+  }
+  if (opts.outDir && existsSync(opts.outDir)) {
+    try {
+      if (!statSync(opts.outDir).isDirectory()) fail(`--out-dir is not a directory: ${opts.outDir}`);
+    } catch {
+      fail(`cannot inspect --out-dir: ${opts.outDir}`);
+    }
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to copilot -p\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function copilotVersion(timeoutMs) {
+  const limit = Math.min(timeoutMs, PROBE_TIMEOUT_MS);
+  // On Windows, npm installs `copilot` as a .cmd shim; shell:true resolves it.
+  // `copilot version` (subcommand) prints "GitHub Copilot CLI X.Y.Z" as the
+  // first line, followed by an optional update notice — parse only the first line.
+  try {
+    const raw = execFileSync("copilot", ["version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      timeout: limit,
+      killSignal: "SIGKILL",
+    }).trim();
+    const firstLine = raw.split("\n")[0].trim();
+    // Extract version from "GitHub Copilot CLI 1.0.78"
+    const versionMatch = firstLine.match(/(\d+\.\d+\.\d+(?:-[A-Za-z0-9._-]+)?)/);
+    return { version: versionMatch ? versionMatch[1] : firstLine || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // shell:true routes a missing binary through cmd.exe, which reports it as a
+    // non-zero exit rather than ENOENT; that is still "not installed".
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    return { version: null, error };
+  }
+}
+
+function buildArgv(opts, briefPath) {
+  // ponytail: shell:true on win32 (needed for the copilot.cmd shim) doesn't quote
+  // args, so a path with spaces splits. Quote the spaceable path args;
+  // --model/--effort/--session are already restricted to safe tokens at parse time.
+  const quotePath = (p) => (process.platform === "win32" ? `"${p}"` : p);
+  const argv = [
+    "--output-format", "json",
+    "--no-color",
+    "--stream", "off",
+  ];
+
+  if (opts.readOnly) {
+    argv.push("--mode", "plan");
+  }
+
+  if (opts.allowAllTools) {
+    argv.push("--allow-all-tools");
+  }
+
+  if (opts.resumeLast) argv.push("--continue");
+  else if (opts.session) argv.push(`--resume=${opts.session}`);
+
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.effort) argv.push("--effort", opts.effort);
+
+  // Deliver the brief via a file, not argv: keeps it out of the host process
+  // list, isn't bounded by the OS arg-length cap, and a brief that begins with
+  // "-" can't be misread as a flag. prepareRunDir already wrote run.briefPath.
+  // On resume the reference gets the RESUME_DIRECTIVE wrapper (see above); its
+  // value contains spaces, so on win32 the whole value is outer-quoted for cmd
+  // (the path then needs no inner quotes of its own).
+  let delivery;
+  if (opts.resumeLast || opts.session) {
+    delivery = process.platform === "win32"
+      ? `"${RESUME_DIRECTIVE}@${briefPath}"`
+      : `${RESUME_DIRECTIVE}@${briefPath}`;
+  } else {
+    delivery = `@${quotePath(briefPath)}`;
+  }
+  argv.push("-p", delivery);
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir =
+    opts.outDir ||
+    join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "copilot",
+      workdir: opts.cd,
+      model: opts.model,
+      effort: opts.effort,
+      readOnly: opts.readOnly,
+      allowAllTools: opts.allowAllTools,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      sessionId: null,
+      copilotVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(opts, writeResult, resultPath) {
+  const result = writeResult({
+    status: "copilot_unavailable",
+    exitCode: 127,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+  });
+  printSummary(result, resultPath);
+  process.stderr.write(
+    "relay: `copilot` not found on PATH. Install with `npm install -g @github/copilot` and run `copilot login`.\n",
+  );
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, timeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `copilot version preflight timed out after ${Math.min(timeoutMs, PROBE_TIMEOUT_MS)}ms; copilot was not dispatched`
+    : `copilot version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; copilot was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the copilot version preflight; copilot was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.off(sig, handler);
+  };
+}
+
+function dispatchToCopilot(opts, run, writeResult, onReady) {
+  const child = spawn("copilot", buildArgv(opts, run.briefPath), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    // shell:true on win32 so the copilot.cmd shim resolves. Safe: the brief
+    // rides `-p @<briefPath>` as a quoted file path, --model/--effort/--session
+    // are restricted to safe tokens at parse time.
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = null;
+  let lastAssistantMessage = "";
+  let denied = false;
+  let denialMessage = "";
+  const stderrTail = [];
+
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  const scan = makeLineScanner((event) => {
+    // Skip ephemeral events (mcp status, skills_loaded, tool.execution_start, etc.)
+    if (event.ephemeral) return;
+
+    // assistant.message — capture the last non-ephemeral one as finalMessage
+    if (event.type === "assistant.message" && event.data && typeof event.data.content === "string") {
+      lastAssistantMessage = event.data.content;
+    }
+
+    // result — carries sessionId and usage
+    if (event.type === "result") {
+      if (event.sessionId) sessionId = event.sessionId;
+    }
+
+    // tool.execution_complete with success:false and error.code:"denied" — the
+    // headless auto-deny trap. copilot exits 0 but the run is a failure.
+    // Copilot wraps the outcome in `data` (event.data.success, event.data.error).
+    if (event.type === "tool.execution_complete" && event.data?.success === false) {
+      if (event.data.error && event.data.error.code === "denied") {
+        denied = true;
+        denialMessage = event.data.error.message || "Permission denied";
+      }
+    }
+  });
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = lastAssistantMessage;
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const exitCode = 128 + (constants.signals[sig] || 15);
+      let finalized = false;
+      const finishAbort = () => {
+        if (finalized) return;
+        finalized = true;
+        if (sigkillTimer) clearTimeout(sigkillTimer);
+        killChild(child, "SIGKILL");
+        const result = writeResult({
+          status: "aborted",
+          exitCode,
+          signal: sig,
+          sessionId,
+          finalMessage: assembleFinal(),
+          touchedFiles: gitTouchedFiles(opts.cd),
+          stderrTail: stderrTail.slice(-20),
+          error: `the relay was killed by ${sig}; copilot was terminated with it — inspect the working tree before re-dispatching`,
+        });
+        printSummary(result, run.resultPath);
+        process.exit(exitCode);
+      };
+      child.once("exit", finishAbort);
+      killChild(child);
+      sigkillTimer = setTimeout(finishAbort, 2000);
+    });
+  }
+  onReady();
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // Force a delimiter so a final event without a trailing newline still parses.
+    scan(`${stdoutDecoder.end()}\n`);
+    const stderrEnd = stderrDecoder.end();
+    if (stderrEnd.trim()) stderrTail.push(stderrEnd.trimEnd());
+    const finalMessage = assembleFinal();
+    const touchedFiles = gitTouchedFiles(opts.cd);
+    // Denial trap: copilot exits 0 even when tool calls are denied headlessly.
+    // The relay catches the denial event and reports failed.
+    const deniedRun = denied && !watchdogFired;
+    const succeeded = code === 0 && !watchdogFired && !deniedRun;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const denialError = deniedRun
+      ? `copilot auto-denied a tool call in headless mode: ${denialMessage}. Pass --allow-all-tools to grant full tool permissions`
+      : null;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      finalMessage,
+      touchedFiles,
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired
+        ? {
+            error: `copilot did not finish within --timeout ${opts.timeout}; killed by the relay watchdog`,
+          }
+        : {}),
+      ...(denialError ? { error: denialError } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const run = prepareRunDir(opts, brief);
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  let writeResult = makeResultWriter(opts, null, run);
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult);
+  const probe = copilotVersion(timeoutMs);
+  // execFileSync defers JS signal handlers; yield once so a signal received
+  // during the bounded preflight becomes "aborted" before any dispatch.
+  await new Promise((resolve) => setImmediate(resolve));
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    return reportUnavailable(opts, writeResult, run.resultPath);
+  }
+  if (probe.error) {
+    clearPreflightSignals();
+    return reportVersionFailure(opts, writeResult, run, probe.error, timeoutMs);
+  }
+  dispatchToCopilot(opts, run, writeResult, clearPreflightSignals);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(
+    `relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  copilot ${result.copilotVersion ?? "?"}`,
+  );
+  if (result.signal === "SIGKILL" && result.status === "failed") {
+    lines.push(
+      "hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a copilot error; check host memory and re-dispatch, or split the task into smaller briefs.",
+    );
+  }
+  if (result.signal === "SIGTERM" && result.status === "failed") {
+    lines.push(
+      "hint: something outside the relay terminated copilot; relay watchdogs and relay signals report timeout or aborted instead.",
+    );
+  }
+  if (result.readOnly) lines.push("mode: plan (read-only)");
+  if (result.allowAllTools) lines.push("autonomy: --allow-all-tools");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- copilot final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push(
+    "relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.",
+  );
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/delegate-setup/references/schema.md
+++ b/skills/delegate-setup/references/schema.md
@@ -58,6 +58,7 @@ later-edited project config fails closed until it is reviewed and written again 
 | `cursor` | cursor-delegate | `cursor-agent` | model, force, timeout, readOnly |
 | `pi` | pi-delegate | `pi` | provider, model, timeout, readOnly |
 | `aider` | aider-delegate | `aider` | model, timeout, readOnly |
+| `copilot` | copilot-delegate | `copilot` | model, effort, timeout, readOnly |
 
 OpenCode uses `variant` for reasoning intensity, not `effort`. Do not write `effort` on an `opencode` lane.
 OpenCode lanes **require** `model` in `provider/model` form, with a non-empty provider before the first

--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -30,6 +30,7 @@ import {
   AGY_EFFORT,
   ALL_DIALS,
   CLAUDE_EFFORT,
+  COPILOT_EFFORT,
   CODEX_SANDBOX,
   CONFIG_VERSION,
   GROK_SANDBOX,
@@ -221,6 +222,9 @@ function validateDialValue(implementer, field, value, laneName, label) {
     }
     if (implementer === "claude" && !CLAUDE_EFFORT.includes(value)) {
       return `${label}: lane ${laneName}.effort must be one of: ${CLAUDE_EFFORT.join(", ")}`;
+    }
+    if (implementer === "copilot" && !COPILOT_EFFORT.includes(value)) {
+      return `${label}: lane ${laneName}.effort must be one of: ${COPILOT_EFFORT.join(", ")}`;
     }
     if ((implementer === "codex" || implementer === "grok") && !/^[a-z][a-z0-9-]*$/i.test(value)) {
       return `${label}: lane ${laneName}.effort must be a bare token`;

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -291,6 +291,7 @@ export const IMPLEMENTER_BY_KEY = Object.freeze(
 
 export const CLAUDE_EFFORT = Object.freeze(["low", "medium", "high", "xhigh", "max", "ultracode"]);
 export const AGY_EFFORT = Object.freeze(["low", "medium", "high"]);
+export const COPILOT_EFFORT = Object.freeze(["low", "medium", "high", "xhigh", "max"]);
 export const CODEX_SANDBOX = Object.freeze(["read-only", "workspace-write", "danger-full-access"]);
 export const GROK_SANDBOX = Object.freeze(["workspace", "read-only", "off"]);
 export const QODER_PERMISSION = Object.freeze([

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -264,6 +264,21 @@ export const IMPLEMENTERS = Object.freeze([
     supports: ["model", "timeout", "readOnly"],
     winShell: false,
   },
+  {
+    key: "copilot",
+    skill: "copilot-delegate",
+    binary: "copilot",
+    versionArgs: ["version"],
+    // No status command exposes login state; copilot login is interactive only
+    // and there is no `copilot auth status` equivalent.
+    authProbe: null,
+    // No credential-free model listing command exists.
+    modelProbe: null,
+    // No documented local session store path is verified.
+    usageProbe: null,
+    supports: ["model", "effort", "timeout", "readOnly"],
+    winShell: true,
+  },
 ]);
 
 /** Prototype-free map so names like "toString" cannot pass as implementers. */

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -188,6 +188,17 @@ if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
     }));
     process.exit(failed ? 1 : 0);
   });
+} else if (process.env.SMOKE_MODE === "copilot-success") {
+  fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
+  console.log(JSON.stringify({ type: "assistant.message", data: { content: "working" }, ephemeral: false }));
+  console.log(JSON.stringify({ type: "assistant.message", data: { content: "fake copilot completed" }, ephemeral: false }));
+  console.log(JSON.stringify({ type: "result", sessionId: "copilot-session-1", exitCode: 0, usage: { codeChanges: { linesAdded: 5, linesRemoved: 2, filesModified: ["src/main.js"] } } }));
+  process.exit(0);
+} else if (process.env.SMOKE_MODE === "copilot-denied") {
+  fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
+  console.log(JSON.stringify({ type: "tool.execution_complete", data: { success: false, error: { message: "Permission denied and could not request permission from user", code: "denied" } } }));
+  console.log(JSON.stringify({ type: "result", sessionId: "copilot-session-denied", exitCode: 0, usage: { codeChanges: { linesAdded: 0, linesRemoved: 0, filesModified: [] } } }));
+  process.exit(0);
 } else if (["cursor-success", "claude-success", "claude-read-only-write", "claude-read-only-clean", "claude-read-only-append", "claude-chunked"].includes(process.env.SMOKE_MODE)) {
   let brief = "";
   process.stdin.setEncoding("utf8");

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
+export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot"];
 
 export const EXTRA_ARGS = {
   claude: [],
@@ -15,6 +15,7 @@ export const EXTRA_ARGS = {
   cursor: [],
   pi: [],
   aider: [],
+  copilot: [],
 };
 
 export const WIN = process.platform === "win32";

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -14,7 +14,7 @@ export function installShim(h) {
   copyFileSync(join(fixturesDir, "fake-cli.cjs"), join(shimDir, "fake-cli.cjs"));
 
   if (WIN) {
-    for (const skill of ["claude", "cline", "codex", "opencode", "grok", "cursor", "pi"]) {
+    for (const skill of ["claude", "cline", "codex", "opencode", "grok", "cursor", "pi", "copilot"]) {
       writeFileSync(join(shimDir, `${binaryName(skill)}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
     }
     const windir = process.env.WINDIR || "C:\\Windows";

--- a/test/relay-isolated.mjs
+++ b/test/relay-isolated.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot"];
 let failed = 0;
 const check = (name, condition) => {
   console.log(`${condition ? "  ok " : "  FAIL"}  ${name}`);

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot"];
 const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],
@@ -27,7 +27,8 @@ const SYMBOLS = [
   ["fingerprintDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["changedDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["readOnlyVerdict", "function", READ_ONLY_TRIPWIRE_RELAYS],
-  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "qoder", "vibe"]],
+  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "copilot", "cursor", "grok", "kimi", "opencode", "pi", "qoder", "vibe"]],
+  ["makeLineScanner", "function", ["vibe", "copilot"]],
   ["makeEventScanner", "function", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "qoder"]],
 ];
 let failed = 0;

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -7,7 +7,7 @@
  * not complete:
  *
  *   1. timeout  — the watchdog kills the implementer's WHOLE process tree and
- *                 result.json reports status "timeout". Driven for all twelve
+ *                 result.json reports status "timeout". Driven for all thirteen
  *                 relays on both platforms. On Windows, claude and cursor
  *                 launch a .cmd shim through a serialized cmd.exe invocation,
  *                 while codex/opencode/grok/pi/cline use shell:true. These are exactly the
@@ -23,7 +23,7 @@
  *   2. aborted  — killing the relay itself still produces result.json with
  *                 status "aborted", and files the implementer flushes during
  *                 the shutdown grace window appear in the refreshed
- *                 touchedFiles. Driven for all twelve relays on POSIX; Windows
+ *                 touchedFiles. Driven for all thirteen relays on POSIX; Windows
  *                 delivers no catchable SIGTERM, so the scenario cannot be
  *                 driven there (the skill docs carry the same caveat).
  *
@@ -31,7 +31,7 @@
  * `changelog`), and can be told to hang or fail that probe by mode name, so a
  * relay whose preflight is unbounded — wedging before any result.json exists —
  * or which reports a broken CLI as a missing one is caught here.
- * A shared matrix also drives all twelve through the --timeout values no
+ * A shared matrix also drives all thirteen through the --timeout values no
  * watchdog can honour — malformed, zero, and past Node's timer ceiling — each of
  * which would otherwise fire on the next tick as a silent instant "timeout".
  * Quick Claude, Cline, Cursor, Qoder, Vibe, and Pi success cases verify brief

--- a/test/relay/copilot.mjs
+++ b/test/relay/copilot.mjs
@@ -146,6 +146,28 @@ for (const scenario of [
     env: fleetEnv,
   });
   h.check("copilot lane: global readOnly lane is written", writeCfg.status === 0);
+  // Control: the lane's readOnly dial applies on its own.
+  const controlOut = join(h.scratch, "out-lane-control-copilot");
+  const controlArgsFile = join(h.scratch, "args-lane-control-copilot");
+  const control = spawnSync(process.execPath, [
+    h.relayPath("copilot"),
+    "--brief", h.briefPath,
+    "--cd", cfgRepo,
+    "--out-dir", controlOut,
+    "--lane", "review",
+  ], {
+    env: { ...fleetEnv, SMOKE_MODE: "copilot-success", SMOKE_ARGS_FILE: controlArgsFile },
+    encoding: "utf8",
+  });
+  const controlArgs = existsSync(controlArgsFile)
+    ? JSON.parse(readFileSync(controlArgsFile, "utf8"))
+    : [];
+  h.check("copilot lane: readOnly dial applies without an override flag",
+    control.status === 0 &&
+    controlArgs.includes("--mode") &&
+    controlArgs.includes("plan") &&
+    h.result(controlOut).readOnly === true &&
+    h.result(controlOut).allowAllTools === false);
   const outDir = join(h.scratch, "out-lane-copilot");
   const argsFile = join(h.scratch, "args-lane-copilot");
   const run = spawnSync(process.execPath, [
@@ -212,19 +234,20 @@ if (!h.WIN) {
   const preflight = h.runRelay("copilot", workDir, outDir, ["--timeout", "1s"], {
     SMOKE_MODE: "copilot-version-hang",
   });
-  h.check("copilot preflight abort: run artifacts are prepared",
-    await h.until(() => existsSync(join(outDir, "events.jsonl")), 2000));
-  preflight.kill("SIGTERM");
-  const exited = await new Promise((resolve) => {
-    const timer = setTimeout(() => resolve(false), 5000);
+  // Attach the close promise immediately so an early exit cannot miss it.
+  const exited = new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), 10000);
     preflight.on("close", () => {
       clearTimeout(timer);
       resolve(true);
     });
   });
+  h.check("copilot preflight abort: run artifacts are prepared",
+    await h.until(() => existsSync(join(outDir, "events.jsonl")), 2000));
+  preflight.kill("SIGTERM");
   const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
   h.check("copilot preflight abort: result is aborted and dispatch never starts",
-    exited &&
+    (await exited) &&
     value.status === "aborted" &&
     value.signal === "SIGTERM" &&
     value.error?.includes("version preflight") &&

--- a/test/relay/copilot.mjs
+++ b/test/relay/copilot.mjs
@@ -128,6 +128,47 @@ for (const scenario of [
   h.check("copilot conflict: --read-only + --allow-all-tools exits 2",
     conflict.status === 2);
 }
+// A readOnly lane must not block an explicit --allow-all-tools (flags win).
+{
+  const setupDir = join(h.testDir, "..", "skills", "delegate-setup", "scripts");
+  const cfgHome = join(h.scratch, "home-lane-copilot");
+  const cfgRepo = h.freshRepo("work-lane-copilot");
+  mkdirSync(cfgHome, { recursive: true });
+  const laneFile = join(cfgRepo, "copilot-readonly.json");
+  writeFileSync(laneFile, `${JSON.stringify({
+    version: "delegate-fleet.v1",
+    lanes: { review: { implementer: "copilot", readOnly: true } },
+  })}\n`);
+  const fleetEnv = { ...h.baseEnv, HOME: cfgHome, USERPROFILE: cfgHome };
+  delete fleetEnv.XDG_CONFIG_HOME;
+  const writeCfg = spawnSync(process.execPath, [join(setupDir, "config.mjs"), "write", "--scope", "global", laneFile], {
+    encoding: "utf8",
+    env: fleetEnv,
+  });
+  h.check("copilot lane: global readOnly lane is written", writeCfg.status === 0);
+  const outDir = join(h.scratch, "out-lane-copilot");
+  const argsFile = join(h.scratch, "args-lane-copilot");
+  const run = spawnSync(process.execPath, [
+    h.relayPath("copilot"),
+    "--brief", h.briefPath,
+    "--cd", cfgRepo,
+    "--out-dir", outDir,
+    "--lane", "review",
+    "--allow-all-tools",
+  ], {
+    env: { ...fleetEnv, SMOKE_MODE: "copilot-success", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  const args = existsSync(argsFile)
+    ? JSON.parse(readFileSync(argsFile, "utf8"))
+    : [];
+  h.check("copilot lane: explicit --allow-all-tools wins over a readOnly lane",
+    run.status === 0 &&
+    args.includes("--allow-all-tools") &&
+    !args.some((a) => a === "--mode" || a === "plan") &&
+    h.result(outDir).allowAllTools === true &&
+    h.result(outDir).readOnly === false);
+}
 for (const [mode, expectedStatus, expectedExit] of [
   ["copilot-version-hang", "timeout", 124],
   ["copilot-version-fail", "failed", 7],

--- a/test/relay/copilot.mjs
+++ b/test/relay/copilot.mjs
@@ -245,9 +245,10 @@ if (!h.WIN) {
   h.check("copilot preflight abort: run artifacts are prepared",
     await h.until(() => existsSync(join(outDir, "events.jsonl")), 2000));
   preflight.kill("SIGTERM");
+  const didExit = await exited;
   const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
   h.check("copilot preflight abort: result is aborted and dispatch never starts",
-    (await exited) &&
+    didExit &&
     value.status === "aborted" &&
     value.signal === "SIGTERM" &&
     value.error?.includes("version preflight") &&

--- a/test/relay/copilot.mjs
+++ b/test/relay/copilot.mjs
@@ -128,6 +128,22 @@ for (const scenario of [
   h.check("copilot conflict: --read-only + --allow-all-tools exits 2",
     conflict.status === 2);
 }
+// Unknown --effort is a usage error: exit 2, no result.json, no dispatch.
+{
+  const workDir = h.freshRepo("work-bad-effort-copilot");
+  const outDir = join(h.scratch, "out-bad-effort-copilot");
+  const bad = spawnSync(process.execPath, [
+    h.relayPath("copilot"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--effort", "foo",
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("copilot invalid effort: exits 2 before dispatch",
+    bad.status === 2 &&
+    /invalid --effort "foo"/.test(bad.stderr) &&
+    !existsSync(join(outDir, "result.json")));
+}
 // A readOnly lane must not block an explicit --allow-all-tools (flags win).
 {
   const setupDir = join(h.testDir, "..", "skills", "delegate-setup", "scripts");

--- a/test/relay/copilot.mjs
+++ b/test/relay/copilot.mjs
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -50,8 +50,8 @@ for (const scenario of [
   },
   {
     name: "model and effort",
-    relayArgs: ["--model", "gpt-5.4", "--effort", "high"],
-    forwarded: ["--output-format", "json", "--no-color", "--stream", "off", "--model", "gpt-5.4", "--effort", "high"],
+    relayArgs: ["--model", "fake-model", "--effort", "high"],
+    forwarded: ["--output-format", "json", "--no-color", "--stream", "off", "--model", "fake-model", "--effort", "high"],
     readOnly: false,
     allowAllTools: false,
     resumed: false,

--- a/test/relay/copilot.mjs
+++ b/test/relay/copilot.mjs
@@ -1,0 +1,192 @@
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Must match RESUME_DIRECTIVE in skills/copilot-delegate/scripts/relay.mjs
+const RESUME_DIRECTIVE =
+  "Execute the instructions in the referenced file, then report what you did. Do not just summarize the file: ";
+
+export async function runCopilot(h) {
+for (const scenario of [
+  {
+    name: "default",
+    relayArgs: [],
+    forwarded: ["--output-format", "json", "--no-color", "--stream", "off"],
+    readOnly: false,
+    allowAllTools: false,
+    resumed: false,
+  },
+  {
+    name: "read only",
+    relayArgs: ["--read-only"],
+    forwarded: ["--output-format", "json", "--no-color", "--stream", "off", "--mode", "plan"],
+    readOnly: true,
+    allowAllTools: false,
+    resumed: false,
+  },
+  {
+    name: "allow all tools",
+    relayArgs: ["--allow-all-tools"],
+    forwarded: ["--output-format", "json", "--no-color", "--stream", "off", "--allow-all-tools"],
+    readOnly: false,
+    allowAllTools: true,
+    resumed: false,
+  },
+  {
+    name: "session resume",
+    relayArgs: ["--session", "copilot-session-1"],
+    forwarded: ["--output-format", "json", "--no-color", "--stream", "off", "--resume=copilot-session-1"],
+    readOnly: false,
+    allowAllTools: false,
+    resumed: true,
+  },
+  {
+    name: "resume last",
+    relayArgs: ["--resume-last"],
+    forwarded: ["--output-format", "json", "--no-color", "--stream", "off", "--continue"],
+    readOnly: false,
+    allowAllTools: false,
+    resumed: true,
+  },
+  {
+    name: "model and effort",
+    relayArgs: ["--model", "gpt-5.4", "--effort", "high"],
+    forwarded: ["--output-format", "json", "--no-color", "--stream", "off", "--model", "gpt-5.4", "--effort", "high"],
+    readOnly: false,
+    allowAllTools: false,
+    resumed: false,
+  },
+]) {
+  const outDir = join(h.scratch, `out-${scenario.name}-copilot`);
+  const workDir = h.freshRepo(`work-${scenario.name}-copilot`);
+  const argsFile = join(h.scratch, `args-${scenario.name}-copilot`);
+  const run = spawnSync(process.execPath, [
+    h.relayPath("copilot"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    ...scenario.relayArgs,
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "copilot-success", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  const args = existsSync(argsFile)
+    ? JSON.parse(readFileSync(argsFile, "utf8"))
+    : [];
+  h.check(`copilot ${scenario.name}: relay exits zero`, run.status === 0);
+  const expectedArgv = [
+    ...scenario.forwarded,
+    "-p", scenario.resumed
+      ? `${RESUME_DIRECTIVE}@${join(outDir, "brief.txt")}`
+      : `@${join(outDir, "brief.txt")}`,
+  ];
+  h.check(`copilot ${scenario.name}: documented argv is exact`,
+    JSON.stringify(args) === JSON.stringify(expectedArgv));
+  h.check(`copilot ${scenario.name}: result and assistant output are captured`,
+    existsSync(join(outDir, "result.json")) &&
+    h.result(outDir).status === "completed" &&
+    h.result(outDir).finalMessage === "fake copilot completed" &&
+    h.result(outDir).resumed === scenario.resumed &&
+    h.result(outDir).readOnly === scenario.readOnly &&
+    h.result(outDir).allowAllTools === scenario.allowAllTools &&
+    h.result(outDir).sessionId === "copilot-session-1");
+}
+// Denial detection: copilot exits 0 but tools denied → relay reports failed
+{
+  const outDir = join(h.scratch, "out-denied-copilot");
+  const workDir = h.freshRepo("work-denied-copilot");
+  const argsFile = join(h.scratch, "args-denied-copilot");
+  const run = spawnSync(process.execPath, [
+    h.relayPath("copilot"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "copilot-denied", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  h.check("copilot denied: relay exits non-zero despite copilot exit 0",
+    run.status !== 0);
+  h.check("copilot denied: result reports failed with denial error",
+    existsSync(join(outDir, "result.json")) &&
+    h.result(outDir).status === "failed" &&
+    h.result(outDir).error?.includes("auto-denied") &&
+    h.result(outDir).error?.includes("--allow-all-tools"));
+}
+// --read-only and --allow-all-tools conflict → exit 2
+{
+  const workDir = h.freshRepo("work-conflict-copilot");
+  const outDir = join(h.scratch, "out-conflict-copilot");
+  const conflict = spawnSync(process.execPath, [
+    h.relayPath("copilot"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--read-only",
+    "--allow-all-tools",
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("copilot conflict: --read-only + --allow-all-tools exits 2",
+    conflict.status === 2);
+}
+for (const [mode, expectedStatus, expectedExit] of [
+  ["copilot-version-hang", "timeout", 124],
+  ["copilot-version-fail", "failed", 7],
+]) {
+  const workDir = h.freshRepo(`work-${mode}`);
+  const outDir = join(h.scratch, `out-${mode}`);
+  const preflight = spawnSync(process.execPath, [
+    h.relayPath("copilot"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--timeout", "1s",
+  ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
+  const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+  h.check(`copilot preflight: ${mode} is explicit and prevents dispatch`,
+    preflight.status === expectedExit &&
+    value.status === expectedStatus &&
+    value.error?.includes("version preflight") &&
+    value.error?.includes("was not dispatched"));
+}
+{
+  const workDir = h.freshRepo("work-unavailable-copilot");
+  const outDir = join(h.scratch, "out-unavailable-copilot");
+  mkdirSync(outDir);
+  writeFileSync(join(outDir, "result.json"), "{\"status\":\"stale\"}\n");
+  writeFileSync(join(outDir, "final.txt"), "stale final\n");
+  const missing = spawnSync(process.execPath, [
+    h.relayPath("copilot"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+  ], { env: { ...process.env, PATH: "" }, encoding: "utf8" });
+  h.check("copilot unavailable: structured result replaces stale artifacts",
+    missing.status === 127 &&
+    h.result(outDir).status === "copilot_unavailable" &&
+    !existsSync(join(outDir, "final.txt")));
+}
+if (!h.WIN) {
+  const workDir = h.freshRepo("work-abort-preflight-copilot");
+  const outDir = join(h.scratch, "out-abort-preflight-copilot");
+  const preflight = h.runRelay("copilot", workDir, outDir, ["--timeout", "1s"], {
+    SMOKE_MODE: "copilot-version-hang",
+  });
+  h.check("copilot preflight abort: run artifacts are prepared",
+    await h.until(() => existsSync(join(outDir, "events.jsonl")), 2000));
+  preflight.kill("SIGTERM");
+  const exited = await new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), 5000);
+    preflight.on("close", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+  const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+  h.check("copilot preflight abort: result is aborted and dispatch never starts",
+    exited &&
+    value.status === "aborted" &&
+    value.signal === "SIGTERM" &&
+    value.error?.includes("version preflight") &&
+    value.error?.includes("was not dispatched"));
+}
+}

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -334,6 +334,19 @@ if (observation === "models") {
     h.check("config validate rejects unknown Agy effort",
       rejectAgy.status === 2 && /low, medium, high/.test(rejectAgy.stderr));
 
+    const badCopilot = {
+      version: "delegate-fleet.v1",
+      lanes: { feature: { implementer: "copilot", effort: "foo" } },
+    };
+    const badCopilotFile = join(cfgRepo, "bad-copilot.json");
+    writeFileSync(badCopilotFile, `${JSON.stringify(badCopilot)}\n`);
+    const rejectCopilot = spawnSync(process.execPath, [join(setupDir, "config.mjs"), "validate", badCopilotFile], {
+      encoding: "utf8",
+      env: process.env,
+    });
+    h.check("config validate rejects unknown copilot effort",
+      rejectCopilot.status === 2 && /low, medium, high, xhigh, max/.test(rejectCopilot.stderr));
+
     const badCursorSandbox = {
       version: "delegate-fleet.v1",
       lanes: { feature: { implementer: "cursor", sandbox: "workspace-write" } },

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -27,7 +27,7 @@ export function runDelegateSetup(h) {
   h.check("discover reports version", report?.version === "delegate-discover.v1");
   h.check("discover lists discovered or missing", Array.isArray(report?.discovered) && Array.isArray(report?.missing));
   h.check(
-    "discover covers all twelve implementers",
+    "discover covers all thirteen implementers",
     Array.isArray(report?.discovered) &&
       Array.isArray(report?.missing) &&
       report.discovered.length + report.missing.length === h.SKILLS.length,

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -16,6 +16,7 @@ import { runTimeoutTree } from "./timeout-tree.mjs";
 import { runAbort } from "./abort.mjs";
 import { runDelegateSetup } from "./delegate-setup.mjs";
 import { runAider } from "./aider.mjs";
+import { runCopilot } from "./copilot.mjs";
 
 export const runners = [
   ["package-shape", runPackageShape],
@@ -32,6 +33,7 @@ export const runners = [
   ["pi", runPi],
   ["claude", runClaude],
   ["aider", runAider],
+  ["copilot", runCopilot],
   ["read-only-tripwire", runReadOnlyTripwire],
   ["timeout-tree", runTimeoutTree],
   ["abort", runAbort],


### PR DESCRIPTION
**Claim:** Closes #74 — the `copilot-delegate` skill for the GitHub Copilot CLI.

## What this PR adds

A new implementer skill so an orchestrator can dispatch coding briefs to the GitHub Copilot CLI (`copilot -p`), capture its JSONL event stream, detect denials, and review/land the resulting diff — the standard delegation loop used by the other twelve implementers.

**Skill package — `skills/copilot-delegate/`:**
- `SKILL.md` — lean frontmatter-triggered skill doc (description well under 1024 chars; only what the skill does and when to use it).
- Four references, loaded only when needed: `writing-the-brief.md` (self-contained briefs, model/effort dials, `--read-only` research runs on a clean or isolated worktree, brief-content vs argv-reference delivery semantics), `dispatch-and-poll.md` (flags, `--session`/`--resume-last` resume flows, polling, abort/timeout behavior, Node 22+ CLI requirement), `review-and-land.md` (independent review, verifying nothing changed between capture and landing, reverting with `git checkout`/`reset`/`clean`, landing), `multi-task-queues.md` (running a queue of briefs through the same CLI).
- One `scripts/relay.mjs` — Node built-ins only, no dependencies, no network calls of its own, no credentials, no telemetry. Uses the repo's shared scanner and parity-gated symbols (`MAX_BUFFERED_CHARS`, `makeLineScanner`), `MAX_TIMER_MS` watchdog, and `killChild` whole-tree cleanup.

**Registration:**
- `skills.sh.json` index, `delegate-setup` implementer list + schema (`copilot` implementer id, `effort` dials), harness `constants.mjs` + `install-shim.mjs`, and wired into `relay-parity.mjs` / `relay-isolated.mjs` / `relay-smoke.mjs` / `relay/index.mjs`. AGENTS.md and README updated; README's "Verification status" lists only what was actually run.

## The contract, as verified

Live on Windows, `copilot` 1.0.78 (the exact version is in the README verification list so the claims stay checkable):

- **`--read-only`** (`--mode plan`) run: edit tools disabled, completed with a clean tree and a captured session id. Docs are explicit that `--mode plan` disables edit tools but does not stop shell commands from mutating files — a research-mode brief is only safe on a clean or isolated worktree.
- **`--allow-all-tools`** edit run created the requested file in a throwaway repo.
- **Headless auto-deny** exercised live: the denial is detected from the real data-wrapped event shape (`event.data.success:false`, `event.data.error.code:"denied"`), the run is reported `failed` with the CLI's own message plus the `--allow-all-tools` hint.
- **Resume flows** (`--session <id>` and `--resume-last`): a bare `@<file>` reference in a resumed session is echoed back instead of executed (verified on 1.0.78), so the relay wraps the reference in a fixed execution directive (`RESUME_DIRECTIVE`); the directive-wrapped `-p @<file>` prompt executed the delta briefs. Fresh deliveries use the file channel (`-p @<briefPath>`) so brief content never rides argv.
- **Node floors**: the relay runs on Node 18+; the Copilot CLI itself requires Node 22+ (it crashes on 18 with `node:sea` missing and on 20 with `node:sqlite` missing — added in 22.5). Compatibility note lives in `SKILL.md` and the npm install step in `dispatch-and-poll.md`.

## Contract-tested (in the shared smoke matrix, both CI platforms)

argv exactness (including the resume directive and win32 quoting), denial shape, `--read-only` + `--allow-all-tools` conflict validation (exit 2), lane dials from `delegate-setup` (`readOnly`, `model`, `effort`) including the explicit-flag-wins-over-lane rule, bounded `copilot version` preflight (hang and failure modes), missing binary, result parsing, stale-artifact replacement on unavailable runs, whole-process-tree timeout/abort cleanup (SIGTERM grace → kill).

**Untested / hedged:** non-Windows launch mechanics (the win32 `shell:true` launch for the `.cmd` shim is the tested path; the native binary path on UNIX is contract-tested only) and live `--model`/`--effort` forwarding (contract-tested only — the suite uses fake model tokens, no pins).

## Review history

Four review passes addressed and verified: CodeRabbit rounds 1–2 (lane override semantics, Node floor docs, plan-mode wording, brief-delivery semantics, abort-test race), the CI-caught race on ubuntu (result.json read before the relay's SIGTERM shutdown write), and the GitHub Copilot AI review (unused import, model pin in the suite, stray comment prefix). All checks pass: parity, isolated, event-scanner, and full smoke on ubuntu + windows; CodeRabbit pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub Copilot CLI as a supported implementation option for delegated coding tasks.
  * Added configurable model, effort, timeout, read-only, and session-resumption options.
  * Added structured run reporting, progress polling, permission handling, failure states, and Windows support.
  * Added guidance for task briefs, multi-task queues, independent review, and safely landing changes.

* **Documentation**
  * Documented Copilot setup, verification coverage, workflow, troubleshooting, and recovery procedures.

* **Tests**
  * Added comprehensive smoke and parity coverage for Copilot delegation, including denied actions, timeouts, resumption, and unavailable CLI scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->