### PR TITLE
feat: add commandcode-delegate implementer skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,13 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Fourteen implementer skills ship today: `claude-delegate` (Claude Code),
+and land the result. Fifteen implementer skills ship today: `claude-delegate` (Claude Code),
 `cline-delegate` (Cline CLI), `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode),
 `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code),
 `qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI),
 `pi-delegate` (Pi CLI), `aider-delegate` (Aider), `copilot-delegate` (GitHub Copilot CLI), and
-`warp-delegate` (Warp Agent CLI); siblings like `gemini-delegate` can be added
+`warp-delegate` (Warp Agent CLI), and `commandcode-delegate` (Command Code); siblings like
+`gemini-delegate` can be added
 later without renaming the repo. One **utility** skill
 ships alongside them: `delegate-setup` (configure fleet lanes — setup only, never dispatches).
 
@@ -29,7 +30,9 @@ jargon. Use these terms; don't invent synonyms.
 | **lane** | a named fleet binding: implementer + optional dials (`model`, `effort` / `variant`, …) | "route", "profile" |
 | **fleet** | the user's set of lanes (which CLI handles which kind of work) | — |
 | **setup skill** / `delegate-setup` | utility that discovers CLIs and writes the lane map after approval | a `*-delegate` skill |
+| `-p` / `--print`, `--yolo` (`--dangerously-skip-permissions`), `--permission-mode` (`standard`/`plan`/`auto-accept`), `--tools-all`, `--resume`, `--continue`, `--effort`, `--max-turns`, `taste` | Command Code’s own terms — use verbatim when discussing `cmd` | never say Command Code has a sandbox or a write-capable middle mode: headless autonomy is withheld-tools or `--yolo`, nothing else, and `--permission-mode auto-accept` does not enable edits. Never call the binary “the cmd shell” |
 | `exec`, `sandbox`, `resume`, `session` | Codex's own terms — use verbatim | don't paraphrase them |
+| `-p` / `--print`, `--yolo` (`--dangerously-skip-permissions`), `--permission-mode` (`standard`/`plan`/`auto-accept`), `--tools-all`, `--resume`, `--continue`, `--effort`, `--max-turns` | Command Code's own terms — use verbatim when discussing `cmd` | never say Command Code has a sandbox, or a write-capable mode between withheld-tools and `--yolo`: `--permission-mode auto-accept` and `--tools-all` do not enable edits headlessly. Never call the binary "the cmd shell" |
 | `run`, `agent` (`build`/`plan`), `session` | OpenCode's own terms — use verbatim | "sandbox" (OpenCode has no sandbox enum; autonomy is the agent) |
 | `project`, `conversation`, `model`, `permissions`, `sandbox`, `TUI`, `tasks`, `subagents` | Antigravity's own terms — use verbatim when discussing `agy` | don't use `subagents` as a generic synonym for implementer |
 | `session`, `sandbox` (`workspace`/`read-only`/`off`), `permission-mode`, `effort`, `streaming-json` | Grok Build's own terms — use verbatim when discussing `grok` | don't paraphrase them |

--- a/README.md
+++ b/README.md
@@ -248,18 +248,31 @@ Per skill — platform, CLI version, and what the run exercised:
   `--session`, and `--resume-last` runs are contributor-reported.
 - `qoder-delegate` — macOS, `qodercli` 1.0.47, by the contributor: Lite edit run, `accept_edits`,
   explicit model and 32768-token context window, no commit.
-- `commandcode-delegate` — macOS, `cmd` 1.26.0: **live read-only run verified**, plus the full smoke
-  matrix (timeout, abort, atomic result publication, preflight hang/fail, and the whole
-  read-only tripwire scenario set, which this relay now enters alongside `claude` and `grok`). The
-  live dispatch verified version preflight, launch, NDJSON parsing (`sessionId` from the nested
-  `run_end` state and the `result` line, `finalText` → `finalMessage` + `final.txt`,
-  `subtype`/`stopReason`/`usage`), `readOnlyViolation: false` on a clean tree, and `status:
-  "completed"` / exit 0. The autonomy claim is verified negatively too: separate live runs confirmed
-  that `--tools-all` and `--permission-mode auto-accept` leave the headless write gate closed, and
-  that `--yolo` opens it. Write and `--session` resume runs were exercised live against the raw CLI
-  while mapping its contract, but not yet end to end through the relay — that pairing is
-  contract-tested only. Windows is untested and the relay refuses to guess there (the binary name
-  `cmd` is `cmd.exe`); it requires `COMMANDCODE_BIN` to name a real executable.
+- `commandcode-delegate` — macOS, `cmd` 1.26.0: **live edit run verified**. A relay dispatch against a
+  throwaway git repository had Command Code fix a remainder-dropping bug in a money-splitting function
+  and add three tests; the project gate was re-run independently by the orchestrator (2 tests before,
+  5 passing after), the diff matched the brief with no writes outside the two named files, and `HEAD`
+  was untouched — the relay does not commit, and the run did not either. A second dispatch with
+  `--session <id>` verified resume through the relay: a one-line delta brief amended exactly the comment
+  it named, with the session id from the first run. A `--read-only` dispatch verified the other
+  direction, returning `readOnlyViolation: false` on a clean tree. Also verified negatively: separate
+  live runs confirmed `--tools-all` and `--permission-mode auto-accept` leave the headless write gate
+  closed and only `--yolo` opens it.
+
+  Live running surfaced a CLI limitation the relay now handles. `cmd` ends a run with a `run_end` event
+  embedding the whole conversation, then exits with `process.exit`, discarding whatever is still queued
+  in its stdout pipe: both write runs lost their `result` line entirely (one cut ~8 KB into `run_end`,
+  the other losing its last ~780 events). So nothing load-bearing is read from that tail — `sessionId`
+  comes from `run_start`, the first line of the stream, and the report from the last `message_end` or
+  its streamed deltas — the event log is written in batches so the relay drains the pipe as fast as it
+  can, `resultLine` reports `complete`/`truncated`/`absent` so a consumer knows which fields are
+  trustworthy, and exit 0 with a lost result line is treated as success rather than failure, since
+  `cmd` still exits non-zero for auth, rate-limit, turn-cap, and credit failures. A smoke case pins
+  that contract. On a long run the report itself can land in the discarded region, so the diff is the
+  deliverable and a thin report means missing information, not a failed run.
+
+  Windows is untested and the relay refuses to guess there (the binary name `cmd` is `cmd.exe`); it
+  requires `COMMANDCODE_BIN` to name a real executable.
 - `warp-delegate` — macOS, `oz` 0.2026.05.27.15.44.stable_01: **live edit run verified**. A relay
   dispatch against a throwaway git repository had Warp add a function plus four assertions across
   two files; both project gates were re-run independently by the orchestrator, the diff matched the

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`claude-delegate`](skills/claude-delegate/SKILL.md) | [Claude Code](https://code.claude.com/docs/en/overview) (`claude`) | `acceptEdits` + explicit tool surface | `--read-only` (`plan` mode) | `--resume-last`, `--session <id>` |
 | [`cline-delegate`](skills/cline-delegate/SKILL.md) | [Cline](https://github.com/cline/cline) (`cline`) | `--auto-approve true` in act mode; upstream sandbox not configured by the relay | `--plan` + `--auto-approve false` (relay-enforced pair) | — (headless JSON resume unsupported) |
 | [`codex-delegate`](skills/codex-delegate/SKILL.md) | [OpenAI Codex](https://github.com/openai/codex) (`codex`) | `--sandbox workspace-write` | `--read-only` | `--resume-last`, `--session <id>` |
+| [`commandcode-delegate`](skills/commandcode-delegate/SKILL.md) | [Command Code](https://commandcode.ai/docs/headless) (`cmd`) | `--yolo` — the only headless write state; no sandbox [^commandcode] | `--read-only` (withheld tools + `plan`) | `--continue-last`, `--session <id>` |
 | [`cursor-delegate`](skills/cursor-delegate/SKILL.md) | [Cursor Agent](https://cursor.com/cli) (`cursor-agent`) | `--force`; `--no-force` withholds command approval | `--read-only` (plan mode) | `--resume-last`, `--session <id>` |
 | [`grok-delegate`](skills/grok-delegate/SKILL.md) | Grok Build (`grok`) | workspace-scoped; `--full-access` opt-in | `--read-only` — best-effort [^grok] | `--resume-last`, `--session <id>` |
 | [`kimi-delegate`](skills/kimi-delegate/SKILL.md) | [Kimi Code](https://moonshotai.github.io/kimi-code/en/) (`kimi`) | `auto permission mode`, always | — [^none] | `--resume-last`, `--session <id>` |
@@ -78,6 +79,12 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`vibe-delegate`](skills/vibe-delegate/SKILL.md) | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits`; `--full-access` opt-in | `--plan-only` (`plan` agent) | `--resume-last`, `--session <id>` |
 | [`copilot-delegate`](skills/copilot-delegate/SKILL.md) | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli) (`copilot`) | `--allow-all-tools` opt-in; headless auto-deny otherwise | `--read-only` (`--mode plan`) | `--resume-last`, `--session <id>` |
 | [`warp-delegate`](skills/warp-delegate/SKILL.md) | [Warp Agent CLI](https://docs.warp.dev/cli/) (`oz`) | full local tools — no sandbox, no permission modes [^none] | — [^none] | `--conversation <id>` |
+
+[^commandcode]: Command Code's headless mode has two states and nothing between them: a `-p` run
+withholds the write, edit, and shell tools, and `--yolo` (alias `--dangerously-skip-permissions`)
+allows every tool anywhere the process can reach. `--permission-mode auto-accept` and `--tools-all`
+do **not** lift the write gate. So an implementation run is full-trust with no path restriction —
+scope it with the brief and a clean tree, and read `touchedFiles` for writes outside it.
 
 [^none]: No CLI-enforced read-only mode. `touchedFiles` and the diff are what you review against, not
 a guarantee: they are post-run `git status` in the workspace, so they cannot show ignored files,
@@ -241,6 +248,18 @@ Per skill — platform, CLI version, and what the run exercised:
   `--session`, and `--resume-last` runs are contributor-reported.
 - `qoder-delegate` — macOS, `qodercli` 1.0.47, by the contributor: Lite edit run, `accept_edits`,
   explicit model and 32768-token context window, no commit.
+- `commandcode-delegate` — macOS, `cmd` 1.26.0: **live read-only run verified**, plus the full smoke
+  matrix (timeout, abort, atomic result publication, preflight hang/fail, and the whole
+  read-only tripwire scenario set, which this relay now enters alongside `claude` and `grok`). The
+  live dispatch verified version preflight, launch, NDJSON parsing (`sessionId` from the nested
+  `run_end` state and the `result` line, `finalText` → `finalMessage` + `final.txt`,
+  `subtype`/`stopReason`/`usage`), `readOnlyViolation: false` on a clean tree, and `status:
+  "completed"` / exit 0. The autonomy claim is verified negatively too: separate live runs confirmed
+  that `--tools-all` and `--permission-mode auto-accept` leave the headless write gate closed, and
+  that `--yolo` opens it. Write and `--session` resume runs were exercised live against the raw CLI
+  while mapping its contract, but not yet end to end through the relay — that pairing is
+  contract-tested only. Windows is untested and the relay refuses to guess there (the binary name
+  `cmd` is `cmd.exe`); it requires `COMMANDCODE_BIN` to name a real executable.
 - `warp-delegate` — macOS, `oz` 0.2026.05.27.15.44.stable_01: **live edit run verified**. A relay
   dispatch against a throwaway git repository had Warp add a function plus four assertions across
   two files; both project gates were re-run independently by the orchestrator, the diff matched the

--- a/README.md
+++ b/README.md
@@ -286,13 +286,14 @@ Per skill — platform, CLI version, and what the run exercised:
   comes from `run_start`, the first line of the stream, and the report from the last `message_end` or
   its streamed deltas — the event log is written in batches so the relay drains the pipe as fast as it
   can, `resultLine` reports `complete`/`truncated`/`absent` so a consumer knows which fields are
-  trustworthy, and exit 0 with a lost result line is treated as success rather than failure, since
-  `cmd` still exits non-zero for auth, rate-limit, turn-cap, and credit failures. A smoke case pins
-  that contract. On a long run the report itself can land in the discarded region, so the diff is the
-  deliverable and a thin report means missing information, not a failed run.
+  trustworthy. A complete non-success result converts a zero child exit to relay exit 1, while a lost
+  result line falls back to the process exit code. Smoke cases pin that contract. On a long run the
+  report itself can land in the discarded region. The diff is the deliverable, and a thin report
+  means missing information, not a failed run.
 
   Windows is untested and the relay refuses to guess there (the binary name `cmd` is `cmd.exe`); it
-  requires `COMMANDCODE_BIN` to name a real executable.
+  requires `COMMANDCODE_BIN` to be the real executable's absolute path, not the system command
+  interpreter.
 - `warp-delegate` — macOS, `oz` 0.2026.05.27.15.44.stable_01: **live edit run verified**. A relay
   dispatch against a throwaway git repository had Warp add a function plus four assertions across
   two files; both project gates were re-run independently by the orchestrator, the diff matched the

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -18,7 +18,8 @@
         "pi-delegate",
         "aider-delegate",
         "copilot-delegate",
-        "warp-delegate"
+        "warp-delegate",
+        "commandcode-delegate"
       ]
     },
     {

--- a/skills/commandcode-delegate/SKILL.md
+++ b/skills/commandcode-delegate/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   Command Code while staying the reviewer. DO NOT USE for tasks small enough to do inline, or when the
   user wants the code written directly without delegating.
 license: MIT
-compatibility: Requires the Command Code CLI (`cmd`, from commandcode.ai) installed and authenticated via `cmd login`, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux). On Windows the binary name collides with `cmd.exe`, so `COMMANDCODE_BIN` must point at the real binary.
+compatibility: Requires the Command Code CLI (`cmd`, from commandcode.ai) installed and authenticated via `cmd login`, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux). On Windows the binary name collides with `cmd.exe`, so `COMMANDCODE_BIN` must be the real binary's absolute path, not the system command interpreter.
 metadata:
   version: 0.5.0
 ---
@@ -56,9 +56,9 @@ process. If writes outside the target tree are unacceptable, use an OS-enforced 
    run `cmd login`.
 2. **Confirm which `cmd` is on PATH.** The name is generic, so a shell builtin, an alias, or another
    tool can shadow it — `command -v cmd` shows the active one. On native Windows `cmd` *is* `cmd.exe`;
-   the relay refuses to guess there and requires `COMMANDCODE_BIN` to point at the real binary. The
-   relay records the version it actually ran into `result.json`, so a wrong binary is visible after
-   the fact.
+   the relay refuses to guess there and requires `COMMANDCODE_BIN` to be the real binary's absolute
+   path, not the system command interpreter. The relay records the version it actually ran into
+   `result.json`, so a wrong binary is visible after the fact.
 3. You are in (or will point `--cd` at) the target git repository, and its tree is clean before you
    dispatch — a full-trust run is much easier to review against a clean baseline.
 

--- a/skills/commandcode-delegate/SKILL.md
+++ b/skills/commandcode-delegate/SKILL.md
@@ -43,8 +43,8 @@ Command Code's headless mode has **exactly two states, with nothing in between**
   can reach. There is no filesystem sandbox and no path restriction. This is what an implementation
   run needs, so the relay passes it by default.
 
-`--permission-mode auto-accept` and `--tools-all` do **not** lift the headless write gate (verified
-against `cmd` 1.26.0 — write, edit, and shell were all refused with both). So an implementation run
+`--permission-mode auto-accept` and `--tools-all` do **not** lift the headless write gate. Direct CLI
+probes refused write, edit, and shell with both. So an implementation run
 through Command Code is a full-trust run: scope it with a tight brief and a clean working tree, not
 with a sandbox. The brief is guidance, and a git worktree isolates a checkout without containing the
 process. If writes outside the target tree are unacceptable, use an OS-enforced sandbox such as

--- a/skills/commandcode-delegate/SKILL.md
+++ b/skills/commandcode-delegate/SKILL.md
@@ -144,9 +144,9 @@ before landing anything. **The orchestrator commits.** Only after the gates pass
 The relay doubles as a clean way to get an adversarial second opinion: dispatch `--read-only` with a
 brief that lists the agreed points, then each contested point with both positions, and ask Command
 Code to defend or concede each — deliverable in its final message, touching no files. The read-only
-guarantee here is the CLI's own permission layer rather than an OS sandbox, so the relay also proves
-it after the fact: check `readOnlyViolation` in `result.json` (`false` = nothing changed, `true` =
-something did, `null` = git could not tell).
+guarantee here is the CLI's own permission layer rather than an OS sandbox, so the relay also checks
+it after the fact: `readOnlyViolation: false` means the Git-visible detector saw no change (ignored
+or outside-repository paths are not covered); `true` means it saw one; `null` means git could not tell.
 
 ## Authorization model
 

--- a/skills/commandcode-delegate/SKILL.md
+++ b/skills/commandcode-delegate/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: commandcode-delegate
+description: >-
+  Delegate a coding task to the Command Code CLI (`cmd`) as a background implementer, then review its
+  diff and land it yourself. Use this whenever the user wants to hand implementation work to Command
+  Code — phrasings like "have Command Code do X", "delegate this to commandcode", "run it through
+  cmd", or "use Command Code to implement/fix/refactor" — or to run a queue of coding tasks through
+  Command Code while staying the reviewer. DO NOT USE for tasks small enough to do inline, or when the
+  user wants the code written directly without delegating.
+license: MIT
+compatibility: Requires the Command Code CLI (`cmd`, from commandcode.ai) installed and authenticated via `cmd login`, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux). On Windows the binary name collides with `cmd.exe`, so `COMMANDCODE_BIN` must point at the real binary.
+metadata:
+  version: 0.5.0
+---
+
+# Command Code Delegate
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the Command Code CLI (`cmd`) — then review what it produced and land it yourself.
+You write the brief and own the judgment; Command Code does the typing in your working tree; you
+verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so it works the same whether you are Claude Code, OpenCode with a selected
+model, or any comparable agent. (It is designed for and run on Claude Code; treat other orchestrators
+as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `cmd` CLI is not installed or not authenticated (run `cmd login`).
+- You want to write the code yourself, or you only need a review (Command Code has its own `/review`).
+- You are on native Windows without `COMMANDCODE_BIN` set — see the autonomy and platform notes below.
+
+## Read this before the first dispatch: the autonomy model
+
+Command Code's headless mode has **exactly two states, with nothing in between**:
+
+- **Default (`-p` with no `--yolo`):** read, grep, and glob work. Every write, edit, and shell call is
+  refused by the CLI's permission layer, and headless mode has no prompt to grant them mid-run. This
+  is the relay's `--read-only`.
+- **`--yolo` (alias `--dangerously-skip-permissions`):** every tool is allowed, anywhere the process
+  can reach. There is no filesystem sandbox and no path restriction. This is what an implementation
+  run needs, so the relay passes it by default.
+
+`--permission-mode auto-accept` and `--tools-all` do **not** lift the headless write gate (verified
+against `cmd` 1.26.0 — write, edit, and shell were all refused with both). So an implementation run
+through Command Code is a full-trust run: scope it with a tight brief and a clean working tree, not
+with a sandbox. If you need OS-enforced containment, use a sibling delegate whose CLI provides it
+(`codex-delegate`) or run this one inside a container or a git worktree.
+
+## Prerequisites (check once)
+
+1. `cmd --version` succeeds and `cmd status` reports authenticated. If not, install Command Code and
+   run `cmd login`.
+2. **Confirm which `cmd` is on PATH.** The name is generic, so a shell builtin, an alias, or another
+   tool can shadow it — `command -v cmd` shows the active one. On native Windows `cmd` *is* `cmd.exe`;
+   the relay refuses to guess there and requires `COMMANDCODE_BIN` to point at the real binary. The
+   relay records the version it actually ran into `result.json`, so a wrong binary is visible after
+   the fact.
+3. You are in (or will point `--cd` at) the target git repository, and its tree is clean before you
+   dispatch — a full-trust run is much easier to review against a clean baseline.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Command Code sees **only** the text you send — no repo memory, no chat history, no shared context
+(beyond the repo's own `AGENTS.md`, which it reads automatically). Everything the task needs goes in
+the brief: the goal, the current state, what to change, what to leave untouched, the project's
+**actual** gate commands (discover them from the repo's AGENTS.md/CLAUDE.md/Makefile — do not assume),
+and a report contract. Tell it that it will **not** commit (you will). Keep one task per brief. Full
+guidance and a template: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to Command Code with the bundled helper. It wraps `cmd -p`, captures the run, and
+writes a structured `result.json` — so your only job is "run a command, read a file." (`<skill-dir>`
+below is this skill's installed directory — the folder containing this `SKILL.md`, i.e. the directory
+you loaded the skill from. Claude Code prints it as "Base directory for this skill" when the skill
+loads; on other orchestrators use that same directory — if unsure where it landed, run
+`find ~ -name relay.mjs -path '*commandcode-delegate*'` and substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (review/diagnosis, no edits):   add --read-only
+# continue the exact session:               add --session <sessionId>  (from result.json; send only the delta brief)
+# fallback when no session id is available: add --continue-last
+# hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
+# see all options:                          node .../relay.mjs --help
+```
+
+The helper defaults to a write-capable (`--yolo`) run and writes its artifacts to a temp dir, so the
+repo under review stays clean. It **never commits** — see step 5. Mechanics, flags, and the
+`result.json` shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Command Code finishes, so back it with whatever your orchestrator offers and
+resume when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh, or your shell's equivalent. The run is done when `result.json`
+  exists with a `status`. (A pre-run usage error — bad args or an empty brief — instead exits with code
+  2 and a stderr message and writes no result file, so check the exit code too. A missing `cmd` binary
+  exits 127 but *does* write a `result.json` with status `commandcode_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line. The implementer's full report is the
+`finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
+
+### 4. Review — do not trust the self-report
+
+`result.json` includes Command Code's own summary and gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did it do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point — and because the run was
+  full-trust, check for edits *outside* the paths the brief named, not just inside them.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+Command Code under `--yolo` *can* write `.git`, which is exactly why the relay does not let it:
+committing is the reviewer's act, and a self-committed run is one you have to unpick before you can
+review it. **The orchestrator commits.** Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--session <sessionId>` from the prior `result.json`
+  (use `--continue-last` only when no session id is available), and review again.
+
+## Read-only second opinions
+
+The relay doubles as a clean way to get an adversarial second opinion: dispatch `--read-only` with a
+brief that lists the agreed points, then each contested point with both positions, and ask Command
+Code to defend or concede each — deliverable in its final message, touching no files. The read-only
+guarantee here is the CLI's own permission layer rather than an OS sandbox, so the relay also proves
+it after the fact: check `readOnlyViolation` in `result.json` (`false` = nothing changed, `true` =
+something did, `null` = git could not tell).
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report Command Code's design decisions, defensible-but-unasked
+turns, and non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if
+correct completion needs going beyond the brief, ask — don't expand the mandate yourself). The full
+treatment is in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief Command
+  Code can execute blind: structure, XML blocks, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the exact-session rework cycle.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -41,7 +41,7 @@ Options:
 | `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
 | `--model <name>` | Model for this run, e.g. `vendor/model` (default: Command Code's own). `cmd --list-models` lists what your account can use. |
 | `--effort <level>` | Reasoning effort — `low` \| `medium` \| `high`, model-dependent. The relay accepts a bare token; Command Code and the model own the supported levels. |
-| `--read-only` | Withhold the write, edit, and shell tools: no `--yolo`, plus `--permission-mode plan`. For review and diagnosis. Verified afterwards via `readOnlyViolation`. |
+| `--read-only` | Withhold the write, edit, and shell tools: no `--yolo`, plus `--permission-mode plan`. For review and diagnosis, followed by a Git-visible `readOnlyViolation` tripwire. |
 | `--tools-all` | Also pass `--tools-all`, so no tool stays withheld. Ignored under `--read-only` — it does not lift the write gate. |
 | `--max-turns <n>` | Cap conversation turns (default: Command Code's own, 100). Command Code may exit 0 at the cap; when its complete result reports `max_turns`, the relay reports failure and exits 1. |
 | `--session <id>` | Continue one specific session by id (the `sessionId` from a prior `result.json`); send only the delta brief. Mutually exclusive with `--continue-last`. |
@@ -102,8 +102,9 @@ brief immediately.
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point.
   `null` (not `[]`) when git can't report — `git` missing, or a non-repo working root; `[]` means git
   ran and the tree is clean
-- `readOnlyViolation` — only meaningful under `--read-only`: `false` when nothing changed beyond the
-  relay's own artifacts, `true` when something did, `null` when git couldn't snapshot either side.
+- `readOnlyViolation` — only meaningful under `--read-only`: `false` when the Git-visible detector
+  saw no change beyond the relay's own artifacts; it does not cover ignored or outside-repository
+  paths. `true` when the detector saw a change, `null` when git couldn't snapshot either side.
   `null` on write-capable runs, where the question doesn't apply
 - `autonomy` — the state the run actually got, in Command Code's terms (`--yolo …` or `plan …`)
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw NDJSON event stream,
@@ -197,10 +198,9 @@ process has exited and `result.json` is written — not when a status line says 
 - **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer or
   a supervisor timeout, not an implementer error. Free up host memory or split the task into smaller
   briefs, then re-dispatch.
-- **`readOnlyViolation: true`:** a `--read-only` run changed the tree anyway. Command Code's read-only
-  state is its own permission layer, not an OS sandbox, so treat the run as write-capable: review the
-  diff before doing anything else, and report the violation — it is a CLI-behavior finding, not just a
-  run outcome.
+- **`readOnlyViolation: true`:** the tripwire detected a Git-visible change during a `--read-only`
+  run. It cannot attribute a concurrent change to Command Code, but its read-only state is a permission
+  layer rather than an OS sandbox. Review the diff and report the warning before doing anything else.
 - **Empty `finalMessage`:** this is missing information, not a separate failure state. Read `status`
   and `resultLine`; when the result line is truncated or absent, inspect the event log and diff before
   landing.

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -92,6 +92,8 @@ brief immediately.
   (global "most recent", which another run can steal)
 - `finalMessage` — Command Code's own final report (the `<structured_output_contract>` you asked for),
   lifted from `finalText` on its result line and also written to `finalPath`
+- `resultLine` — how much of the tail survived: `complete`, `truncated`, or `absent`. See the
+  truncation section below; the three fields under it are null unless this says `complete`
 - `resultSubtype` / `stopReason` / `usage` / `durationMs` — straight from that result line: `success`,
   `error`, or `max_turns`; why the turn ended; token counts; wall-clock
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point.
@@ -113,6 +115,31 @@ brief immediately.
 
 The helper also prints a summary to stdout and exits with Command Code's exit code, so a wrapping
 script can branch on success/failure directly.
+
+## The tail is not reliable — read `resultLine`
+
+`cmd` ends a run with a `run_end` event that embeds the **entire conversation** — every tool call,
+its arguments, and its result — and then exits with `process.exit`, which discards whatever is still
+queued in its stdout pipe. On any run big enough to matter, the tail therefore arrives cut mid-write
+and the `result` line after it never lands. Measured on `cmd` 1.26.0: two successful write runs lost
+their result line, one cut at ~8 KB into the `run_end` line, the other losing the last ~780 events
+outright. A synthetic writer that exits the same way loses the stream down to whatever fits the OS
+pipe buffer, no matter how fast the reader is — so this is the CLI's flush behavior, not the relay's
+read speed (the relay batches its event-log writes precisely so it drains as fast as it can).
+
+What the relay does about it, and what it means for you:
+
+- Nothing load-bearing is read from the tail. `sessionId` comes from `run_start`, the **first** line of
+  the stream, so resume always works. The report is taken from the last `message_end`, falling back to
+  the streamed `text_delta`s of a message whose `message_end` was lost.
+- `resultLine` tells you which case you got. Under `truncated` or `absent`, `resultSubtype`,
+  `stopReason`, `usage`, and `durationMs` are `null` because the CLI never delivered them — not because
+  the run lacked them. The summary prints a note saying so.
+- `finalMessage` can still come back short or empty when the report itself was in the discarded
+  region. **The diff is the deliverable, not the report** — review `touchedFiles` and `git diff`, and
+  treat a thin report as missing information rather than as a failed run.
+- Read-only runs are small and usually keep a `complete` result line, so the second-opinion use is
+  unaffected.
 
 **A zero exit is not a completed task.** Command Code exits `0` for a run that ended cleanly with the
 work unfinished — including the case where every write was refused because `--yolo` was absent. The

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -94,7 +94,7 @@ brief immediately.
   (global "most recent", which another run can steal)
 - `finalMessage` — Command Code's own final report (the `<structured_output_contract>` you asked for),
   lifted from `finalText` on a complete result line or recovered from the last `message_end` or
-  `text_delta`; recovered text may be partial or empty, and is also written to `finalPath`
+  `text_delta`; recovered text may be partial or empty, and is written to `finalPath` only when non-empty
 - `resultLine` — how much of the tail survived: `complete`, `truncated`, or `absent`. See the
   truncation section below; the four fields under it are null unless this says `complete`
 - `resultSubtype` / `stopReason` / `usage` / `durationMs` — straight from that result line: `success`,
@@ -108,7 +108,7 @@ brief immediately.
   `null` on write-capable runs, where the question doesn't apply
 - `autonomy` — the state the run actually got, in Command Code's terms (`--yolo …` or `plan …`)
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw NDJSON event stream,
-  and the final-message file
+  and the final-message file; `finalPath` is `null` when `finalMessage` is empty
 - `workdir`, `readOnly`, `toolsAll`, `model`, `effort`, `maxTurns`, `session`, `continueLast`,
   `cleanEnv`, `keepEnv`, `startedAt`, `finishedAt` — `session` is the explicit session id, or `null`
   for fresh and `--continue-last` runs; `keepEnv` records names only, never values

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -38,7 +38,7 @@ Options:
 | `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
 | `--cd <dir>` | Working root for Command Code (default: current directory). It is the child's working directory — Command Code has no `--cd` of its own, and under `--yolo` it is a starting point, not a boundary. |
 | `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
-| `--model <name>` | Model for this run, e.g. `zai-org/glm-5.3` (default: Command Code's own). `cmd --list-models` lists what your account can use. |
+| `--model <name>` | Model for this run, e.g. `vendor/model` (default: Command Code's own). `cmd --list-models` lists what your account can use. |
 | `--effort <level>` | Reasoning effort — `low` \| `medium` \| `high`, model-dependent. The relay accepts a bare token; Command Code and the model own the supported levels. |
 | `--read-only` | Withhold the write, edit, and shell tools: no `--yolo`, plus `--permission-mode plan`. For review and diagnosis. Verified afterwards via `readOnlyViolation`. |
 | `--tools-all` | Also pass `--tools-all`, so no tool stays withheld. Ignored under `--read-only` — it does not lift the write gate. |
@@ -122,9 +122,9 @@ script can branch on success/failure directly.
 `cmd` ends a run with a `run_end` event that embeds the **entire conversation** — every tool call,
 its arguments, and its result — and then exits with `process.exit`, which discards whatever is still
 queued in its stdout pipe. On any run big enough to matter, the tail therefore arrives cut mid-write
-and the `result` line after it never lands. Measured on `cmd` 1.26.0: two successful write runs lost
-their result line, one cut at ~8 KB into the `run_end` line, the other losing the last ~780 events
-outright. A synthetic writer that exits the same way loses the stream down to whatever fits the OS
+and the `result` line after it never lands. Successful live write runs have lost the result line,
+either truncating `run_end` or dropping the rest of the stream. A synthetic writer that exits the
+same way loses the stream down to whatever fits the OS
 pipe buffer, no matter how fast the reader is — so this is the CLI's flush behavior, not the relay's
 read speed (the relay batches its event-log writes precisely so it drains as fast as it can).
 
@@ -142,11 +142,11 @@ What the relay does about it, and what it means for you:
 - Read-only runs are small and usually keep a `complete` result line, so the second-opinion use is
   unaffected.
 
-**A zero exit is not a completed task.** Command Code exits `0` for a run that ended cleanly with the
-work unfinished — including the case where every write was refused because `--yolo` was absent. The
-relay therefore requires `exitCode 0` **and** `resultSubtype: "success"` before it reports
-`status: "completed"`; a clean exit with any other subtype, or with no result line at all, is reported
-`failed` with exit 1 and an `error` explaining which. Read `status`, not the exit code alone.
+When a complete result line arrives, `status: "completed"` requires exit 0 and
+`resultSubtype: "success"`; any other subtype is reported as failed with exit 1. When the result line
+is truncated or absent, the relay falls back to the process exit code: exit 0 is completed and a
+non-zero exit is failed. In that fallback case, read `resultLine` and review the diff because the
+missing subtype cannot prove the task finished.
 
 ## Waiting for completion
 

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -42,7 +42,7 @@ Options:
 | `--effort <level>` | Reasoning effort — `low` \| `medium` \| `high`, model-dependent. The relay accepts a bare token; Command Code and the model own the supported levels. |
 | `--read-only` | Withhold the write, edit, and shell tools: no `--yolo`, plus `--permission-mode plan`. For review and diagnosis. Verified afterwards via `readOnlyViolation`. |
 | `--tools-all` | Also pass `--tools-all`, so no tool stays withheld. Ignored under `--read-only` — it does not lift the write gate. |
-| `--max-turns <n>` | Cap conversation turns (default: Command Code's own, 100). A run that hits the cap exits 8 with `stopReason: max_turns`. |
+| `--max-turns <n>` | Cap conversation turns (default: Command Code's own, 100). Command Code may exit 0 at the cap; when its complete result reports `max_turns`, the relay reports failure and exits 1. |
 | `--session <id>` | Continue one specific session by id (the `sessionId` from a prior `result.json`); send only the delta brief. Mutually exclusive with `--continue-last`. |
 | `--continue-last` | Continue the most recent session. "Most recent" is global, not per-repo, so an unrelated run can steal it — prefer `--session`. |
 | `--clean-env` | Pass only runtime basics (`PATH`, home, locale, temp, and Windows equivalents) to Command Code and its version preflight. This changes inherited variables only; it does not protect files or other same-user secrets. |
@@ -83,7 +83,7 @@ brief immediately.
 
 - `schema` — the result-format version (currently `delegate-relay.result.v1`)
 - `status` — `completed` | `failed` | `timeout` | `aborted` | `commandcode_unavailable`
-- `exitCode` — mirrors Command Code's exit code; `128` plus the signal number if the child was killed;
+- `exitCode` — preserves Command Code's non-zero exit code; changes a zero exit with a complete non-success result to 1; uses `128` plus the signal number if the child was killed;
   `127` if the binary isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child
   exited `0` after the watchdog's SIGTERM
 - `signal` — the signal that killed the child, otherwise `null`
@@ -174,7 +174,7 @@ process has exited and `result.json` is written — not when a status line says 
 - **`status: failed` at exit 3:** not authenticated. `cmd login`, then re-dispatch.
 - **`status: failed` at exit 5 or 10:** rate limited, or out of credits. Wait, lower the model tier, or
   top up — the relay's summary names which.
-- **`status: failed` with `stopReason: max_turns` (exit 8):** the run hit the turn cap mid-task and the
+- **`status: failed` with `stopReason: max_turns`:** the run hit the turn cap mid-task. If Command Code exited 0, the relay exits 1; otherwise it preserves the non-zero child exit. The
   tree may hold a half-applied change. Inspect it, then either raise `--max-turns` and re-dispatch, or
   split the brief.
 - **`status: failed` at exit 0→1 with an `error` about subtype:** Command Code ended the run cleanly

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -16,8 +16,9 @@ cmd status            # must report authenticated (else `cmd login`)
 ```
 
 On native Windows, `cmd` resolves to `cmd.exe`. The relay refuses to run there rather than hand your
-brief to a shell: set `COMMANDCODE_BIN` to the Command Code binary's full path, and note that it must be
-a real executable — the relay never launches through a shell, so a `.cmd`/`.bat` wrapper will not start.
+brief to a shell: set `COMMANDCODE_BIN` to the Command Code binary's absolute path, not `COMSPEC`, and
+note that it must be a real executable — the relay never launches through a shell, so a `.cmd`/`.bat`
+wrapper will not start.
 Windows is untested for this skill. The same variable overrides the binary on any platform when several
 installs compete.
 
@@ -48,10 +49,11 @@ Options:
 | `--clean-env` | Pass only runtime basics (`PATH`, home, locale, temp, and Windows equivalents) to Command Code and its version preflight. This changes inherited variables only; it does not protect files or other same-user secrets. |
 | `--keep-env <name>` | Keep one additional variable under `--clean-env`; repeat for each required environment-backed credential, proxy, certificate, or MCP variable. The name must be set and use portable environment-variable syntax. |
 | `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
-| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh private dir under the system temp dir). |
 
 Artifacts default to the system temp dir so relay-created files stay out of the target repository.
-The touched-files report then shows Command Code's Git-visible edits without the helper's artifacts.
+On POSIX, that directory is mode `0700` and its files are created as `0600`. The touched-files report
+then shows Command Code's Git-visible edits without the helper's artifacts.
 
 `--clean-env` is not a security boundary: Command Code still reaches files and other same-user secrets
 through `HOME` (its own state lives in `~/.commandcode`) and OS facilities, and under `--yolo` there is
@@ -199,8 +201,9 @@ process has exited and `result.json` is written — not when a status line says 
   state is its own permission layer, not an OS sandbox, so treat the run as write-capable: review the
   diff before doing anything else, and report the violation — it is a CLI-behavior finding, not just a
   run outcome.
-- **Empty `finalMessage`:** the run exited before emitting its result line. Treat as failed; the event
-  log usually shows where it stopped.
+- **Empty `finalMessage`:** this is missing information, not a separate failure state. Read `status`
+  and `resultLine`; when the result line is truncated or absent, inspect the event log and diff before
+  landing.
 
 ## Recovering lost work
 

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,192 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `cmd -p`, feeds it the brief on stdin, captures the
+NDJSON event stream, and writes a structured `result.json`. Your job collapses to: run one command,
+then read one file. Everything Command Code-specific lives in the helper, which is what keeps the loop
+portable across orchestrators.
+
+## Before the first run: check the binary
+
+Three gotchas, all worth 30 seconds:
+
+```bash
+command -v cmd        # `cmd` is a generic name — an alias or another tool can shadow it
+cmd --version         # the relay records this in result.json; confirm it is Command Code's
+cmd status            # must report authenticated (else `cmd login`)
+```
+
+On native Windows, `cmd` resolves to `cmd.exe`. The relay refuses to run there rather than hand your
+brief to a shell: set `COMMANDCODE_BIN` to the Command Code binary's full path, and note that it must be
+a real executable — the relay never launches through a shell, so a `.cmd`/`.bat` wrapper will not start.
+Windows is untested for this skill. The same variable overrides the binary on any platform when several
+installs compete.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for Command Code (default: current directory). It is the child's working directory — Command Code has no `--cd` of its own, and under `--yolo` it is a starting point, not a boundary. |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Model for this run, e.g. `zai-org/glm-5.3` (default: Command Code's own). `cmd --list-models` lists what your account can use. |
+| `--effort <level>` | Reasoning effort — `low` \| `medium` \| `high`, model-dependent. The relay accepts a bare token; Command Code and the model own the supported levels. |
+| `--read-only` | Withhold the write, edit, and shell tools: no `--yolo`, plus `--permission-mode plan`. For review and diagnosis. Verified afterwards via `readOnlyViolation`. |
+| `--tools-all` | Also pass `--tools-all`, so no tool stays withheld. Ignored under `--read-only` — it does not lift the write gate. |
+| `--max-turns <n>` | Cap conversation turns (default: Command Code's own, 100). A run that hits the cap exits 8 with `stopReason: max_turns`. |
+| `--session <id>` | Continue one specific session by id (the `sessionId` from a prior `result.json`); send only the delta brief. Mutually exclusive with `--continue-last`. |
+| `--continue-last` | Continue the most recent session. "Most recent" is global, not per-repo, so an unrelated run can steal it — prefer `--session`. |
+| `--clean-env` | Pass only runtime basics (`PATH`, home, locale, temp, and Windows equivalents) to Command Code and its version preflight. This changes inherited variables only; it does not protect files or other same-user secrets. |
+| `--keep-env <name>` | Keep one additional variable under `--clean-env`; repeat for each required environment-backed credential, proxy, certificate, or MCP variable. The name must be set and use portable environment-variable syntax. |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only Command Code's edits and nothing of the helper's own.
+
+`--clean-env` is not a security boundary: Command Code still reaches files and other same-user secrets
+through `HOME` (its own state lives in `~/.commandcode`) and OS facilities, and under `--yolo` there is
+no sandbox at all. Its login credentials are file-backed, so a `--clean-env` run stays authenticated;
+provider, proxy, certificate, or MCP settings that reference a stripped variable need it named with
+`--keep-env`. The same filtered environment is used for preflight and dispatch.
+
+## What the helper is doing
+
+```bash
+cmd -p --output-format json --skip-onboarding --no-auto-update -t --yolo [--tools-all] \
+    [-m <model>] [--effort <level>] [--max-turns <n>] < brief.txt          # fresh implementation run
+cmd -p --output-format json --skip-onboarding --no-auto-update -t --permission-mode plan …  # --read-only
+cmd -p … --resume <sessionId> < delta-brief.txt                            # exact-session rework
+cmd -p … --continue < delta-brief.txt                                      # most-recent fallback
+```
+
+The four constant flags earn their place: `--output-format json` is what makes the run machine-readable
+at all, `--skip-onboarding` stops the taste-onboarding prompt from blocking an automated run, `-t`
+auto-trusts the project so the trust prompt doesn't, and `--no-auto-update` keeps a background update
+from swapping the binary mid-run. The brief goes in on stdin, never in argv — Command Code's `-p` takes
+an optional query argument, so an unrecognized flag would be read as that query and the run would die
+with "too many arguments". Command Code waits at most 30 seconds for piped stdin; the relay writes the
+brief immediately.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `commandcode_unavailable`
+- `exitCode` — mirrors Command Code's exit code; `128` plus the signal number if the child was killed;
+  `127` if the binary isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child
+  exited `0` after the watchdog's SIGTERM
+- `signal` — the signal that killed the child, otherwise `null`
+- `commandCodeVersion` — the binary that actually ran
+- `sessionId` — feed this to a later `--session <id>` (exact session; preferred) or `--continue-last`
+  (global "most recent", which another run can steal)
+- `finalMessage` — Command Code's own final report (the `<structured_output_contract>` you asked for),
+  lifted from `finalText` on its result line and also written to `finalPath`
+- `resultSubtype` / `stopReason` / `usage` / `durationMs` — straight from that result line: `success`,
+  `error`, or `max_turns`; why the turn ended; token counts; wall-clock
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point.
+  `null` (not `[]`) when git can't report — `git` missing, or a non-repo working root; `[]` means git
+  ran and the tree is clean
+- `readOnlyViolation` — only meaningful under `--read-only`: `false` when nothing changed beyond the
+  relay's own artifacts, `true` when something did, `null` when git couldn't snapshot either side.
+  `null` on write-capable runs, where the question doesn't apply
+- `autonomy` — the state the run actually got, in Command Code's terms (`--yolo …` or `plan …`)
+- `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw NDJSON event stream,
+  and the final-message file
+- `workdir`, `readOnly`, `toolsAll`, `model`, `effort`, `maxTurns`, `session`, `continueLast`,
+  `cleanEnv`, `keepEnv`, `startedAt`, `finishedAt` — `session` is the explicit session id, or `null`
+  for fresh and `--continue-last` runs; `keepEnv` records names only, never values
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`,
+  `timeout`, `aborted`), absent on `completed`, `commandcode_unavailable`, and launch failures
+- `error` — present on a launch failure, on `timeout` and `aborted` runs, and when Command Code
+  reported a non-success result of its own
+
+The helper also prints a summary to stdout and exits with Command Code's exit code, so a wrapping
+script can branch on success/failure directly.
+
+**A zero exit is not a completed task.** Command Code exits `0` for a run that ended cleanly with the
+work unfinished — including the case where every write was refused because `--yolo` was absent. The
+relay therefore requires `exitCode 0` **and** `resultSubtype: "success"` before it reports
+`status: "completed"`; a clean exit with any other subtype, or with no result line at all, is reported
+`failed` with exit 1 and an `error` explaining which. Read `status`, not the exit code alone.
+
+## Waiting for completion
+
+The helper blocks until Command Code finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh, or your shell's equivalent (`Start-Job` in PowerShell). A run is done when
+  `result.json` exists with a `status`. **But** a pre-run usage error (bad args, empty brief) exits with
+  code 2 *before* writing any file — so check the exit code too, don't only watch for the file. (A
+  missing binary exits 127 but *does* write a `result.json` with status `commandcode_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: commandcode_unavailable` (exit 127):** the binary isn't on PATH. Install Command Code, run
+  `cmd login`, or set `COMMANDCODE_BIN`, then re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `cmd --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
+  Command Code was never dispatched; only the relay's own artifacts may already exist under
+  `--out-dir`. Check the install by running `cmd --version` yourself.
+- **`status: failed` at exit 3:** not authenticated. `cmd login`, then re-dispatch.
+- **`status: failed` at exit 5 or 10:** rate limited, or out of credits. Wait, lower the model tier, or
+  top up — the relay's summary names which.
+- **`status: failed` with `stopReason: max_turns` (exit 8):** the run hit the turn cap mid-task and the
+  tree may hold a half-applied change. Inspect it, then either raise `--max-turns` and re-dispatch, or
+  split the brief.
+- **`status: failed` at exit 0→1 with an `error` about subtype:** Command Code ended the run cleanly
+  without succeeding. The usual cause is a write-capable task dispatched `--read-only`, where the report
+  says the tools were refused. Re-dispatch without `--read-only`.
+- **`status: failed` otherwise:** read `result.json`'s `stderrTail` and the tail of `eventsPath`. Common
+  causes: an invalid `--model`, an unsupported `--effort` for the selected model, or a network lapse.
+  Fix the cause and re-dispatch; don't paper over it by doing the work yourself unless that's what the
+  user wants.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a closed
+  terminal) and forwarded the kill to `cmd`. The result is written before the relay exits; inspect the
+  working tree before re-dispatching. On native Windows a hard kill of the relay is uncatchable (Node
+  supports no `SIGTERM` handler there), so this status may never get written — a relay process that is
+  gone without a `result.json` is an aborted run; inspect the working tree and `events.jsonl` directly.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer or
+  a supervisor timeout, not an implementer error. Free up host memory or split the task into smaller
+  briefs, then re-dispatch.
+- **`readOnlyViolation: true`:** a `--read-only` run changed the tree anyway. Command Code's read-only
+  state is its own permission layer, not an OS sandbox, so treat the run as write-capable: review the
+  diff before doing anything else, and report the violation — it is a CLI-behavior finding, not just a
+  run outcome.
+- **Empty `finalMessage`:** the run exited before emitting its result line. Treat as failed; the event
+  log usually shows where it stopped.
+
+## Recovering lost work
+
+`events.jsonl` records every NDJSON line Command Code streamed, and its `run_end` event embeds the
+whole conversation — every tool call, its arguments, and its result. That makes the log both the map of
+what a lost run did and, for file writes, often a literal copy of the content it wrote. If finished work
+is lost — the run killed late, or the tree damaged afterward — read the event log before re-dispatching.
+The flip side of that completeness: the log contains whatever the run read or wrote, so treat it as
+sensitive as the repo itself, and note that it grows with the transcript (tens of KB for a trivial run,
+much more for a long one).
+
+## The commit boundary
+
+The helper never commits — by design, not omission. Under `--yolo` Command Code *can* write `.git`,
+which is the reason: a run that commits itself is a run you must unpick before you can review it. The
+robust contract is: Command Code edits the working tree, the orchestrator reviews and commits. See
+[review-and-land.md](review-and-land.md).

--- a/skills/commandcode-delegate/references/multi-task-queues.md
+++ b/skills/commandcode-delegate/references/multi-task-queues.md
@@ -1,0 +1,81 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+With Command Code there's a fourth reason, and it's the strongest: an implementation run has no
+filesystem sandbox. Two concurrent `--yolo` runs in one tree can interleave writes to the same file with
+nothing arbitrating between them, and the resulting diff belongs to neither task. If you do need
+parallelism, give each run its own tree — `git worktree add` per task, or a container — rather than
+running two of them side by side in the same checkout. Default to sequential.
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. Command Code has no memory of the earlier run, so a constraint that
+emerged in task 2 must be restated in task 5's brief or it won't hold. This is the queue equivalent of
+keeping briefs self-contained.
+
+(`--session` does carry one run's context into its own rework, but that's for reworking a single task —
+not a channel for handing task 2's discoveries to task 5. Each task in a queue gets a fresh dispatch.)
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions Command Code made, non-blocking nitpicks, any write that
+  landed outside the brief's paths, anything you want the human to overrule or confirm. This is the
+  section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Watch the per-task budget
+
+Each dispatch has its own turn cap (Command Code's default is 100; `--max-turns` overrides it) and its
+own `--timeout` if you set one. In a long queue those limits bite unevenly: the task in the middle that
+touches twenty files is the one that stops at `stopReason: max_turns` with a half-applied change. Size
+briefs so no single task needs the whole budget, and treat a capped task as an unfinished one — inspect
+the tree, then re-dispatch or split, rather than letting the queue move on past it.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/commandcode-delegate/references/review-and-land.md
+++ b/skills/commandcode-delegate/references/review-and-land.md
@@ -1,0 +1,142 @@
+# Review and land
+
+Command Code did the typing; you own the judgment. This is where delegation earns its keep or quietly
+ships a mistake. The discipline is simple to state and easy to skip under time pressure: **verify
+against reality, never against the self-report — and read the diff as generated code, which fails in
+ways a green gate can't see.**
+
+One thing to add to the usual routine here: the run had no sandbox. An implementation dispatch goes out
+under `--yolo`, so "did it stay inside the brief's paths?" is a question you answer from `touchedFiles`,
+not one the tooling answered for you.
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries Command Code's own claim that the gates passed. Treat that as a claim, not
+evidence — re-run the project's actual test/lint/build commands in the working tree and read the output.
+And keep the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a
+gate, not just misreport it — that is what the test check above and the sweep below exist to catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Out-of-scope writes** — this is the first check here, not an afterthought. Under `--yolo` there was
+  nothing stopping a write outside `--cd` or outside the paths the brief named. Scan the whole
+  `touchedFiles` list before you read any single file's diff, and if the run wrote somewhere unexpected,
+  understand why before continuing.
+- **Scope creep** — did it change things the brief said to leave untouched? Unasked refactors, renames,
+  "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version? A `stopReason` of `max_turns` in `result.json` is a strong hint of a run that
+  stopped mid-task rather than finishing.
+- **Quiet judgment calls** — sometimes Command Code makes a defensible decision the brief didn't
+  anticipate. Don't just accept it because it looks reasonable; understand it and decide.
+- **A commit it made itself** — the brief forbids it, but nothing enforced that. Check `git log` against
+  your own last commit; if the run committed, `git reset --soft HEAD~1` and review the diff properly.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If Command Code couldn't implement
+  something, the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to Command Code as a delta brief (below) or gets fixed in the tree
+before commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never Command Code. This
+isn't a workaround for a missing feature; it's the deliberate boundary. Under `--yolo` Command Code is
+perfectly capable of committing, and that is precisely the problem: committing should be the act of the
+party that verified the work, and a self-committed run has to be unpicked before it can be reviewed.
+Write a clear message describing what landed. If your project attributes co-authorship, that's the place
+for it.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`, `git diff --cached`
+for anything the implementer staged (plain `git diff` is blind to the index), and open any untracked
+files (`??` in `git status`) directly — they are the implementer's new files, and no diff shows their
+contents. The tree is evidence, not clutter. After that inspection the verdict can legitimately be to
+discard — work built on a premise you have since corrected, for example — and then `git checkout`/`clean`
+is the right tool. The ban is on reflexive cleanup before anyone has looked.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same Command Code session
+with just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --session <sessionId> --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).
+`<sessionId>` is the field of that name from the prior `result.json`.)
+
+`--session <sessionId>` keeps the context from the first run, so a short delta is enough; use
+`--continue-last` only when no session id came back, since "most recent" is global and another run can
+steal it. Then review again — rework gets the same gate-rerun, test check, diff-read, and sweep as the
+original, no shortcuts. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** Command Code made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Report any write outside the brief's paths**, and any `readOnlyViolation: true` on a read-only
+  dispatch, even when the change itself looks harmless. Those say something about the run's containment,
+  which is the human's call to weigh, not yours to normalize.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or Command Code's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/commandcode-delegate/references/writing-the-brief.md
+++ b/skills/commandcode-delegate/references/writing-the-brief.md
@@ -1,0 +1,145 @@
+# Writing the brief
+
+A brief is the entire task as Command Code will see it. It runs in a fresh process with **no memory of
+your conversation, no access to your prior notes, and no shared context** — only the text you send and
+whatever it can read from the working tree (including the repo's own `AGENTS.md`, which it picks up
+automatically, and any skills it discovers there).
+If a constraint isn't in the brief or discoverable in the repo, it doesn't exist for Command Code. The
+single most common failure is a brief that assumes context it doesn't have.
+
+## The shape that works
+
+Command Code responds best to compact, block-structured prompts with XML tags rather than long prose.
+State the task, what "done" looks like, how to behave by default, and the few constraints that actually
+matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps Command Code
+from wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences) and run with `--read-only` so the write, edit, and shell tools stay withheld.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Path discipline is the sandbox
+
+An implementation run goes out under `--yolo`, which means no filesystem boundary: Command Code can
+write anywhere the process can reach, not just under `--cd`. The brief's path list is therefore doing
+the job a sandbox would do elsewhere. Name the files or directories it may change, say plainly that
+everything else is off limits, and keep `<action_safety>` in every write-capable brief. Then verify it
+held — `touchedFiles` in the result is the check, and it is worth reading even when the report says
+the change was small.
+
+## `git commit` is not blocked, only forbidden
+
+Sibling delegates can rely on a sandbox refusing to write `.git`. This one cannot: under `--yolo`,
+Command Code is perfectly able to commit, so the brief has to tell it not to. Keep the "do NOT run
+git add or git commit" line — and if a run commits anyway, unpick it (`git reset --soft HEAD~1`) before
+reviewing, so you are reviewing a diff rather than history.
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you an implementer that guesses — or skips.
+
+## Honor the repo's conventions
+
+Command Code reads the repo's `AGENTS.md` automatically, so house rules there (style, forbidden
+patterns, commit conventions) already apply. If the project forbids certain things in code — say,
+spec/ticket IDs in comments, process language like "MVP"/"for now"/"phase N", or specific test
+conventions, whatever the repo's own conventions ban — restate the load-bearing ones in the brief too,
+because compliance is only as reliable as what's in front of it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and
+suggest a roadmap" produces a muddled run; split it into separate dispatches. One brief → one run →
+one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+Turns are capped (Command Code's own default is 100; `--max-turns` changes it). A brief bundling four
+jobs is also the brief most likely to hit that cap and stop mid-way, reported as `stopReason:
+max_turns` with a half-finished tree.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## Expect environment preamble in the reply
+
+The final message may carry environment noise on top of your requested report — a banner injected by
+the repo's `AGENTS.md`, extra text from an MCP server or skill you have configured locally, taste
+notes from Command Code's own learning. That comes from your setup, not a relay defect. The
+`<structured_output_contract>` is your defense: ask for a clearly delimited report section so you can
+find the real output regardless of what wraps it.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched, and do not write outside services/billing/.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -6,8 +6,7 @@
  * the run, and write a structured result the orchestrating agent can review.
  * The orchestrator runs this one command and reads the result JSON — every
  * Command Code-specific mechanic lives in here, which keeps the skill
- * orchestrator-agnostic. Verified on Claude Code against cmd 1.26.0; other
- * shell-capable agents (OpenCode, Cursor, …) are designed-for but not verified.
+ * orchestrator-agnostic. Shell-capable agents use the same file contract.
  *
  * Trust posture: relay.mjs itself makes no network calls, reads or writes no
  * credentials, and sends no telemetry; it has no dependencies (Node built-ins
@@ -47,7 +46,7 @@
  *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
  *   --cd <dir>              Working root for Command Code (default: current directory).
  *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
- *   --model <name>          Model for this run, e.g. zai-org/glm-5.3 (default: Command Code's own).
+ *   --model <name>          Model for this run, e.g. vendor/model (default: Command Code's own).
  *                           `cmd --list-models` shows what is available to your account.
  *   --effort <level>        Reasoning effort — low | medium | high, model-dependent
  *                           (default: Command Code's own configured effort).
@@ -86,7 +85,7 @@
  * A caveat that shapes the parsing: cmd's `run_end` event embeds the entire
  * conversation, so on a real run the tail of the stream exceeds a pipe buffer and
  * cmd exits without waiting for it to drain — the tail arrives cut mid-write and
- * the result line after it is simply lost (seen on cmd 1.26.0). `resultLine`
+ * the result line after it is simply lost in live runs. `resultLine`
  * reports which happened ("complete" | "truncated" | "absent"), and everything
  * load-bearing is read from the small early events instead: sessionId from
  * `run_start`, the report from the last `message_end`.
@@ -122,6 +121,7 @@ import {
   readlinkSync,
   realpathSync,
   renameSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
@@ -139,7 +139,7 @@ const VERSION_PROBE_TIMEOUT_MS = 10_000;
 const MAX_TIMER_MS = 2_147_483_647;
 const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
-// Command Code model ids are vendor/name slugs (zai-org/glm-5.3). Keep in lockstep
+// Command Code model ids are vendor/name slugs. Keep in lockstep
 // with delegate-setup MODEL_TOKEN.shellSafe.
 const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
 
@@ -678,7 +678,7 @@ function buildArgv(opts) {
     argv.push("--permission-mode", "plan");
   } else {
     // The only headless setting that enables edits. --permission-mode auto-accept and
-    // --tools-all do not lift the gate; verified against cmd 1.26.0.
+    // --tools-all do not lift the gate; verified in direct CLI probes.
     argv.push("--yolo");
     if (opts.toolsAll) argv.push("--tools-all");
   }
@@ -699,7 +699,7 @@ function buildArgv(opts) {
  * entire conversation — every tool call, argument, and result — so on a real run
  * it is far larger than a pipe buffer, and cmd exits without waiting for the
  * write to drain: the tail arrives cut mid-string and the result line never
- * lands at all (observed on cmd 1.26.0, a successful run truncated at ~8 KB).
+ * lands at all, as observed in live runs.
  * So everything load-bearing is taken from the small early events instead —
  * `run_start` carries the sessionId as the very first line, and each
  * `message_end` carries that message's text blocks, the last of which is the
@@ -789,6 +789,17 @@ function prepareRunDir(opts, brief) {
     briefPath: join(outDir, "brief.txt"),
     resultPath: join(outDir, "result.json"),
   };
+  // A poller treats result.json existence as completion, so a reused directory
+  // must stop advertising ordinary artifacts from the previous run. Leave
+  // aliases and symlinks alone: the read-only tripwire must observe those paths.
+  for (const path of [run.finalPath, run.resultPath]) {
+    let exactLeaf = false;
+    try { exactLeaf = readdirSync(dirname(path)).includes(basename(path)); } catch { /* handled below */ }
+    if (!exactLeaf) continue;
+    try {
+      if (lstatSync(path).isFile()) rmSync(path, { force: true });
+    } catch { /* the writer will report an unusable artifact path */ }
+  }
   writeFileSync(run.briefPath, brief, "utf8");
   writeFileSync(run.eventsPath, "", "utf8");
   return run;

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -24,8 +24,8 @@
  * write gate (verified — both were refused). So this relay passes `--yolo` for
  * implementation runs and omits it (adding `--permission-mode plan`) for
  * `--read-only`. That read-only guarantee is the CLI's own permission layer, not
- * an OS sandbox: it held under test, but the relay still proves it after the fact
- * with `readOnlyViolation`.
+ * an OS sandbox. The relay also reports a Git-visible change tripwire through
+ * `readOnlyViolation`; ignored and outside-repository paths remain outside it.
  *
  * It deliberately does NOT commit. Committing belongs to the reviewer, after it
  * reads the diff and re-runs the project gates.
@@ -53,7 +53,7 @@
  *                           (default: Command Code's own configured effort).
  *   --read-only             Withhold write/edit/shell tools: no --yolo, plus --permission-mode plan.
  *                           For review and diagnosis. Enforced by the CLI's permission layer, and
- *                           checked afterwards via readOnlyViolation.
+ *                           followed by a Git-visible readOnlyViolation tripwire.
  *   --tools-all             Also pass --tools-all, so no tool stays withheld. Ignored under
  *                           --read-only (it does not lift the write gate anyway).
  *   --max-turns <n>         Cap conversation turns (default: Command Code's own, 100).
@@ -385,26 +385,47 @@ function commandCodeEnv(opts) {
   return Object.fromEntries(keep.filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]]));
 }
 
-function commandCodeVersion(probeTimeoutMs, env) {
-  try {
-    // Never launched through a shell — on Windows that would route the name `cmd` straight
-    // to cmd.exe. parseArgs requires COMMANDCODE_BIN there, and it must name a real
-    // executable: a .cmd/.bat wrapper cannot be started without the shell this relay refuses.
-    const version = execFileSync(BIN, ["--version"], {
-      encoding: "utf8",
+async function commandCodeVersion(probeTimeoutMs, env, onChild) {
+  // Never launched through a shell — on Windows that would route the name `cmd` straight
+  // to cmd.exe. parseArgs requires COMMANDCODE_BIN there, and it must name a real
+  // executable: a .cmd/.bat wrapper cannot be started without the shell this relay refuses.
+  const probe = await new Promise((resolveProbe) => {
+    const child = spawn(BIN, ["--version"], {
+      stdio: ["ignore", "pipe", "pipe"],
       shell: false,
-      timeout: probeTimeoutMs,
-      killSignal: "SIGKILL",
+      detached: process.platform !== "win32",
       env,
-    }).trim();
-    return { version: version || "unknown", error: null };
-  } catch (error) {
-    if (error?.code === "ENOENT") return { version: null, error: null };
-    // Anything else — a hung probe we killed, or a real non-zero exit — means cmd is
-    // installed but not usable. Reporting that as "unavailable" would send the caller
-    // off to reinstall a binary that is already there.
-    return { version: null, error };
+    });
+    onChild(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timer = null;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolveProbe({ stdout, stderr, ...result });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => finish({ code: null, error, timedOut: false }));
+    child.on("close", (code) => finish({ code, error: null, timedOut }));
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+    }, probeTimeoutMs);
+  });
+  if (probe.timedOut) {
+    return { version: null, error: Object.assign(new Error(`${BIN} --version timed out`), { code: "ETIMEDOUT", stderr: probe.stderr }) };
   }
+  if (probe.error?.code === "ENOENT") return { version: null, error: null };
+  if (probe.error) return { version: null, error: probe.error };
+  if (probe.code !== 0) {
+    return { version: null, error: Object.assign(new Error(`${BIN} --version failed`), { status: probe.code, stderr: probe.stderr }) };
+  }
+  return { version: probe.stdout.trim() || "unknown", error: null };
 }
 
 // Command Code's read-only state is its own permission layer, not an OS sandbox, so the
@@ -906,6 +927,39 @@ function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
   process.exit(result.exitCode);
 }
 
+function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: null,
+        resultSubtype: null,
+        stopReason: null,
+        usage: null,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the cmd version preflight; Command Code was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
 function dispatchToCommandCode(opts, brief, run, writeResult, env) {
   const argv = buildArgv(opts);
   // detached on POSIX: the child leads a new process group so killChild can fell the whole tree.
@@ -1106,7 +1160,7 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
   child.stdin.end();
 }
 
-function main() {
+async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const brief = readBrief(opts);
   if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
@@ -1120,18 +1174,24 @@ function main() {
   const beforeFingerprints = opts.readOnly ? fingerprintDirtyPaths(opts.cd, relayArtifacts(run)) : null;
   const probeTimeoutMs = versionProbeTimeout(opts);
   const env = commandCodeEnv(opts);
-  const probe = commandCodeVersion(probeTimeoutMs, env);
-  const writeResult = makeResultWriter(opts, probe.version, run, beforeTree, beforeFingerprints);
+  let writeResult = makeResultWriter(opts, null, run, beforeTree, beforeFingerprints);
+  let preflightChild = null;
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const probe = await commandCodeVersion(probeTimeoutMs, env, (child) => { preflightChild = child; });
+  writeResult = makeResultWriter(opts, probe.version, run, beforeTree, beforeFingerprints);
 
   if (!probe.version && !probe.error) {
+    clearPreflightSignals();
     reportUnavailable(writeResult, run.resultPath);
     return;
   }
   if (probe.error) {
+    clearPreflightSignals();
     reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
     return;
   }
 
+  clearPreflightSignals();
   dispatchToCommandCode(opts, brief, run, writeResult, env);
 }
 
@@ -1158,7 +1218,7 @@ function printSummary(result, resultPath) {
       ? "read-only check: not verifiable (git could not report) — inspect the working tree directly"
       : result.readOnlyViolation
         ? "read-only check: FAILED — the tree changed beyond this relay's artifacts; treat the run as write-capable and review the diff"
-        : "read-only check: clean — no tree changes beyond this relay's artifacts");
+        : "read-only check: no Git-visible change detected (ignored or outside-repository paths are not covered)");
   }
   const touched = result.touchedFiles;
   if (touched === null) {

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -129,7 +129,7 @@ import {
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir } from "node:os";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { StringDecoder } from "node:string_decoder";
 import { TextDecoder } from "node:util";
 
@@ -896,9 +896,25 @@ function makeResultWriter(opts, version, run, beforeTree, beforeFingerprints) {
     }
     // Publish atomically so a polling orchestrator never reads a half-written file
     // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
-    const temporary = `${run.resultPath}.${process.pid}.tmp`;
-    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
-    renameSync(temporary, run.resultPath);
+    const resultContents = `${JSON.stringify(result, null, 2)}\n`;
+    let resultTemporary = null;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const resultCandidate = `${run.resultPath}.${process.pid}.${randomBytes(12).toString("hex")}.tmp`;
+      try {
+        writeFileSync(resultCandidate, resultContents, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
+        resultTemporary = resultCandidate;
+        break;
+      } catch (error) {
+        if (error?.code !== "EEXIST") throw error;
+      }
+    }
+    if (resultTemporary === null) throw new Error("could not reserve a result.json temporary file");
+    try {
+      renameSync(resultTemporary, run.resultPath);
+    } catch (error) {
+      rmSync(resultTemporary, { force: true });
+      throw error;
+    }
     return result;
   };
 }
@@ -951,6 +967,8 @@ function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
     const handler = () => {
       if (!active) return;
       active = false;
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
       const result = writeResult({
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
@@ -964,8 +982,6 @@ function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
         error: `the relay was killed by ${sig} during the cmd version preflight; Command Code was not dispatched`,
       });
       printSummary(result, run.resultPath);
-      const child = getChild();
-      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
       process.exit(result.exitCode);
     };
     handlers.set(sig, handler);
@@ -1071,33 +1087,38 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
       if (settled) return;
       settled = true;
       clearWatchdog();
-      const touched = gitTouchedFiles(opts.cd);
-      flushEvents(run, state);
-      const final = persistFinal();
-      const abortedFields = {
-        status: "aborted",
-        exitCode: 128 + (constants.signals[sig] || 15),
-        signal: sig,
-        sessionId: state.sessionId,
-        resultSubtype: state.result?.subtype ?? null,
-        stopReason: state.result?.stopReason ?? null,
-        usage: state.result?.usage ?? null,
-        finalMessage: final.text,
-        touchedFiles: touched,
-        stderrTail: stderrTail.slice(-20),
-        error: final.error || `the relay was killed by ${sig}; cmd was terminated with it — inspect the working tree before re-dispatching`,
-      };
-      const result = writeResult(abortedFields);
-      printSummary(result, run.resultPath);
       killChild(child);
-      setTimeout(() => {
+      try {
+        const touched = gitTouchedFiles(opts.cd);
+        flushEvents(run, state);
+        const final = persistFinal();
+        const abortedFields = {
+          status: "aborted",
+          exitCode: 128 + (constants.signals[sig] || 15),
+          signal: sig,
+          sessionId: state.sessionId,
+          resultSubtype: state.result?.subtype ?? null,
+          stopReason: state.result?.stopReason ?? null,
+          usage: state.result?.usage ?? null,
+          finalMessage: final.text,
+          touchedFiles: touched,
+          stderrTail: stderrTail.slice(-20),
+          error: final.error || `the relay was killed by ${sig}; cmd was terminated with it — inspect the working tree before re-dispatching`,
+        };
+        const result = writeResult(abortedFields);
+        printSummary(result, run.resultPath);
+        setTimeout(() => {
+          killChild(child, "SIGKILL");
+          // the child may flush files during the grace window; refresh the snapshot so the
+          // artifact matches the tree the orchestrator will actually find
+          const late = gitTouchedFiles(opts.cd);
+          writeResult({ ...abortedFields, touchedFiles: late });
+          process.exit(result.exitCode);
+        }, 2000);
+      } catch (error) {
         killChild(child, "SIGKILL");
-        // the child may flush files during the grace window; refresh the snapshot so the
-        // artifact matches the tree the orchestrator will actually find
-        const late = gitTouchedFiles(opts.cd);
-        writeResult({ ...abortedFields, touchedFiles: late });
-        process.exit(result.exitCode);
-      }, 2000);
+        throw error;
+      }
     });
   }
 

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -821,14 +821,18 @@ function prepareRunDir(opts, brief) {
     resultPath: join(outDir, "result.json"),
   };
   // A poller treats result.json existence as completion, so a reused directory
-  // must stop advertising ordinary artifacts from the previous run. Leave
-  // aliases and symlinks alone: the read-only tripwire must observe those paths.
+  // must stop advertising ordinary artifacts from the previous run. A result.json
+  // symlink is also stale completion state, but leave final.txt symlinks alone:
+  // the read-only tripwire must observe those paths.
   for (const path of [run.finalPath, run.resultPath]) {
     let exactLeaf = false;
     try { exactLeaf = readdirSync(dirname(path)).includes(basename(path)); } catch { /* handled below */ }
     if (!exactLeaf) continue;
     try {
-      if (lstatSync(path).isFile()) rmSync(path, { force: true });
+      const artifact = lstatSync(path);
+      if (artifact.isFile() || (path === run.resultPath && artifact.isSymbolicLink())) {
+        rmSync(path, { force: true });
+      }
     } catch { /* the writer will report an unusable artifact path */ }
   }
   writeFileSync(run.briefPath, brief, { encoding: "utf8", mode: PRIVATE_FILE_MODE });

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -32,7 +32,8 @@
  *
  * Windows: the Command Code binary is named `cmd`, which collides with the
  * system `cmd.exe`. Rather than risk driving a shell with your brief, the relay
- * refuses to guess there — set COMMANDCODE_BIN to the real binary's full path.
+ * refuses to guess there — set COMMANDCODE_BIN to the real binary's absolute path,
+ * never the system command interpreter.
  * That path must be a real executable: this relay never launches through a
  * shell, so a `.cmd`/`.bat` wrapper cannot start. Windows is untested here.
  * The same variable overrides the binary on any platform when several installs
@@ -114,6 +115,7 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  mkdtempSync,
   openSync,
   readFileSync,
   readSync,
@@ -124,7 +126,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir } from "node:os";
 import { createHash } from "node:crypto";
@@ -142,11 +144,15 @@ const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 // Command Code model ids are vendor/name slugs. Keep in lockstep
 // with delegate-setup MODEL_TOKEN.shellSafe.
 const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+const PRIVATE_FILE_MODE = 0o600;
 
 const IMPLEMENTER_KEY = "commandcode";
 // `cmd` is Command Code's binary name; COMMANDCODE_BIN overrides it (and is required
 // on Windows, where the name collides with cmd.exe).
-const BIN = process.env.COMMANDCODE_BIN || "cmd";
+const CONFIGURED_BIN = process.env.COMMANDCODE_BIN || null;
+const BIN = CONFIGURED_BIN && /[\\/]/.test(CONFIGURED_BIN)
+  ? resolve(CONFIGURED_BIN)
+  : CONFIGURED_BIN || "cmd";
 
 // Command Code's documented headless exit codes, for a summary hint that points at the
 // actual cause instead of a bare number.
@@ -195,6 +201,11 @@ function applyFleetLane(opts, flagged) {
 function fail(message, code = 2) {
   process.stderr.write(`relay: ${message}\n`);
   process.exit(code);
+}
+
+function executablePathKey(path) {
+  try { return realpathSync.native(path).toLowerCase(); }
+  catch { return resolve(path).toLowerCase(); }
 }
 
 function parseArgs(argv) {
@@ -280,10 +291,14 @@ function parseArgs(argv) {
   if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
     fail("--session must be a session id (letters, digits, . _ : -)");
   }
-  // `cmd` is cmd.exe on Windows. Guessing would hand the brief to a shell, so the
-  // relay stops instead and asks for the real path.
-  if (process.platform === "win32" && !process.env.COMMANDCODE_BIN) {
-    fail("on Windows the name `cmd` resolves to cmd.exe; set COMMANDCODE_BIN to the full path of the Command Code binary");
+  if (process.platform === "win32") {
+    if (!CONFIGURED_BIN || !isAbsolute(CONFIGURED_BIN)) {
+      fail("on Windows COMMANDCODE_BIN must be the absolute path of the Command Code executable");
+    }
+    const comspec = process.env.ComSpec || process.env.COMSPEC;
+    if (comspec && executablePathKey(BIN) === executablePathKey(comspec)) {
+      fail("COMMANDCODE_BIN points to the Windows command interpreter; set it to the Command Code executable");
+    }
   }
   return opts;
 }
@@ -662,11 +677,6 @@ function gitTouchedFiles(cwd) {
   }
 }
 
-function timestamp() {
-  // Local script (not a workflow): Date is available and fine here.
-  return new Date().toISOString().replace(/[:.]/g, "-");
-}
-
 function buildArgv(opts) {
   // -p with no query argument: Command Code auto-detects the piped brief on stdin.
   // Order matters — an unrecognized flag is read as the optional -p query and the CLI
@@ -780,8 +790,8 @@ function prepareRunDir(opts, brief) {
   const startedAt = new Date().toISOString();
   // Keep relay artifacts outside the target repository so touchedFiles reports
   // Command Code's Git-visible edits without the helper's own files.
-  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
-  mkdirSync(outDir, { recursive: true });
+  const outDir = opts.outDir || mkdtempSync(join(tmpdir(), "delegate-relay-"));
+  if (opts.outDir) mkdirSync(outDir, { recursive: true });
   const run = {
     startedAt,
     eventsPath: join(outDir, "events.jsonl"),
@@ -800,8 +810,8 @@ function prepareRunDir(opts, brief) {
       if (lstatSync(path).isFile()) rmSync(path, { force: true });
     } catch { /* the writer will report an unusable artifact path */ }
   }
-  writeFileSync(run.briefPath, brief, "utf8");
-  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.briefPath, brief, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
+  writeFileSync(run.eventsPath, "", { encoding: "utf8", mode: PRIVATE_FILE_MODE });
   return run;
 }
 
@@ -849,7 +859,7 @@ function makeResultWriter(opts, version, run, beforeTree, beforeFingerprints) {
     // Publish atomically so a polling orchestrator never reads a half-written file
     // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
     const temporary = `${run.resultPath}.${process.pid}.tmp`;
-    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
     renameSync(temporary, run.resultPath);
     return result;
   };
@@ -947,7 +957,7 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
     const streamed = state.deltas.join("").trim();
     const text = state.result?.finalText || state.lastText || streamed || "";
     if (!text) return "";
-    writeFileSync(run.finalPath, `${text}\n`, "utf8");
+    writeFileSync(run.finalPath, `${text}\n`, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
     return text.trim();
   };
 

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -820,12 +820,25 @@ function prepareRunDir(opts, brief) {
     briefPath: join(outDir, "brief.txt"),
     resultPath: join(outDir, "result.json"),
   };
+  const paths = [run.finalPath, run.resultPath, run.briefPath, run.eventsPath];
+  if (basename(canonicalFilePath(run.resultPath)) !== basename(run.resultPath)) {
+    fail("--out-dir contains a case-aliased result.json artifact");
+  }
+  let entries = [];
+  try { entries = readdirSync(outDir); } catch { /* the writers report an unusable output directory */ }
+  const collides = paths.some((path) => entries.includes(basename(path)));
+  if (collides) {
+    let priorRun = false;
+    try {
+      priorRun = lstatSync(run.resultPath).isFile() &&
+        JSON.parse(readFileSync(run.resultPath, "utf8")).schema === "delegate-relay.result.v1";
+    } catch { /* an absent, malformed, or linked marker is not reusable */ }
+    if (!priorRun) fail("--out-dir contains relay artifacts without a prior delegate-relay.result.v1 result");
+  }
   // Exact relay files may be reused, but no stale artifact endpoint may survive:
   // final.txt is written after dispatch and would otherwise follow its symlink.
-  for (const path of [run.finalPath, run.resultPath, run.briefPath, run.eventsPath]) {
-    let exactLeaf = false;
-    try { exactLeaf = readdirSync(dirname(path)).includes(basename(path)); } catch { /* handled below */ }
-    if (!exactLeaf) continue;
+  for (const path of paths) {
+    if (!entries.includes(basename(path))) continue;
     try {
       const artifact = lstatSync(path);
       if (artifact.isFile() || artifact.isSymbolicLink()) {
@@ -884,7 +897,7 @@ function makeResultWriter(opts, version, run, beforeTree, beforeFingerprints) {
     // Publish atomically so a polling orchestrator never reads a half-written file
     // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
     const temporary = `${run.resultPath}.${process.pid}.tmp`;
-    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
     renameSync(temporary, run.resultPath);
     return result;
   };
@@ -1013,15 +1026,15 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
   const persistFinal = () => {
     // Last resort: the deltas of a message whose message_end never arrived.
     const streamed = state.deltas.join("").trim();
-    const text = state.result?.finalText || state.lastText || streamed || "";
+    const text = (state.result?.finalText || state.lastText || streamed || "").trim();
     if (!text) return { text: "", error: null };
     try {
       // final.txt is deliberately created only once. This refuses a symlink or
       // case-aliased endpoint introduced after prepareRunDir completed.
       writeFileSync(run.finalPath, `${text}\n`, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
-      return { text: text.trim(), error: null };
+      return { text, error: null };
     } catch (error) {
-      return { text: text.trim(), error: `could not safely create final.txt: ${error.code || error.message}` };
+      return { text, error: `could not safely create final.txt: ${error.code || error.message}` };
     }
   };
 

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -79,9 +79,17 @@
  *
  * Result: written to <out-dir>/result.json and summarized on stdout —
  *   status, exitCode, signal, commandCodeVersion, sessionId (for a later --session),
- *   resultSubtype/stopReason/usage from Command Code's own result line, finalMessage
- *   (its report), touchedFiles (git porcelain, null if git can't report),
- *   readOnlyViolation, and the paths to events.jsonl and final.txt.
+ *   resultLine plus resultSubtype/stopReason/usage from Command Code's own result
+ *   line, finalMessage (its report), touchedFiles (git porcelain, null if git
+ *   can't report), readOnlyViolation, and the paths to events.jsonl and final.txt.
+ *
+ * A caveat that shapes the parsing: cmd's `run_end` event embeds the entire
+ * conversation, so on a real run the tail of the stream exceeds a pipe buffer and
+ * cmd exits without waiting for it to drain — the tail arrives cut mid-write and
+ * the result line after it is simply lost (seen on cmd 1.26.0). `resultLine`
+ * reports which happened ("complete" | "truncated" | "absent"), and everything
+ * load-bearing is read from the small early events instead: sessionId from
+ * `run_start`, the report from the last `message_end`.
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `cmd` binary exits 127;
@@ -89,6 +97,8 @@
  * authenticated, 5 rate limited, 8 max turns, 10 out of credits, …). A run that
  * exits 0 while its own result line says `subtype: "error"` is reported failed
  * with exit 1 — Command Code can end a run cleanly with the task unfinished.
+ * Where that line was truncated or lost, exit 0 is taken at face value: cmd still
+ * exits non-zero for the failures that matter.
  * If the child dies on a signal, the exit code is 128 plus the signal number and
  * `result.json` records the signal.
  * Once the brief validates, `result.json` is written on every outcome —
@@ -121,6 +131,10 @@ import { createHash } from "node:crypto";
 import { StringDecoder } from "node:string_decoder";
 import { TextDecoder } from "node:util";
 
+const MAX_BUFFERED_CHARS = 1_048_576;
+// Batch size for the event log; small enough to bound memory, large enough that the
+// stdout pipe keeps draining while we write.
+const EVENT_FLUSH_CHARS = 262_144;
 const VERSION_PROBE_TIMEOUT_MS = 10_000;
 const MAX_TIMER_MS = 2_147_483_647;
 const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
@@ -679,8 +693,18 @@ function buildArgv(opts) {
 /**
  * Command Code streams NDJSON: `{"type":"event",…}` lines, then one
  * `{"type":"result",…}` line carrying finalText, sessionId, subtype, stopReason,
- * and usage. The last result line wins; a sessionId on any line is a fallback for
- * runs that die before the result line lands.
+ * and usage.
+ *
+ * That tail cannot be relied on. The `run_end` event just before it embeds the
+ * entire conversation — every tool call, argument, and result — so on a real run
+ * it is far larger than a pipe buffer, and cmd exits without waiting for the
+ * write to drain: the tail arrives cut mid-string and the result line never
+ * lands at all (observed on cmd 1.26.0, a successful run truncated at ~8 KB).
+ * So everything load-bearing is taken from the small early events instead —
+ * `run_start` carries the sessionId as the very first line, and each
+ * `message_end` carries that message's text blocks, the last of which is the
+ * report. The result line is still parsed when it survives, because its subtype
+ * is the only place a clean-exit failure is named.
  */
 function scanEventLine(line, state) {
   let event;
@@ -689,9 +713,26 @@ function scanEventLine(line, state) {
   } catch {
     return; // progress noise, or a partial line; events.jsonl keeps it either way
   }
-  if (typeof event?.sessionId === "string" && event.sessionId) state.sessionId = event.sessionId;
-  const nested = event?.event?.result?.nextState?.sessionId;
-  if (typeof nested === "string" && nested) state.sessionId = nested;
+  const inner = event?.event;
+  for (const candidate of [event?.sessionId, inner?.sessionId, inner?.result?.nextState?.sessionId]) {
+    if (typeof candidate === "string" && candidate) state.sessionId = candidate;
+  }
+  // Streamed text, kept per message: the report often arrives as deltas long before
+  // the message_end that collects them, and on a cut stream the deltas are all there is.
+  if (inner?.type === "message_start") state.deltas = [];
+  if (inner?.type === "text_delta" && typeof inner.delta === "string") state.deltas.push(inner.delta);
+  if (inner?.type === "text_end" && typeof inner.text === "string" && inner.text.trim()) {
+    state.lastText = inner.text.trim();
+  }
+  // The report as the model actually sent it, before the oversized tail.
+  if (inner?.type === "message_end" && Array.isArray(inner.content)) {
+    const text = inner.content
+      .filter((block) => block?.type === "text" && typeof block.text === "string")
+      .map((block) => block.text)
+      .join("\n")
+      .trim();
+    if (text) state.lastText = text;
+  }
   if (event?.type !== "result") return;
   state.result = {
     subtype: typeof event.subtype === "string" ? event.subtype : null,
@@ -703,9 +744,31 @@ function scanEventLine(line, state) {
   };
 }
 
-function recordEventLine(eventsPath, line, state) {
-  appendFileSync(eventsPath, `${line}\n`, "utf8");
+/**
+ * Buffer the event log instead of appending per line, because reading speed decides
+ * how much of the stream survives. cmd ends with `process.exit`, which discards
+ * whatever is still queued in the stdout pipe, so a relay that blocks on a
+ * synchronous write for every line loses the tail: appending each of ~2000 lines
+ * individually kept only 51 of them in a reproduction, while buffering keeps the
+ * whole stream. Lines are parsed in memory as they arrive and flushed in batches.
+ */
+function recordEventLine(run, line, state) {
+  state.pending.push(line, "\n");
+  state.pendingChars += line.length + 1;
+  if (state.pendingChars >= EVENT_FLUSH_CHARS) flushEvents(run, state);
   scanEventLine(line, state);
+}
+
+function flushEvents(run, state) {
+  if (state.pending.length === 0) return;
+  const batch = state.pending.join("");
+  state.pending = [];
+  state.pendingChars = 0;
+  try {
+    appendFileSync(run.eventsPath, batch, "utf8");
+  } catch {
+    // The log is a diagnostic aid; losing it must not lose the run's result.
+  }
 }
 
 /** The relay's own files, excluded from the read-only tripwire: --out-dir may sit inside the repo. */
@@ -761,6 +824,7 @@ function makeResultWriter(opts, version, run, beforeTree, beforeFingerprints) {
       finalPath: existsSync(run.finalPath) ? run.finalPath : null,
       // Absent on write-capable runs would read as "not checked"; null says the
       // question does not apply, and only --read-only replaces it with a verdict.
+      resultLine: null,
       readOnlyViolation: null,
       ...extra,
     };
@@ -826,7 +890,7 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
   // detached on POSIX: the child leads a new process group so killChild can fell the whole tree.
   const child = spawn(BIN, argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: false, detached: process.platform !== "win32", env });
 
-  const state = { sessionId: null, result: null };
+  const state = { sessionId: null, result: null, lastText: null, truncatedTail: false, deltas: [], pending: [], pendingChars: 0 };
   let stdoutBuf = "";
   const stderrTail = [];
 
@@ -842,7 +906,15 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
       const line = stdoutBuf.slice(0, nl);
       stdoutBuf = stdoutBuf.slice(nl + 1);
       if (!line.trim()) continue;
-      recordEventLine(run.eventsPath, line, state);
+      recordEventLine(run, line, state);
+    }
+    // A run_end event embeds the whole transcript, so one line can be arbitrarily
+    // large. Flush it as a fragment rather than growing the buffer without bound;
+    // the fragment cannot be parsed, which is exactly what a truncated tail is.
+    if (stdoutBuf.length > MAX_BUFFERED_CHARS) {
+      recordEventLine(run, stdoutBuf, state);
+      stdoutBuf = "";
+      state.truncatedTail = true;
     }
   });
 
@@ -855,10 +927,14 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
     while (stderrTail.length > 20) stderrTail.shift();
   });
 
-  // Command Code has no -o flag, so the final report only exists inside the NDJSON
-  // result line; the relay writes final.txt itself once that line arrives.
+  // Command Code has no -o flag, so the report exists only in the event stream and
+  // the relay writes final.txt itself. Prefer the result line's finalText, and fall
+  // back to the last message_end text — which is the same report, delivered earlier
+  // and small enough to survive a truncated tail.
   const persistFinal = () => {
-    const text = state.result?.finalText ?? "";
+    // Last resort: the deltas of a message whose message_end never arrived.
+    const streamed = state.deltas.join("").trim();
+    const text = state.result?.finalText || state.lastText || streamed || "";
     if (!text) return "";
     writeFileSync(run.finalPath, `${text}\n`, "utf8");
     return text.trim();
@@ -906,7 +982,7 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
         resultSubtype: state.result?.subtype ?? null,
         stopReason: state.result?.stopReason ?? null,
         usage: state.result?.usage ?? null,
-        finalMessage: persistFinal(),
+        finalMessage: (flushEvents(run, state), persistFinal()),
         touchedFiles: touched,
         stderrTail: stderrTail.slice(-20),
         error: `the relay was killed by ${sig}; cmd was terminated with it — inspect the working tree before re-dispatching`,
@@ -953,27 +1029,38 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
     // a descendant that ignored SIGTERM must not outlive the timeout report: once the
     // parent is down, sweep the group (no-op where taskkill already felled the tree)
     if (watchdogFired) killChild(child, "SIGKILL");
-    if (stdoutBuf.trim()) recordEventLine(run.eventsPath, stdoutBuf, state);
+    if (stdoutBuf.trim()) {
+      recordEventLine(run, stdoutBuf, state);
+      // Leftover bytes with no closing newline are a cut-off write, not a final line.
+      state.truncatedTail = true;
+    }
+    flushEvents(run, state);
     const finalMessage = persistFinal();
-    // Command Code can exit 0 with its own result line reporting an error or a turn
-    // cap; a clean process exit is not a completed task. No result line at all means
-    // the stream never got there — also not a completion.
-    const cliOk = code === 0 && state.result !== null && state.result.subtype === "success";
+    // Command Code can exit 0 with its own result line reporting an error or a turn cap,
+    // so a clean process exit is not proof of a completed task where that line exists.
+    // Where it does NOT, the exit code is the authority: cmd truncates its oversized tail
+    // on exit, and treating that lost line as a failure would fail every large successful
+    // run. It still exits non-zero for the real failures (3 auth, 5 rate limit, 8 turn
+    // cap, 10 credits), so nothing is being waved through.
+    const cliOk = code === 0 && (state.result === null || state.result.subtype === "success");
     const succeeded = cliOk && !watchdogFired;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const touched = gitTouchedFiles(opts.cd);
     const cliError = state.result?.error
       ? `Command Code reported ${state.result.subtype ?? "an error"}: ${state.result.error}`
       : code === 0 && !cliOk
-        ? state.result === null
-          ? "Command Code exited 0 without a result line; the run ended before it reported"
-          : `Command Code exited 0 but reported subtype "${state.result.subtype}" (stopReason ${state.result.stopReason ?? "unknown"})`
+        ? `Command Code exited 0 but reported subtype "${state.result.subtype}" (stopReason ${state.result.stopReason ?? "unknown"})`
         : null;
     const result = writeResult({
       status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
       exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
       signal: signal ?? null,
       sessionId: state.sessionId,
+      // How much of the tail survived, so a consumer knows which fields are trustworthy:
+      // "complete" = the result line landed, "truncated" = it was cut off mid-write,
+      // "absent" = it never arrived. Under the last two, subtype/stopReason/usage are
+      // null because cmd never delivered them — not because the run lacked them.
+      resultLine: state.result !== null ? "complete" : state.truncatedTail ? "truncated" : "absent",
       resultSubtype: state.result?.subtype ?? null,
       stopReason: state.result?.stopReason ?? null,
       usage: state.result?.usage ?? null,
@@ -1040,6 +1127,9 @@ function printSummary(result, resultPath) {
   if (result.continueLast) lines.push("mode: continued most recent session");
   if (result.session) lines.push(`mode: resumed session ${result.session}`);
   if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId})`);
+  if (result.resultLine === "truncated" || result.resultLine === "absent") {
+    lines.push(`note: cmd's result line was ${result.resultLine} (its oversized run_end tail is not flushed on exit), so subtype/usage are unavailable; the report and session id come from the earlier events.`);
+  }
   if (result.resultSubtype && result.resultSubtype !== "success") {
     lines.push(`Command Code result: ${result.resultSubtype}${result.stopReason ? ` (stopReason ${result.stopReason})` : ""}`);
   }

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -820,23 +820,24 @@ function prepareRunDir(opts, brief) {
     briefPath: join(outDir, "brief.txt"),
     resultPath: join(outDir, "result.json"),
   };
-  // A poller treats result.json existence as completion, so a reused directory
-  // must stop advertising ordinary artifacts from the previous run. A result.json
-  // symlink is also stale completion state, but leave final.txt symlinks alone:
-  // the read-only tripwire must observe those paths.
-  for (const path of [run.finalPath, run.resultPath]) {
+  // Exact relay files may be reused. Leave final.txt symlinks alone so the
+  // read-only tripwire observes their targets; the other endpoints must never
+  // follow a stale symlink outside the output directory.
+  for (const path of [run.finalPath, run.resultPath, run.briefPath, run.eventsPath]) {
     let exactLeaf = false;
     try { exactLeaf = readdirSync(dirname(path)).includes(basename(path)); } catch { /* handled below */ }
     if (!exactLeaf) continue;
     try {
       const artifact = lstatSync(path);
-      if (artifact.isFile() || (path === run.resultPath && artifact.isSymbolicLink())) {
+      if (artifact.isFile() || (path !== run.finalPath && artifact.isSymbolicLink())) {
         rmSync(path, { force: true });
       }
     } catch { /* the writer will report an unusable artifact path */ }
   }
-  writeFileSync(run.briefPath, brief, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
-  writeFileSync(run.eventsPath, "", { encoding: "utf8", mode: PRIVATE_FILE_MODE });
+  // Exclusive creation also closes the cleanup-to-write race and refuses a
+  // differently cased endpoint on case-insensitive filesystems.
+  writeFileSync(run.briefPath, brief, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
+  writeFileSync(run.eventsPath, "", { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
   return run;
 }
 

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -820,21 +820,20 @@ function prepareRunDir(opts, brief) {
     briefPath: join(outDir, "brief.txt"),
     resultPath: join(outDir, "result.json"),
   };
-  // Exact relay files may be reused. Leave final.txt symlinks alone so the
-  // read-only tripwire observes their targets; the other endpoints must never
-  // follow a stale symlink outside the output directory.
+  // Exact relay files may be reused, but no stale artifact endpoint may survive:
+  // final.txt is written after dispatch and would otherwise follow its symlink.
   for (const path of [run.finalPath, run.resultPath, run.briefPath, run.eventsPath]) {
     let exactLeaf = false;
     try { exactLeaf = readdirSync(dirname(path)).includes(basename(path)); } catch { /* handled below */ }
     if (!exactLeaf) continue;
     try {
       const artifact = lstatSync(path);
-      if (artifact.isFile() || (path !== run.finalPath && artifact.isSymbolicLink())) {
+      if (artifact.isFile() || artifact.isSymbolicLink()) {
         rmSync(path, { force: true });
       }
     } catch { /* the writer will report an unusable artifact path */ }
   }
-  // Exclusive creation also closes the cleanup-to-write race and refuses a
+  // Exclusive creation closes the cleanup-to-write race and refuses a
   // differently cased endpoint on case-insensitive filesystems.
   writeFileSync(run.briefPath, brief, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
   writeFileSync(run.eventsPath, "", { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
@@ -1015,9 +1014,15 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
     // Last resort: the deltas of a message whose message_end never arrived.
     const streamed = state.deltas.join("").trim();
     const text = state.result?.finalText || state.lastText || streamed || "";
-    if (!text) return "";
-    writeFileSync(run.finalPath, `${text}\n`, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
-    return text.trim();
+    if (!text) return { text: "", error: null };
+    try {
+      // final.txt is deliberately created only once. This refuses a symlink or
+      // case-aliased endpoint introduced after prepareRunDir completed.
+      writeFileSync(run.finalPath, `${text}\n`, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
+      return { text: text.trim(), error: null };
+    } catch (error) {
+      return { text: text.trim(), error: `could not safely create final.txt: ${error.code || error.message}` };
+    }
   };
 
   let settled = false;
@@ -1054,6 +1059,8 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
       settled = true;
       clearWatchdog();
       const touched = gitTouchedFiles(opts.cd);
+      flushEvents(run, state);
+      const final = persistFinal();
       const abortedFields = {
         status: "aborted",
         exitCode: 128 + (constants.signals[sig] || 15),
@@ -1062,10 +1069,10 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
         resultSubtype: state.result?.subtype ?? null,
         stopReason: state.result?.stopReason ?? null,
         usage: state.result?.usage ?? null,
-        finalMessage: (flushEvents(run, state), persistFinal()),
+        finalMessage: final.text,
         touchedFiles: touched,
         stderrTail: stderrTail.slice(-20),
-        error: `the relay was killed by ${sig}; cmd was terminated with it — inspect the working tree before re-dispatching`,
+        error: final.error || `the relay was killed by ${sig}; cmd was terminated with it — inspect the working tree before re-dispatching`,
       };
       const result = writeResult(abortedFields);
       printSummary(result, run.resultPath);
@@ -1115,14 +1122,14 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
       state.truncatedTail = true;
     }
     flushEvents(run, state);
-    const finalMessage = persistFinal();
+    const final = persistFinal();
     // Command Code can exit 0 with its own result line reporting an error or a turn cap,
     // so a clean process exit is not proof of a completed task where that line exists.
     // Where it does NOT, the exit code is the authority: cmd truncates its oversized tail
     // on exit, and treating that lost line as a failure would fail every large successful
     // run. Non-zero child failures are still preserved, so nothing is waved through.
     const cliOk = code === 0 && (state.result === null || state.result.subtype === "success");
-    const succeeded = cliOk && !watchdogFired;
+    const succeeded = cliOk && !watchdogFired && final.error === null;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
     const touched = gitTouchedFiles(opts.cd);
     const cliError = state.result?.error
@@ -1144,10 +1151,12 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
       stopReason: state.result?.stopReason ?? null,
       usage: state.result?.usage ?? null,
       durationMs: state.result?.durationMs ?? null,
-      finalMessage,
+      finalMessage: final.text,
       touchedFiles: touched,
       ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
-      ...(watchdogFired
+      ...(final.error
+        ? { error: final.error }
+        : watchdogFired
         ? { error: `cmd did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` }
         : cliError
           ? { error: cliError }
@@ -1173,17 +1182,21 @@ async function main() {
   // Prepare the run dir before probing, so a preflight that times out or fails still has
   // somewhere to publish result.json rather than exiting silently.
   const run = prepareRunDir(opts, brief);
-  // Both baselines are taken before anything is dispatched, and only for a read-only run:
-  // the tripwire compares against the tree as it stood at dispatch, not as it stands now.
-  const beforeTree = opts.readOnly ? gitTripwireState(opts.cd, relayArtifacts(run)) : null;
-  const beforeFingerprints = opts.readOnly ? fingerprintDirtyPaths(opts.cd, relayArtifacts(run)) : null;
-  const probeTimeoutMs = versionProbeTimeout(opts);
-  const env = commandCodeEnv(opts);
-  let writeResult = makeResultWriter(opts, null, run, beforeTree, beforeFingerprints);
+  // Keep the preflight handler live while synchronous Git snapshots run. Node queues
+  // signals during those calls, so yield before publishing a completed baseline; an
+  // abort in that window must honestly report the read-only verdict as unknown.
+  let resultWriter = makeResultWriter(opts, null, run, null, null);
+  const writeResult = (extra) => resultWriter(extra);
   let preflightChild = null;
   const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const beforeTree = opts.readOnly ? gitTripwireState(opts.cd, relayArtifacts(run)) : null;
+  const beforeFingerprints = opts.readOnly ? fingerprintDirtyPaths(opts.cd, relayArtifacts(run)) : null;
+  await new Promise((resolveYield) => setImmediate(resolveYield));
+  resultWriter = makeResultWriter(opts, null, run, beforeTree, beforeFingerprints);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const env = commandCodeEnv(opts);
   const probe = await commandCodeVersion(probeTimeoutMs, env, (child) => { preflightChild = child; });
-  writeResult = makeResultWriter(opts, probe.version, run, beforeTree, beforeFingerprints);
+  resultWriter = makeResultWriter(opts, probe.version, run, beforeTree, beforeFingerprints);
 
   if (!probe.version && !probe.error) {
     clearPreflightSignals();

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -56,7 +56,8 @@
  *   --tools-all             Also pass --tools-all, so no tool stays withheld. Ignored under
  *                           --read-only (it does not lift the write gate anyway).
  *   --max-turns <n>         Cap conversation turns (default: Command Code's own, 100).
- *                           A run that hits the cap exits 8 and reports stopReason max_turns.
+ *                           Command Code may exit 0 at the cap; a complete max_turns result
+ *                           makes the relay report failure and exit 1.
  *   --session <id>          Continue a specific session by id (the sessionId from a prior
  *                           result.json); send only the delta brief. Mutually exclusive
  *                           with --continue-last.
@@ -92,10 +93,9 @@
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `cmd` binary exits 127;
- * otherwise the exit code mirrors Command Code's own (0 success, 1 error, 3 not
- * authenticated, 5 rate limited, 8 max turns, 10 out of credits, …). A run that
- * exits 0 while its own result line says `subtype: "error"` is reported failed
- * with exit 1 — Command Code can end a run cleanly with the task unfinished.
+ * otherwise the relay preserves Command Code's non-zero exit code. A run that
+ * exits 0 while its own complete result line reports any non-success subtype is
+ * reported failed with exit 1 — Command Code can end a run cleanly with the task unfinished.
  * Where that line was truncated or lost, exit 0 is taken at face value: cmd still
  * exits non-zero for the failures that matter.
  * If the child dies on a signal, the exit code is 128 plus the signal number and
@@ -1051,8 +1051,7 @@ function dispatchToCommandCode(opts, brief, run, writeResult, env) {
     // so a clean process exit is not proof of a completed task where that line exists.
     // Where it does NOT, the exit code is the authority: cmd truncates its oversized tail
     // on exit, and treating that lost line as a failure would fail every large successful
-    // run. It still exits non-zero for the real failures (3 auth, 5 rate limit, 8 turn
-    // cap, 10 credits), so nothing is being waved through.
+    // run. Non-zero child failures are still preserved, so nothing is waved through.
     const cliOk = code === 0 && (state.result === null || state.result.subtype === "success");
     const succeeded = cliOk && !watchdogFired;
     const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -1,0 +1,1075 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · commandcode-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Command Code CLI (`cmd -p`), capture
+ * the run, and write a structured result the orchestrating agent can review.
+ * The orchestrator runs this one command and reads the result JSON — every
+ * Command Code-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified on Claude Code against cmd 1.26.0; other
+ * shell-capable agents (OpenCode, Cursor, …) are designed-for but not verified.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `cmd` and `git`. The `cmd` process it launches
+ * does authenticate — exactly as you do at the terminal. Read this file before
+ * you run it.
+ *
+ * Autonomy, in Command Code's own terms: a `-p` run withholds the write, edit,
+ * and shell tools and there is no prompt to grant them mid-run, so the CLI
+ * offers exactly two headless states. Without `--yolo` the agent can read, grep,
+ * and glob but every write is refused by its permission layer. With `--yolo`
+ * (alias `--dangerously-skip-permissions`) every tool is allowed, everywhere the
+ * process can reach. There is no filesystem sandbox and no middle setting:
+ * `--permission-mode auto-accept` and `--tools-all` do NOT lift the headless
+ * write gate (verified — both were refused). So this relay passes `--yolo` for
+ * implementation runs and omits it (adding `--permission-mode plan`) for
+ * `--read-only`. That read-only guarantee is the CLI's own permission layer, not
+ * an OS sandbox: it held under test, but the relay still proves it after the fact
+ * with `readOnlyViolation`.
+ *
+ * It deliberately does NOT commit. Committing belongs to the reviewer, after it
+ * reads the diff and re-runs the project gates.
+ *
+ * Windows: the Command Code binary is named `cmd`, which collides with the
+ * system `cmd.exe`. Rather than risk driving a shell with your brief, the relay
+ * refuses to guess there — set COMMANDCODE_BIN to the real binary's full path.
+ * That path must be a real executable: this relay never launches through a
+ * shell, so a `.cmd`/`.bat` wrapper cannot start. Windows is untested here.
+ * The same variable overrides the binary on any platform when several installs
+ * compete.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for Command Code (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Model for this run, e.g. zai-org/glm-5.3 (default: Command Code's own).
+ *                           `cmd --list-models` shows what is available to your account.
+ *   --effort <level>        Reasoning effort — low | medium | high, model-dependent
+ *                           (default: Command Code's own configured effort).
+ *   --read-only             Withhold write/edit/shell tools: no --yolo, plus --permission-mode plan.
+ *                           For review and diagnosis. Enforced by the CLI's permission layer, and
+ *                           checked afterwards via readOnlyViolation.
+ *   --tools-all             Also pass --tools-all, so no tool stays withheld. Ignored under
+ *                           --read-only (it does not lift the write gate anyway).
+ *   --max-turns <n>         Cap conversation turns (default: Command Code's own, 100).
+ *                           A run that hits the cap exits 8 and reports stopReason max_turns.
+ *   --session <id>          Continue a specific session by id (the sessionId from a prior
+ *                           result.json); send only the delta brief. Mutually exclusive
+ *                           with --continue-last.
+ *   --continue-last         Continue the most recent Command Code session; send only the delta
+ *                           brief. "Most recent" is global, not per-repo, so another run can
+ *                           steal it — prefer --session.
+ *   --clean-env             Launch Command Code and its version preflight with only runtime basics.
+ *                           Changes inherited variables only; does not protect files or other
+ *                           same-user secrets.
+ *   --keep-env <name>       Keep one additional variable under --clean-env (repeatable).
+ *                           Required for environment-backed auth and other stripped variables.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the cmd child is killed
+ *                           and result.json gets status "timeout". Command Code has no
+ *                           timeout flag of its own, so the watchdog is relay-only.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, commandCodeVersion, sessionId (for a later --session),
+ *   resultSubtype/stopReason/usage from Command Code's own result line, finalMessage
+ *   (its report), touchedFiles (git porcelain, null if git can't report),
+ *   readOnlyViolation, and the paths to events.jsonl and final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `cmd` binary exits 127;
+ * otherwise the exit code mirrors Command Code's own (0 success, 1 error, 3 not
+ * authenticated, 5 rate limited, 8 max turns, 10 out of credits, …). A run that
+ * exits 0 while its own result line says `subtype: "error"` is reported failed
+ * with exit 1 — Command Code can end a run cleanly with the task unfinished.
+ * If the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to cmd), or commandcode_unavailable. An
+ * orchestrator that polls for the file must therefore also treat a non-zero exit
+ * with no file as a usage error.
+ */
+
+import { spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+import { StringDecoder } from "node:string_decoder";
+import { TextDecoder } from "node:util";
+
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+// Command Code model ids are vendor/name slugs (zai-org/glm-5.3). Keep in lockstep
+// with delegate-setup MODEL_TOKEN.shellSafe.
+const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "commandcode";
+// `cmd` is Command Code's binary name; COMMANDCODE_BIN overrides it (and is required
+// on Windows, where the name collides with cmd.exe).
+const BIN = process.env.COMMANDCODE_BIN || "cmd";
+
+// Command Code's documented headless exit codes, for a summary hint that points at the
+// actual cause instead of a bare number.
+const EXIT_HINTS = new Map([
+  [3, "not authenticated — run `cmd login`, then re-dispatch"],
+  [4, "permission denied — an implementation run needs write access; this relay passes --yolo unless --read-only was set"],
+  [5, "rate limit exceeded — wait and re-dispatch, or lower the model tier"],
+  [6, "network failure — check connectivity and re-dispatch"],
+  [7, "Command Code API server error (5xx) — transient; re-dispatch"],
+  [8, "hit the turn cap — raise --max-turns or split the brief into smaller tasks"],
+  [9, "the model produced no response — re-dispatch, and check the brief is not empty of instruction"],
+  [10, "insufficient credits — top up the account, then re-dispatch"],
+]);
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    readOnly: false,
+    toolsAll: false,
+    maxTurns: null,
+    session: null,
+    continueLast: false,
+    cleanEnv: false,
+    keepEnv: [],
+    timeout: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--effort": opts.effort = next(); flagged.add("effort"); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--tools-all": opts.toolsAll = true; break;
+      case "--max-turns": opts.maxTurns = next(); break;
+      case "--session": opts.session = next(); break;
+      case "--continue-last": opts.continueLast = true; break;
+      case "--clean-env": opts.cleanEnv = true; break;
+      case "--keep-env": opts.keepEnv.push(next()); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.effort !== null && !/^[a-z][a-z0-9-]*$/i.test(opts.effort)) {
+    fail(`invalid --effort "${opts.effort}" (expected a non-empty bare token)`);
+  }
+  if (opts.model !== null && !SAFE_MODEL.test(opts.model)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, . _ : / -)");
+  }
+  if (opts.maxTurns !== null && !/^[1-9][0-9]{0,4}$/.test(String(opts.maxTurns))) {
+    fail(`invalid --max-turns "${opts.maxTurns}" (expected a positive integer up to 99999)`);
+  }
+  if (opts.keepEnv.length && !opts.cleanEnv) {
+    fail("--keep-env requires --clean-env");
+  }
+  const invalidEnvName = opts.keepEnv.find((name) => !SAFE_ENV_NAME.test(name));
+  if (invalidEnvName) {
+    fail(`invalid --keep-env "${invalidEnvName}" (expected an environment variable name)`);
+  }
+  const missingEnvName = opts.keepEnv.find((name) => process.env[name] === undefined);
+  if (missingEnvName) {
+    fail(`--keep-env "${missingEnvName}" is not set`);
+  }
+  // The watchdog is relay-only (Command Code has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  if (opts.session !== null && opts.continueLast) {
+    fail("--session and --continue-last are mutually exclusive; pass only one");
+  }
+  if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
+    fail("--session must be a session id (letters, digits, . _ : -)");
+  }
+  // `cmd` is cmd.exe on Windows. Guessing would hand the brief to a shell, so the
+  // relay stops instead and asks for the real path.
+  if (process.platform === "win32" && !process.env.COMMANDCODE_BIN) {
+    fail("on Windows the name `cmd` resolves to cmd.exe; set COMMANDCODE_BIN to the full path of the Command Code binary");
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to cmd -p\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once cmd is running, so the preflight needs a bound of
+  // its own: a `cmd --version` that never returns would wedge the relay here, before
+  // any result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function commandCodeEnv(opts) {
+  if (!opts.cleanEnv) return process.env;
+  const keep = ["PATH", "HOME", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "LC_CTYPE", "TERM",
+    "TMPDIR", "COMMANDCODE_BIN", "SystemRoot", "SystemDrive", "USERPROFILE", "APPDATA", "LOCALAPPDATA",
+    "TEMP", "TMP", "PATHEXT", "COMSPEC", ...opts.keepEnv];
+  return Object.fromEntries(keep.filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]]));
+}
+
+function commandCodeVersion(probeTimeoutMs, env) {
+  try {
+    // Never launched through a shell — on Windows that would route the name `cmd` straight
+    // to cmd.exe. parseArgs requires COMMANDCODE_BIN there, and it must name a real
+    // executable: a .cmd/.bat wrapper cannot be started without the shell this relay refuses.
+    const version = execFileSync(BIN, ["--version"], {
+      encoding: "utf8",
+      shell: false,
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+      env,
+    }).trim();
+    return { version: version || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // Anything else — a hung probe we killed, or a real non-zero exit — means cmd is
+    // installed but not usable. Reporting that as "unavailable" would send the caller
+    // off to reinstall a binary that is already there.
+    return { version: null, error };
+  }
+}
+
+// Command Code's read-only state is its own permission layer, not an OS sandbox, so the
+// claim gets checked rather than trusted — the same tripwire claude-delegate and
+// grok-delegate carry, and byte-identical to theirs by contract.
+// Porcelain status alone cannot see every write. A path that is " M file" before a run and
+// " M file" after it produces an identical line, so comparing status lines proves nothing about
+// its contents — which is why the read-only tripwire below fingerprints the already-dirty paths
+// as well. Two sentinels stand for "could not fingerprint"; they are never treated as unchanged.
+const FINGERPRINT_UNREADABLE = "<unreadable>";
+const FINGERPRINT_DIRECTORY = "<directory>";
+
+function gitRepoRoot(cwd) {
+  // Porcelain paths are relative to the repository ROOT, not to the directory git ran in
+  // (--porcelain forces status.relativePaths off). Joining them against a --cd that is a
+  // subdirectory would look for <repo>/src/src/file and find nothing at either end.
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).replace(/\n$/, "") || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitStatusEntries(cwd) {
+  // -z so a path containing a space, a quote, or a newline stays one field rather than being
+  // quoted and escaped; -uall so an untracked directory is expanded into its files, because a
+  // collapsed "?? dir/" line never changes when a file inside it does.
+  try {
+    const output = execFileSync("git", ["status", "--porcelain", "-z", "-uall"], {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const fields = new TextDecoder("utf-8", { fatal: true }).decode(output)
+      .split("\0").filter((field) => field.length > 0);
+    const entries = [];
+    for (let i = 0; i < fields.length; i += 1) {
+      const entry = fields[i];
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      // R and C can sit in EITHER status column, and under -z such an entry is followed by its
+      // origin path as its own unprefixed field. Consume that field in both cases. A rename
+      // origin belongs in the dirty set (the file moved away from it); a copy origin does not,
+      // since a copy source can be a perfectly clean file.
+      const renamed = status.includes("R");
+      const copied = status.includes("C");
+      let origin = null;
+      if (renamed || copied) {
+        i += 1;
+        origin = fields[i] ?? null;
+      }
+      entries.push({ status, path, origin });
+    }
+    return entries;
+  } catch {
+    return null;
+  }
+}
+
+function dirtyPaths(cwd) {
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const paths = [];
+  for (const entry of entries) {
+    paths.push(entry.path);
+    if (entry.status.includes("R") && entry.origin !== null) paths.push(entry.origin);
+  }
+  return paths;
+}
+
+function asciiFold(value) {
+  return value.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+}
+
+function canonicalFilePath(path) {
+  const absolute = resolve(path);
+  let parent;
+  try { parent = realpathSync.native(dirname(absolute)); } catch { return absolute; }
+  const leaf = basename(absolute);
+  const canonical = join(parent, leaf);
+  try { lstatSync(canonical); } catch { return canonical; }
+  try {
+    const entries = readdirSync(parent);
+    if (entries.includes(leaf)) return canonical;
+    const matches = entries.filter((entry) => asciiFold(entry) === asciiFold(leaf));
+    return join(parent, matches.length === 1 ? matches[0] : leaf);
+  } catch {
+    return canonical;
+  }
+}
+
+function gitPathKey(root, path) {
+  let canonicalRoot;
+  try { canonicalRoot = realpathSync.native(root); } catch { canonicalRoot = resolve(root); }
+  const key = relative(canonicalRoot, canonicalFilePath(path));
+  return process.platform === "win32" ? key.replaceAll("\\", "/") : key;
+}
+
+function gitPathIsExcluded(root, path, excluded, foldedExcluded) {
+  return excluded.has(path) ||
+    (foldedExcluded.has(asciiFold(path)) && excluded.has(gitPathKey(root, join(root, path))));
+}
+
+function gitTripwireState(cwd, excludedPaths) {
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return entries.flatMap((entry) => [
+    [entry.status, "path", entry.path],
+    ...(entry.origin === null ? [] : [[entry.status.replace(/[^RC]/g, " "), "origin", entry.origin]]),
+  ]
+    .filter(([, , path]) => !gitPathIsExcluded(root, path, excluded, foldedExcluded)));
+}
+
+function pathFingerprint(absolutePath) {
+  // Identity, not just bytes: a retargeted symlink, a flipped mode bit, or a file replaced by a
+  // directory are all writes, and none of them change file contents.
+  let stats;
+  try {
+    stats = lstatSync(absolutePath);
+  } catch (error) {
+    // Absence is a state, not a failure - it differs from every real fingerprint, so a deletion
+    // or a re-creation still registers. Any other errno means we genuinely cannot tell.
+    return error && error.code === "ENOENT" ? "absent" : FINGERPRINT_UNREADABLE;
+  }
+  if (stats.isSymbolicLink()) {
+    try {
+      return `symlink:${readlinkSync(absolutePath, { encoding: "buffer" }).toString("hex")}`;
+    } catch {
+      return FINGERPRINT_UNREADABLE;
+    }
+  }
+  // A directory in the dirty set is a submodule, whose contents belong to another repository.
+  // Reported as unknown coverage rather than silently passed off as unchanged.
+  if (stats.isDirectory()) return FINGERPRINT_DIRECTORY;
+  if (!stats.isFile()) return FINGERPRINT_UNREADABLE;
+  let fd;
+  try {
+    // Streamed rather than read whole: an unignored multi-gigabyte artifact must not be pulled
+    // into memory just to answer whether it changed.
+    const hash = createHash("sha256");
+    fd = openSync(absolutePath, "r");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      const read = readSync(fd, buffer, 0, buffer.length, null);
+      if (read <= 0) break;
+      hash.update(buffer.subarray(0, read));
+    }
+    return `file:${(stats.mode & 0o7777).toString(8)}:${hash.digest("hex")}`;
+  } catch {
+    return FINGERPRINT_UNREADABLE;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+  }
+}
+
+function gitIndexFingerprints(root, paths) {
+  if (paths.length === 0) return new Map();
+  try {
+    const output = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const wanted = new Set(paths);
+    const prints = new Map(paths.map((path) => [path, []]));
+    for (const field of new TextDecoder("utf-8", { fatal: true }).decode(output).split("\0")) {
+      if (!field) continue;
+      const separator = field.indexOf("\t");
+      if (separator === -1) return null;
+      const path = field.slice(separator + 1);
+      if (wanted.has(path)) prints.get(path).push(field.slice(0, separator));
+    }
+    return prints;
+  } catch {
+    return null;
+  }
+}
+
+function fingerprintPaths(root, paths) {
+  // `complete` goes false the moment one path cannot be fingerprinted, so the caller reports
+  // "unknown" instead of an unearned clean bill of health.
+  const indexPrints = gitIndexFingerprints(root, paths);
+  const prints = new Map();
+  let complete = indexPrints !== null;
+  for (const path of paths) {
+    const file = pathFingerprint(join(root, path));
+    if (file === FINGERPRINT_UNREADABLE || file === FINGERPRINT_DIRECTORY) complete = false;
+    prints.set(path, { file, index: indexPrints?.get(path) ?? null });
+  }
+  return { prints, complete };
+}
+
+function fingerprintDirtyPaths(cwd, excludedPaths) {
+  // Only the already-dirty set is covered. A path that is clean at dispatch and gets written
+  // surfaces as a brand-new porcelain line anyway, and fingerprinting a whole repository per run
+  // would cost far more than the case it covers.
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const paths = dirtyPaths(cwd);
+  if (paths === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return {
+    root,
+    ...fingerprintPaths(root, paths.filter((path) => !gitPathIsExcluded(root, path, excluded, foldedExcluded))),
+  };
+}
+
+function changedDirtyPaths(before) {
+  // Re-fingerprint exactly the baseline paths, not whatever happens to be dirty now: a path the
+  // run newly dirtied is already reported by the porcelain comparison, and letting an unreadable
+  // one of those blind this signal would be a regression, not caution.
+  if (!before) return { changed: [], complete: false };
+  const now = fingerprintPaths(before.root, [...before.prints.keys()]);
+  const changed = [];
+  for (const [path, print] of before.prints) {
+    const current = now.prints.get(path);
+    const fileKnown = print.file !== FINGERPRINT_UNREADABLE && current.file !== FINGERPRINT_UNREADABLE;
+    const fileChanged = fileKnown &&
+      !(print.file === FINGERPRINT_DIRECTORY && current.file === FINGERPRINT_DIRECTORY) &&
+      current.file !== print.file;
+    const indexChanged = print.index !== null && current.index !== null &&
+      JSON.stringify(current.index) !== JSON.stringify(print.index);
+    if (fileChanged || indexChanged) changed.push(path);
+  }
+  return { changed: changed.sort(), complete: before.complete && now.complete };
+}
+
+function readOnlyVerdict(beforeTree, afterTree, beforeFingerprints) {
+  // Three-valued on purpose. Proof of a write settles it even when the other signal is unknown;
+  // only when nothing is proven AND coverage is incomplete is the answer genuinely unknown.
+  // Collapsing that last case to false is the false assurance a tripwire must never give.
+  const changed = changedDirtyPaths(beforeFingerprints);
+  const porcelainMoved =
+    beforeTree !== null && afterTree !== null && JSON.stringify(beforeTree) !== JSON.stringify(afterTree);
+  if (porcelainMoved || changed.changed.length > 0) return true;
+  if (beforeTree === null || afterTree === null || !changed.complete) return null;
+  return false;
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts) {
+  // -p with no query argument: Command Code auto-detects the piped brief on stdin.
+  // Order matters — an unrecognized flag is read as the optional -p query and the CLI
+  // rejects the run with "too many arguments", so only known flags go in here.
+  const argv = ["-p", "--output-format", "json", "--skip-onboarding", "--no-auto-update", "-t"];
+  if (opts.readOnly) {
+    // No --yolo: the write, edit, and shell tools stay withheld. Plan mode is the
+    // CLI's own name for read-only and makes the intent visible in its transcript.
+    argv.push("--permission-mode", "plan");
+  } else {
+    // The only headless setting that enables edits. --permission-mode auto-accept and
+    // --tools-all do not lift the gate; verified against cmd 1.26.0.
+    argv.push("--yolo");
+    if (opts.toolsAll) argv.push("--tools-all");
+  }
+  if (opts.session) argv.push("--resume", opts.session);
+  else if (opts.continueLast) argv.push("--continue");
+  if (opts.model) argv.push("-m", opts.model);
+  if (opts.effort !== null) argv.push("--effort", opts.effort);
+  if (opts.maxTurns !== null) argv.push("--max-turns", String(opts.maxTurns));
+  return argv;
+}
+
+/**
+ * Command Code streams NDJSON: `{"type":"event",…}` lines, then one
+ * `{"type":"result",…}` line carrying finalText, sessionId, subtype, stopReason,
+ * and usage. The last result line wins; a sessionId on any line is a fallback for
+ * runs that die before the result line lands.
+ */
+function scanEventLine(line, state) {
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    return; // progress noise, or a partial line; events.jsonl keeps it either way
+  }
+  if (typeof event?.sessionId === "string" && event.sessionId) state.sessionId = event.sessionId;
+  const nested = event?.event?.result?.nextState?.sessionId;
+  if (typeof nested === "string" && nested) state.sessionId = nested;
+  if (event?.type !== "result") return;
+  state.result = {
+    subtype: typeof event.subtype === "string" ? event.subtype : null,
+    stopReason: typeof event.stopReason === "string" ? event.stopReason : null,
+    usage: event.usage ?? null,
+    durationMs: Number.isFinite(event.durationMs) ? event.durationMs : null,
+    finalText: typeof event.finalText === "string" ? event.finalText : "",
+    error: typeof event.error === "string" ? event.error : null,
+  };
+}
+
+function recordEventLine(eventsPath, line, state) {
+  appendFileSync(eventsPath, `${line}\n`, "utf8");
+  scanEventLine(line, state);
+}
+
+/** The relay's own files, excluded from the read-only tripwire: --out-dir may sit inside the repo. */
+function relayArtifacts(run) {
+  return [run.briefPath, run.eventsPath, run.finalPath, run.resultPath];
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only Command Code's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    eventsPath: join(outDir, "events.jsonl"),
+    finalPath: join(outDir, "final.txt"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run, beforeTree, beforeFingerprints) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary. It also owns the
+  // read-only verdict, so every outcome path — completed, failed, timeout,
+  // aborted — gets a freshly measured one without threading it through.
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      workdir: opts.cd,
+      readOnly: opts.readOnly,
+      autonomy: opts.readOnly ? "plan (write/edit/shell withheld)" : "--yolo (all permissions bypassed)",
+      toolsAll: opts.readOnly ? false : opts.toolsAll,
+      model: opts.model,
+      effort: opts.effort,
+      maxTurns: opts.maxTurns === null ? null : Number(opts.maxTurns),
+      session: opts.session,
+      continueLast: opts.continueLast,
+      cleanEnv: opts.cleanEnv,
+      keepEnv: opts.keepEnv,
+      commandCodeVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      eventsPath: run.eventsPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      // Absent on write-capable runs would read as "not checked"; null says the
+      // question does not apply, and only --read-only replaces it with a verdict.
+      readOnlyViolation: null,
+      ...extra,
+    };
+    if (opts.readOnly) {
+      result.readOnlyViolation = readOnlyVerdict(
+        beforeTree,
+        gitTripwireState(opts.cd, relayArtifacts(run)),
+        beforeFingerprints,
+      );
+    }
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "commandcode_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    resultSubtype: null,
+    stopReason: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write(`relay: \`${BIN}\` not found on PATH. Install Command Code, run \`cmd login\`, or point COMMANDCODE_BIN at the binary.\n`);
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `${BIN} --version preflight timed out after ${probeTimeoutMs}ms; Command Code was not dispatched`
+    : `${BIN} --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Command Code was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    resultSubtype: null,
+    stopReason: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToCommandCode(opts, brief, run, writeResult, env) {
+  const argv = buildArgv(opts);
+  // detached on POSIX: the child leads a new process group so killChild can fell the whole tree.
+  const child = spawn(BIN, argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: false, detached: process.platform !== "win32", env });
+
+  const state = { sessionId: null, result: null };
+  let stdoutBuf = "";
+  const stderrTail = [];
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    stdoutBuf += stdoutDecoder.write(chunk);
+    let nl;
+    while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+      const line = stdoutBuf.slice(0, nl);
+      stdoutBuf = stdoutBuf.slice(nl + 1);
+      if (!line.trim()) continue;
+      recordEventLine(run.eventsPath, line, state);
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk); // surface Command Code progress live for the orchestrator
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  // Command Code has no -o flag, so the final report only exists inside the NDJSON
+  // result line; the relay writes final.txt itself once that line arrives.
+  const persistFinal = () => {
+    const text = state.result?.finalText ?? "";
+    if (!text) return "";
+    writeFileSync(run.finalPath, `${text}\n`, "utf8");
+    return text.trim();
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the cmd child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const touched = gitTouchedFiles(opts.cd);
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: state.sessionId,
+        resultSubtype: state.result?.subtype ?? null,
+        stopReason: state.result?.stopReason ?? null,
+        usage: state.result?.usage ?? null,
+        finalMessage: persistFinal(),
+        touchedFiles: touched,
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; cmd was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        const late = gitTouchedFiles(opts.cd);
+        writeResult({ ...abortedFields, touchedFiles: late });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const touched = gitTouchedFiles(opts.cd);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId: state.sessionId,
+      resultSubtype: null,
+      stopReason: null,
+      usage: null,
+      finalMessage: "",
+      touchedFiles: touched,
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    if (stdoutBuf.trim()) recordEventLine(run.eventsPath, stdoutBuf, state);
+    const finalMessage = persistFinal();
+    // Command Code can exit 0 with its own result line reporting an error or a turn
+    // cap; a clean process exit is not a completed task. No result line at all means
+    // the stream never got there — also not a completion.
+    const cliOk = code === 0 && state.result !== null && state.result.subtype === "success";
+    const succeeded = cliOk && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const touched = gitTouchedFiles(opts.cd);
+    const cliError = state.result?.error
+      ? `Command Code reported ${state.result.subtype ?? "an error"}: ${state.result.error}`
+      : code === 0 && !cliOk
+        ? state.result === null
+          ? "Command Code exited 0 without a result line; the run ended before it reported"
+          : `Command Code exited 0 but reported subtype "${state.result.subtype}" (stopReason ${state.result.stopReason ?? "unknown"})`
+        : null;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      sessionId: state.sessionId,
+      resultSubtype: state.result?.subtype ?? null,
+      stopReason: state.result?.stopReason ?? null,
+      usage: state.result?.usage ?? null,
+      durationMs: state.result?.durationMs ?? null,
+      finalMessage,
+      touchedFiles: touched,
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired
+        ? { error: `cmd did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` }
+        : cliError
+          ? { error: cliError }
+          : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+
+  // If the child failed to launch, writing to its stdin can emit a stray 'error'
+  // on the pipe; the 'error' handler above owns that outcome, so swallow it here.
+  // Command Code caps its wait for piped stdin at 30s, so the brief goes in at once.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  // Both baselines are taken before anything is dispatched, and only for a read-only run:
+  // the tripwire compares against the tree as it stood at dispatch, not as it stands now.
+  const beforeTree = opts.readOnly ? gitTripwireState(opts.cd, relayArtifacts(run)) : null;
+  const beforeFingerprints = opts.readOnly ? fingerprintDirtyPaths(opts.cd, relayArtifacts(run)) : null;
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const env = commandCodeEnv(opts);
+  const probe = commandCodeVersion(probeTimeoutMs, env);
+  const writeResult = makeResultWriter(opts, probe.version, run, beforeTree, beforeFingerprints);
+
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+
+  dispatchToCommandCode(opts, brief, run, writeResult, env);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  cmd ${result.commandCodeVersion ?? "?"}`);
+  const hint = EXIT_HINTS.get(result.exitCode);
+  if (hint && result.status === "failed") lines.push(`hint: ${hint}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a Command Code error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated cmd (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  lines.push(`autonomy: ${result.autonomy}`);
+  if (result.continueLast) lines.push("mode: continued most recent session");
+  if (result.session) lines.push(`mode: resumed session ${result.session}`);
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId})`);
+  if (result.resultSubtype && result.resultSubtype !== "success") {
+    lines.push(`Command Code result: ${result.resultSubtype}${result.stopReason ? ` (stopReason ${result.stopReason})` : ""}`);
+  }
+  if (result.readOnly) {
+    lines.push(result.readOnlyViolation === null
+      ? "read-only check: not verifiable (git could not report) — inspect the working tree directly"
+      : result.readOnlyViolation
+        ? "read-only check: FAILED — the tree changed beyond this relay's artifacts; treat the run as write-capable and review the diff"
+        : "read-only check: clean — no tree changes beyond this relay's artifacts");
+  }
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- Command Code final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/delegate-setup/references/schema.md
+++ b/skills/delegate-setup/references/schema.md
@@ -49,6 +49,7 @@ later-edited project config fails closed until it is reviewed and written again 
 | `claude` | claude-delegate | `claude` | model, effort, timeout, readOnly |
 | `cline` | cline-delegate | `cline` | provider, model, timeout |
 | `codex` | codex-delegate | `codex` | model, effort, sandbox, timeout, readOnly |
+| `commandcode` | commandcode-delegate | `cmd` | model, effort, timeout, readOnly |
 | `opencode` | opencode-delegate | `opencode` | model, **variant**, timeout, readOnly |
 | `agy` | agy-delegate | `agy` | model, effort, timeout, readOnly |
 | `grok` | grok-delegate | `grok` | model, effort, sandbox, timeout, readOnly |

--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -231,7 +231,10 @@ function validateDialValue(implementer, field, value, laneName, label) {
     if (implementer === "omp" && !OMP_THINKING.includes(value)) {
       return `${label}: lane ${laneName}.effort must be one of: ${OMP_THINKING.join(", ")}`;
     }
-    if ((implementer === "codex" || implementer === "grok") && !/^[a-z][a-z0-9-]*$/i.test(value)) {
+    if (
+      (implementer === "codex" || implementer === "grok" || implementer === "commandcode") &&
+      !/^[a-z][a-z0-9-]*$/i.test(value)
+    ) {
       return `${label}: lane ${laneName}.effort must be a bare token`;
     }
     return null;
@@ -284,6 +287,7 @@ function validateModelOrProvider(implementer, field, value, laneName, label) {
     implementer === "pi" ||
     implementer === "omp" ||
     implementer === "opencode" ||
+    implementer === "commandcode" ||
     // codex (and any other win32 shell:true relay) must not accept cmd metacharacters in -m.
     implementer === "codex" ||
     IMPLEMENTER_BY_KEY[implementer]?.winShell

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -105,6 +105,7 @@ function expandCandidate(raw) {
 function resolveLaunch(impl) {
   if (impl.key === "commandcode" && process.env.COMMANDCODE_BIN) {
     const configured = process.env.COMMANDCODE_BIN;
+    if (process.platform === "win32" && !/[\\/]/.test(configured) && /^cmd(?:\.exe)?$/i.test(configured)) return null;
     const command = /[\\/]/.test(configured) ? resolve(configured) : resolveBinary(configured);
     if (!command || (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(command))) return null;
     try {

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -103,10 +103,10 @@ function expandCandidate(raw) {
  * carries the bundle path when a launcher (node) runs it.
  */
 function resolveLaunch(impl) {
-  if (process.platform === "win32" && impl.key === "commandcode") {
-    if (!process.env.COMMANDCODE_BIN) return null;
-    const command = resolve(process.env.COMMANDCODE_BIN);
-    if (/\.(?:cmd|bat)$/i.test(command)) return null;
+  if (impl.key === "commandcode" && process.env.COMMANDCODE_BIN) {
+    const configured = process.env.COMMANDCODE_BIN;
+    const command = /[\\/]/.test(configured) ? resolve(configured) : resolveBinary(configured);
+    if (!command || (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(command))) return null;
     try {
       if (statSync(command).isFile()) return { path: command, command, prefixArgs: [] };
     } catch {
@@ -114,6 +114,7 @@ function resolveLaunch(impl) {
     }
     return null;
   }
+  if (process.platform === "win32" && impl.key === "commandcode") return null;
   const onPath = resolveBinary(impl.binary);
   if (onPath) return { path: onPath, command: onPath, prefixArgs: [] };
   const candidates = impl.locate?.candidates?.[process.platform] ?? [];

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -16,9 +16,9 @@
  */
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { accessSync, constants as fsConstants, readdirSync, readFileSync, statSync } from "node:fs";
+import { accessSync, constants as fsConstants, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { delimiter, join, resolve, sep } from "node:path";
+import { delimiter, isAbsolute, join, resolve, sep } from "node:path";
 import { IMPLEMENTERS } from "./implementers.mjs";
 
 const PROBE_TIMEOUT_MS = 10_000;
@@ -105,10 +105,16 @@ function expandCandidate(raw) {
 function resolveLaunch(impl) {
   if (impl.key === "commandcode" && process.env.COMMANDCODE_BIN) {
     const configured = process.env.COMMANDCODE_BIN;
-    if (process.platform === "win32" && !/[\\/]/.test(configured) && /^cmd(?:\.exe)?$/i.test(configured)) return null;
+    if (process.platform === "win32" && !isAbsolute(configured)) return null;
     const command = /[\\/]/.test(configured) ? resolve(configured) : resolveBinary(configured);
     if (!command || (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(command))) return null;
     try {
+      const comspec = process.env.ComSpec || process.env.COMSPEC;
+      if (
+        process.platform === "win32" &&
+        comspec &&
+        realpathSync.native(command).toLowerCase() === realpathSync.native(comspec).toLowerCase()
+      ) return null;
       if (statSync(command).isFile()) return { path: command, command, prefixArgs: [] };
     } catch {
       // report it missing below

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -106,6 +106,7 @@ function resolveLaunch(impl) {
   if (process.platform === "win32" && impl.key === "commandcode") {
     if (!process.env.COMMANDCODE_BIN) return null;
     const command = resolve(process.env.COMMANDCODE_BIN);
+    if (/\.(?:cmd|bat)$/i.test(command)) return null;
     try {
       if (statSync(command).isFile()) return { path: command, command, prefixArgs: [] };
     } catch {

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -217,6 +217,12 @@ function parseModelLines(raw, format) {
     identifiers = lines
       .filter((line) => line.startsWith("* "))
       .map((line) => line.slice(2).replace(/\s*\(default\)$/, "").trim());
+  } else if (format === "commandcode") {
+    // "vendor/name  description" rows, grouped under plain-text section headers and a
+    // count line. A slash in the first column is what separates a model row from those.
+    identifiers = lines
+      .map((line) => line.split(/\s+/, 1)[0])
+      .filter((first) => first.includes("/"));
   } else if (format === "table") {
     identifiers = lines
       .slice(1)

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -30,7 +30,7 @@
  *     missMeansFalse?: boolean,
  *   },
  *   modelProbe: null
- *     | { args: string[], format: "lines"|"cursor"|"grok"|"table" }
+ *     | { args: string[], format: "lines"|"cursor"|"grok"|"table"|"commandcode" }
  *     | { envDir: string, homeSubdir: string, file: string, format: "codex-cache" }
  *     | { static: readonly string[] },
  *   usageProbe: null | {
@@ -108,6 +108,30 @@ export const IMPLEMENTERS = Object.freeze([
     },
     supports: ["model", "effort", "sandbox", "timeout", "readOnly"],
     winShell: true,
+  },
+  {
+    key: "commandcode",
+    skill: "commandcode-delegate",
+    // Command Code's binary; on Windows the name is cmd.exe, so its relay requires
+    // COMMANDCODE_BIN and discovery here can only report what PATH resolves to.
+    binary: "cmd",
+    versionArgs: ["--version"],
+    authProbe: { args: ["status"], successPattern: /Authenticated/i, failPattern: /not authenticated|logged out/i },
+    // Must stay a flag: `cmd models` would be read as a prompt. --list-models prints
+    // "vendor/name  description" rows under section headers.
+    modelProbe: { args: ["--list-models"], format: "commandcode" },
+    // projects/<project-slug>/<session-uuid>.jsonl, with a sibling
+    // <session-uuid>.checkpoints.jsonl that must not count as a second session.
+    usageProbe: {
+      homeSubdir: ".commandcode",
+      path: ["projects", "*"],
+      entry: "file",
+      match: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i,
+    },
+    // No sandbox or permissionMode dial: headless Command Code has only the withheld-tools
+    // default and --yolo, and --permission-mode does not change either.
+    supports: ["model", "effort", "timeout", "readOnly"],
+    winShell: false,
   },
   {
     key: "opencode",

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -423,7 +423,7 @@ export const MODEL_TOKEN = Object.freeze({
   claude: /^[A-Za-z0-9][A-Za-z0-9._:@\/\[\]-]*$/,
   /** Keep in lockstep with cursor-delegate SAFE_MODEL. */
   cursor: /^[A-Za-z0-9][A-Za-z0-9._:@\/\[\]\,=-]*$/,
-  /** Keep in lockstep with grok/pi/codex shell-safe tokens (also used for opencode). */
+  /** Keep in lockstep with grok/pi/codex/commandcode shell-safe tokens (also used for opencode). */
   shellSafe: /^[A-Za-z0-9][A-Za-z0-9._:\/-]*$/,
 });
 

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -193,6 +193,7 @@ if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
   "commandcode-unfinished",
   "commandcode-read-only-clean",
   "commandcode-read-only-append",
+  "commandcode-truncated-tail",
 ].includes(process.env.SMOKE_MODE)) {
   let brief = "";
   process.stdin.setEncoding("utf8");
@@ -203,13 +204,37 @@ if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
       fs.appendFileSync(process.env.SMOKE_APPEND_FILE ?? "already-dirty.txt", "appended by fake commandcode\n");
     }
     if (process.env.SMOKE_ARGS_FILE) fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify({ args, brief, cwd: process.cwd() }));
-    console.log(JSON.stringify({ type: "event", event: { type: "turn_end", turnNumber: 1, hadToolCalls: true } }));
+    // Blocking writes in the truncated case, so the cut tail is the only thing under test:
+    // an async write followed by process.exit would drop these earlier lines too, which is
+    // the CLI bug itself rather than the parsing contract this case exists to pin.
+    const emit = process.env.SMOKE_MODE === "commandcode-truncated-tail"
+      ? (value) => fs.writeSync(1, `${JSON.stringify(value)}\n`)
+      : (value) => console.log(JSON.stringify(value));
+    // The session id arrives on the FIRST line, and the report in a message_end, both well
+    // before the oversized tail — which is why the relay reads them from here.
+    emit({ type: "event", event: { type: "run_start", sessionId: "commandcode-session-1" } });
+    emit({
+      type: "event",
+      event: {
+        type: "message_end",
+        content: [{ type: "text", text: unfinished ? "ran out of turns partway" : "fake commandcode completed" }],
+      },
+    });
+    emit({ type: "event", event: { type: "turn_end", turnNumber: 1, hadToolCalls: true } });
+    if (process.env.SMOKE_MODE === "commandcode-truncated-tail") {
+      // What cmd does on a real run: an oversized run_end cut mid-write, and no result
+      // line after it. writeSync so the cut is the only thing under test — an async write
+      // followed by process.exit would drop the earlier lines too, which is the CLI bug
+      // itself rather than the parsing contract this case is here to pin.
+      fs.writeSync(1, `{"type":"event","event":{"type":"run_end","result":{"nextState":{"blob":"${"y".repeat(4096)}`);
+      process.exit(0);
+    }
     // run_end carries the session id nested, as the real CLI does; the result line repeats it.
-    console.log(JSON.stringify({
+    emit({
       type: "event",
       event: { type: "run_end", result: { nextState: { sessionId: "commandcode-session-1" } } },
-    }));
-    console.log(JSON.stringify({
+    });
+    emit({
       type: "result",
       subtype: unfinished ? "max_turns" : "success",
       sessionId: "commandcode-session-1",
@@ -217,7 +242,7 @@ if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
       usage: { inputTokens: 7, outputTokens: 2, cacheReadTokens: 1, cacheWriteTokens: 0 },
       durationMs: 42,
       finalText: unfinished ? "ran out of turns partway" : "fake commandcode completed",
-    }));
+    });
     // The real CLI exits 0 for a clean run even when the task did not finish.
     process.exit(0);
   });

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -19,6 +19,9 @@ const versionProbe = args.includes("--version") || args[0] === "version" || args
 if (versionProbe && process.env.SMOKE_PREFLIGHT_ENV_FILE) {
   fs.writeFileSync(process.env.SMOKE_PREFLIGHT_ENV_FILE, JSON.stringify(capturedEnv()));
 }
+if (versionProbe && process.env.SMOKE_PREFLIGHT_PID_FILE) {
+  fs.writeFileSync(process.env.SMOKE_PREFLIGHT_PID_FILE, String(process.pid));
+}
 if (versionProbe && process.env.SMOKE_MODE === "grok-spawn-error" && process.platform !== "win32") {
   fs.renameSync(require("node:path").join(__dirname, "grok"), require("node:path").join(__dirname, "grok.removed"));
   console.log("fake-cli 0.0.0-smoke");

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -188,6 +188,39 @@ if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
     }));
     process.exit(failed ? 1 : 0);
   });
+} else if ([
+  "commandcode-success",
+  "commandcode-unfinished",
+  "commandcode-read-only-clean",
+  "commandcode-read-only-append",
+].includes(process.env.SMOKE_MODE)) {
+  let brief = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => { brief += chunk; });
+  process.stdin.on("end", () => {
+    const unfinished = process.env.SMOKE_MODE === "commandcode-unfinished";
+    if (process.env.SMOKE_MODE === "commandcode-read-only-append") {
+      fs.appendFileSync(process.env.SMOKE_APPEND_FILE ?? "already-dirty.txt", "appended by fake commandcode\n");
+    }
+    if (process.env.SMOKE_ARGS_FILE) fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify({ args, brief, cwd: process.cwd() }));
+    console.log(JSON.stringify({ type: "event", event: { type: "turn_end", turnNumber: 1, hadToolCalls: true } }));
+    // run_end carries the session id nested, as the real CLI does; the result line repeats it.
+    console.log(JSON.stringify({
+      type: "event",
+      event: { type: "run_end", result: { nextState: { sessionId: "commandcode-session-1" } } },
+    }));
+    console.log(JSON.stringify({
+      type: "result",
+      subtype: unfinished ? "max_turns" : "success",
+      sessionId: "commandcode-session-1",
+      stopReason: unfinished ? "max_turns" : "end_turn",
+      usage: { inputTokens: 7, outputTokens: 2, cacheReadTokens: 1, cacheWriteTokens: 0 },
+      durationMs: 42,
+      finalText: unfinished ? "ran out of turns partway" : "fake commandcode completed",
+    }));
+    // The real CLI exits 0 for a clean run even when the task did not finish.
+    process.exit(0);
+  });
 } else if (process.env.SMOKE_MODE === "copilot-success") {
   fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
   console.log(JSON.stringify({ type: "assistant.message", data: { content: "working" }, ephemeral: false }));

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp"];
+export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp", "commandcode"];
 
 export const EXTRA_ARGS = {
   claude: [],
@@ -17,12 +17,20 @@ export const EXTRA_ARGS = {
   aider: [],
   copilot: [],
   warp: [],
+  commandcode: [],
 };
 
 export const WIN = process.platform === "win32";
 
+// commandcode's binary is `cmd`, which IS cmd.exe on Windows — the relay refuses to
+// guess there and requires COMMANDCODE_BIN, so the shim is planted under its own name
+// and pointed at by that variable instead of by PATH (see install-shim).
 export const binaryName = (skill) =>
-  skill === "qoder" ? "qodercli" : skill === "cursor" ? "cursor-agent" : skill === "warp" ? "oz" : skill;
+  skill === "qoder" ? "qodercli"
+    : skill === "cursor" ? "cursor-agent"
+      : skill === "warp" ? "oz"
+        : skill === "commandcode" ? "cmd"
+          : skill;
 
 export const relayPath = (testDir, skill) =>
   join(testDir, "..", "skills", `${skill}-delegate`, "scripts", "relay.mjs");

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -36,6 +36,9 @@ export function installShim(h) {
         // without a shell, so a .cmd shim would never be found the way the real one is.
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "aider.exe"));
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "oz.exe"));
+        // commandcode's relay never uses a shell, so on Windows its binary must be a real
+        // executable — a .cmd stand-in could not be launched the way the real one is.
+        copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "commandcode.exe"));
       } else {
         console.error(`${compiled.stdout ?? ""}${compiled.stderr ?? ""}`);
       }
@@ -50,7 +53,15 @@ export function installShim(h) {
 
   h.briefPath = join(h.scratch, "brief.txt");
   writeFileSync(h.briefPath, "smoke brief: run until killed.");
-  h.baseEnv = { ...process.env, PATH: shimDir + delimiter + process.env.PATH, SMOKE_NODE: process.execPath };
+  // COMMANDCODE_BIN pins the commandcode relay to the fake rather than to whatever `cmd`
+  // PATH would resolve to — mandatory on Windows (cmd.exe), and the honest choice on POSIX
+  // too, where an unrelated `cmd` may exist on the host.
+  h.baseEnv = {
+    ...process.env,
+    PATH: shimDir + delimiter + process.env.PATH,
+    SMOKE_NODE: process.execPath,
+    COMMANDCODE_BIN: join(shimDir, WIN ? "commandcode.exe" : "cmd"),
+  };
 
   const slowWriteHook = join(h.scratch, "slow-result-write.cjs");
   copyFileSync(join(fixturesDir, "slow-result-write.cjs"), slowWriteHook);

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -4,8 +4,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp"];
-const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp", "commandcode"];
+const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok", "commandcode"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],
   ["parseDuration", "function", RELAYS],

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -27,7 +27,7 @@ const SYMBOLS = [
   ["fingerprintDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["changedDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["readOnlyVerdict", "function", READ_ONLY_TRIPWIRE_RELAYS],
-  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "copilot", "cursor", "grok", "kimi", "opencode", "pi", "omp", "qoder", "vibe", "warp", "zcode"]],
+  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "copilot", "cursor", "grok", "kimi", "opencode", "pi", "omp", "qoder", "vibe", "warp", "zcode", "commandcode"]],
   ["makeLineScanner", "function", ["vibe", "copilot"]],
   ["makeEventScanner", "function", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "omp", "qoder", "warp"]],
 ];

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -43,6 +43,27 @@ if (h.WIN) {
     !existsSync(join(outDir, "result.json")));
   console.log("  skip  commandcode dispatch scenarios: native Windows launch is unverified");
   return;
+}
+{
+  const workDir = h.freshRepo("work-reused-out-dir-commandcode");
+  const outDir = join(h.scratch, "out-reused-commandcode");
+  const resultPath = join(outDir, "result.json");
+  const finalPath = join(outDir, "final.txt");
+  mkdirSync(outDir);
+  writeFileSync(resultPath, "{\"status\":\"stale\"}\n");
+  writeFileSync(finalPath, "stale report\n");
+  const child = spawn(process.execPath, [
+    h.relayPath("commandcode"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--timeout", "5s",
+  ], { env: { ...h.baseEnv, SMOKE_MODE: "commandcode-version-hang" }, stdio: "ignore" });
+  h.check("commandcode reused out-dir: stale terminal artifacts disappear before completion",
+    await h.until(() => !existsSync(resultPath) && !existsSync(finalPath), 4_000));
+  const exitCode = await new Promise((resolve) => child.on("close", resolve));
+  h.check("commandcode reused out-dir: current run publishes its own terminal result",
+    exitCode === 124 && h.result(outDir).status === "timeout");
 }
 for (const scenario of [
   { name: "default", relayArgs: [], forwarded: [...CONSTANT, "--yolo"], readOnly: false, toolsAll: false },

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
 
 // Every dispatch carries these, in this order: JSON output is what makes the run
 // machine-readable, and the other three keep an automated run from stalling on
@@ -41,6 +41,23 @@ if (h.WIN) {
     guarded.status === 2 &&
     /COMMANDCODE_BIN/.test(guarded.stderr) &&
     !existsSync(join(outDir, "result.json")));
+  const comspec = h.baseEnv.ComSpec || h.baseEnv.COMSPEC;
+  for (const [name, commandCodeBin] of [
+    ["bare cmd", "cmd"],
+    ...(comspec ? [["COMSPEC", comspec]] : []),
+  ]) {
+    const rejectedOutDir = join(h.scratch, `out-win-${name.toLowerCase().replaceAll(" ", "-")}-commandcode`);
+    const rejected = spawnSync(process.execPath, [
+      h.relayPath("commandcode"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", rejectedOutDir,
+    ], { env: { ...h.baseEnv, COMMANDCODE_BIN: commandCodeBin }, encoding: "utf8", timeout: 5_000 });
+    h.check(`commandcode windows guard: rejects ${name}`,
+      rejected.status === 2 &&
+      /COMMANDCODE_BIN/.test(rejected.stderr) &&
+      !existsSync(join(rejectedOutDir, "result.json")));
+  }
   console.log("  skip  commandcode dispatch scenarios: native Windows launch is unverified");
   return;
 }
@@ -64,6 +81,34 @@ if (h.WIN) {
   const exitCode = await new Promise((resolve) => child.on("close", resolve));
   h.check("commandcode reused out-dir: current run publishes its own terminal result",
     exitCode === 124 && h.result(outDir).status === "timeout");
+}
+{
+  const commandCodeBin = `./${relative(process.cwd(), h.baseEnv.COMMANDCODE_BIN)}`;
+  const { run, captured } = dispatch(h, "relative-commandcode-bin", [], { COMMANDCODE_BIN: commandCodeBin });
+  h.check("commandcode relative COMMANDCODE_BIN: preflight and dispatch use the same executable",
+    run.status === 0 && captured.brief.includes("smoke brief"));
+}
+{
+  const workDir = h.freshRepo("work-private-artifacts-commandcode");
+  const run = spawnSync(process.execPath, [
+    h.relayPath("commandcode"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+  ], { env: { ...h.baseEnv, SMOKE_MODE: "commandcode-success" }, encoding: "utf8" });
+  const resultPath = /^result: (.+)$/m.exec(run.stdout)?.[1];
+  const runResult = resultPath && existsSync(resultPath)
+    ? JSON.parse(readFileSync(resultPath, "utf8"))
+    : null;
+  const outDir = resultPath ? dirname(resultPath) : null;
+  const artifactPaths = runResult
+    ? [runResult.briefPath, runResult.eventsPath, runResult.finalPath, resultPath]
+    : [];
+  h.check("commandcode default artifacts: directory and files are private",
+    run.status === 0 &&
+    outDir !== null &&
+    (statSync(outDir).mode & 0o777) === 0o700 &&
+    artifactPaths.every((path) => path && (statSync(path).mode & 0o777) === 0o600));
+  if (outDir) rmSync(outDir, { recursive: true, force: true });
 }
 for (const scenario of [
   { name: "default", relayArgs: [], forwarded: [...CONSTANT, "--yolo"], readOnly: false, toolsAll: false },

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -264,19 +264,28 @@ if (!h.WIN) {
 {
   const workDir = h.freshRepo("work-unavailable-commandcode");
   const outDir = join(h.scratch, "out-unavailable-commandcode");
+  const victimPath = join(workDir, "victim.txt");
+  writeFileSync(victimPath, "tracked victim\n");
+  spawnSync("git", ["-C", workDir, "add", "victim.txt"]);
+  const victimCommitted = spawnSync("git", ["-C", workDir, "-c", "user.name=Smoke", "-c", "user.email=smoke@example.invalid", "commit", "-qm", "fixture"]).status === 0;
   mkdirSync(outDir);
   writeFileSync(join(outDir, "result.json"), "{\"status\":\"stale\"}\n");
+  symlinkSync(victimPath, join(outDir, "brief.txt"));
   const missing = spawnSync(process.execPath, [
     h.relayPath("commandcode"),
     "--brief", h.briefPath,
     "--cd", workDir,
     "--out-dir", outDir,
+    "--read-only",
   ], {
-    // No PATH and no COMMANDCODE_BIN: the binary genuinely cannot be found.
-    env: { ...process.env, PATH: "", COMMANDCODE_BIN: "" },
+    // Keep git available for the read-only verdict while naming a missing CLI directly.
+    env: { ...h.baseEnv, COMMANDCODE_BIN: join(h.scratch, "missing-commandcode") },
     encoding: "utf8",
   });
+  const value = h.result(outDir);
   h.check("commandcode unavailable: structured result replaces the stale one",
-    missing.status === 127 && h.result(outDir).status === "commandcode_unavailable");
+    missing.status === 127 && value.status === "commandcode_unavailable");
+  h.check("commandcode read-only brief symlink: tracked target is untouched and the clean verdict is truthful",
+    victimCommitted && readFileSync(victimPath, "utf8") === "tracked victim\n" && value.readOnlyViolation === false);
 }
 }

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -235,6 +235,30 @@ for (const [mode, expectedStatus, expectedExit, timeout] of [
     value.error?.includes("version preflight") &&
     value.error?.includes("was not dispatched"));
 }
+if (!h.WIN) {
+  const workDir = h.freshRepo("work-abort-preflight-commandcode");
+  const outDir = join(h.scratch, "out-abort-preflight-commandcode");
+  const preflight = h.runRelay("commandcode", workDir, outDir, [], {
+    SMOKE_MODE: "commandcode-version-hang",
+  });
+  h.check("commandcode preflight abort: run artifacts are prepared",
+    await h.until(() => existsSync(join(outDir, "events.jsonl")), 2000));
+  preflight.kill("SIGTERM");
+  const exited = await new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), 5000);
+    preflight.on("close", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+  const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+  h.check("commandcode preflight abort: result is aborted and dispatch never starts",
+    exited &&
+    value.status === "aborted" &&
+    value.signal === "SIGTERM" &&
+    value.error?.includes("version preflight") &&
+    value.error?.includes("was not dispatched"));
+}
 {
   const workDir = h.freshRepo("work-unavailable-commandcode");
   const outDir = join(h.scratch, "out-unavailable-commandcode");

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -279,15 +279,51 @@ if (!h.WIN) {
   const workDir = h.freshRepo("work-result-temp-symlink-commandcode");
   const outDir = join(h.scratch, "out-result-temp-symlink-commandcode");
   const victimPath = join(h.scratch, "result-temp-victim-commandcode");
+  const preflightPidPath = join(h.scratch, "result-temp-preflight-pid-commandcode");
   writeFileSync(victimPath, "protected\n");
-  const preflight = h.runRelay("commandcode", workDir, outDir, [], { SMOKE_MODE: "commandcode-version-hang" });
+  const preflight = h.runRelay("commandcode", workDir, outDir, [], {
+    SMOKE_MODE: "commandcode-version-hang",
+    SMOKE_PREFLIGHT_PID_FILE: preflightPidPath,
+  });
   h.check("commandcode result temp symlink: run artifacts are prepared",
-    await h.until(() => existsSync(join(outDir, "events.jsonl")), 2_000));
+    await h.until(() => existsSync(join(outDir, "events.jsonl")) && existsSync(preflightPidPath), 2_000));
   symlinkSync(victimPath, `${join(outDir, "result.json")}.${preflight.pid}.tmp`);
-  preflight.kill("SIGTERM");
-  await new Promise((resolve) => preflight.on("close", resolve));
+  chmodSync(outDir, 0o500);
+  try {
+    preflight.kill("SIGTERM");
+    await new Promise((resolve) => preflight.on("close", resolve));
+  } finally {
+    chmodSync(outDir, 0o700);
+  }
   h.check("commandcode result temp symlink: target is not overwritten",
     readFileSync(victimPath, "utf8") === "protected\n");
+  h.check("commandcode result write failure: preflight child is dead",
+    await h.until(() => !h.alive(Number(readFileSync(preflightPidPath, "utf8"))), 5_000));
+}
+if (!h.WIN) {
+  const workDir = h.freshRepo("work-dispatch-result-write-failure-commandcode");
+  const outDir = join(h.scratch, "out-dispatch-result-write-failure-commandcode");
+  const pidPath = join(h.scratch, "dispatch-pid-commandcode");
+  const grandPidPath = join(h.scratch, "dispatch-grandpid-commandcode");
+  const child = h.runRelay("commandcode", workDir, outDir, [], {
+    SMOKE_MODE: "abort",
+    SMOKE_PID_FILE: pidPath,
+    SMOKE_GRAND_PID_FILE: grandPidPath,
+    SMOKE_LATE_FILE: join(workDir, "late-dispatch-result-write-failure.txt"),
+  });
+  h.check("commandcode dispatch result write failure: implementer came up",
+    await h.until(() => existsSync(pidPath) && existsSync(grandPidPath), 5_000));
+  const implementerPid = Number(readFileSync(pidPath, "utf8"));
+  const grandPid = Number(readFileSync(grandPidPath, "utf8"));
+  chmodSync(outDir, 0o500);
+  try {
+    child.kill("SIGTERM");
+    await new Promise((resolve) => child.on("close", resolve));
+  } finally {
+    chmodSync(outDir, 0o700);
+  }
+  h.check("commandcode dispatch result write failure: implementer and subprocess are dead",
+    await h.until(() => !h.alive(implementerPid) && !h.alive(grandPid), 5_000));
 }
 if (!h.WIN) {
   const workDir = h.freshRepo("work-snapshot-abort-commandcode");

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -1,0 +1,172 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Every dispatch carries these, in this order: JSON output is what makes the run
+// machine-readable, and the other three keep an automated run from stalling on
+// onboarding, a trust prompt, or a background self-update.
+const CONSTANT = ["-p", "--output-format", "json", "--skip-onboarding", "--no-auto-update", "-t"];
+
+function dispatch(h, name, relayArgs, env = {}) {
+  const outDir = join(h.scratch, `out-${name}-commandcode`);
+  const workDir = h.freshRepo(`work-${name}-commandcode`);
+  const argsFile = join(h.scratch, `args-${name}-commandcode`);
+  const run = spawnSync(process.execPath, [
+    h.relayPath("commandcode"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    ...relayArgs,
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "commandcode-success", SMOKE_ARGS_FILE: argsFile, ...env },
+    encoding: "utf8",
+  });
+  const captured = existsSync(argsFile) ? JSON.parse(readFileSync(argsFile, "utf8")) : { args: [], brief: "" };
+  return { run, outDir, workDir, captured };
+}
+
+export async function runCommandcode(h) {
+for (const scenario of [
+  { name: "default", relayArgs: [], forwarded: [...CONSTANT, "--yolo"], readOnly: false, toolsAll: false },
+  { name: "read-only", relayArgs: ["--read-only"], forwarded: [...CONSTANT, "--permission-mode", "plan"], readOnly: true, toolsAll: false },
+  { name: "tools-all", relayArgs: ["--tools-all"], forwarded: [...CONSTANT, "--yolo", "--tools-all"], readOnly: false, toolsAll: true },
+  { name: "session", relayArgs: ["--session", "commandcode-session-1"], forwarded: [...CONSTANT, "--yolo", "--resume", "commandcode-session-1"], readOnly: false, toolsAll: false },
+  { name: "continue-last", relayArgs: ["--continue-last"], forwarded: [...CONSTANT, "--yolo", "--continue"], readOnly: false, toolsAll: false },
+  {
+    name: "dials",
+    relayArgs: ["--model", "fake/model", "--effort", "high", "--max-turns", "7"],
+    forwarded: [...CONSTANT, "--yolo", "-m", "fake/model", "--effort", "high", "--max-turns", "7"],
+    readOnly: false,
+    toolsAll: false,
+  },
+  // --tools-all does not lift the headless write gate, so it must not silently imply
+  // a write-capable run when --read-only asked for the opposite.
+  { name: "read-only-wins", relayArgs: ["--read-only", "--tools-all"], forwarded: [...CONSTANT, "--permission-mode", "plan"], readOnly: true, toolsAll: false },
+]) {
+  const { run, outDir, captured } = dispatch(h, scenario.name, scenario.relayArgs);
+  h.check(`commandcode ${scenario.name}: relay exits zero`, run.status === 0);
+  h.check(`commandcode ${scenario.name}: documented argv is exact`,
+    JSON.stringify(captured.args) === JSON.stringify(scenario.forwarded));
+  h.check(`commandcode ${scenario.name}: the brief arrives on stdin, never in argv`,
+    captured.brief.includes("smoke brief") &&
+    !captured.args.some((arg) => arg.includes("smoke brief")));
+  const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+  h.check(`commandcode ${scenario.name}: result line is parsed into the result`,
+    value.status === "completed" &&
+    value.finalMessage === "fake commandcode completed" &&
+    value.sessionId === "commandcode-session-1" &&
+    value.resultSubtype === "success" &&
+    value.stopReason === "end_turn" &&
+    value.usage?.outputTokens === 2 &&
+    value.readOnly === scenario.readOnly &&
+    value.toolsAll === scenario.toolsAll);
+  h.check(`commandcode ${scenario.name}: final.txt holds the report`,
+    value.finalPath === join(outDir, "final.txt") &&
+    readFileSync(join(outDir, "final.txt"), "utf8").trim() === "fake commandcode completed");
+}
+// A clean exit with an unfinished task is a failure, not a completion: Command Code
+// exits 0 for a run that stopped at the turn cap or refused every write.
+{
+  const { run, outDir } = dispatch(h, "unfinished", [], { SMOKE_MODE: "commandcode-unfinished" });
+  const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+  h.check("commandcode unfinished: relay exits non-zero despite cmd exit 0", run.status === 1);
+  h.check("commandcode unfinished: result reports failed and names the subtype",
+    value.status === "failed" &&
+    value.resultSubtype === "max_turns" &&
+    value.stopReason === "max_turns" &&
+    value.error?.includes("max_turns") &&
+    value.finalMessage === "ran out of turns partway");
+}
+// The read-only guarantee is the CLI's permission layer, not a sandbox, so the relay
+// proves it after the fact — both directions.
+{
+  const { outDir } = dispatch(h, "read-only-clean", ["--read-only"]);
+  h.check("commandcode read-only clean: no violation on an untouched tree",
+    h.result(outDir).readOnlyViolation === false);
+}
+{
+  const { outDir } = dispatch(h, "read-only-write", ["--read-only"], { SMOKE_WRITE_FILE: "sneaked.txt" });
+  h.check("commandcode read-only write: a tree change is reported as a violation",
+    h.result(outDir).readOnlyViolation === true);
+}
+{
+  const { outDir } = dispatch(h, "write-capable", []);
+  h.check("commandcode write-capable: the read-only question does not apply",
+    h.result(outDir).readOnlyViolation === null);
+}
+// Usage errors: exit 2, a named cause, and no result.json — nothing was dispatched.
+for (const [name, args, pattern] of [
+  ["invalid effort", ["--effort", "very fast"], /invalid --effort/],
+  ["invalid max-turns", ["--max-turns", "0"], /invalid --max-turns/],
+  ["invalid model", ["--model", "a b;c"], /--model contains unsupported characters/],
+  ["session conflict", ["--session", "abc", "--continue-last"], /mutually exclusive/],
+  ["keep-env without clean-env", ["--keep-env", "PATH"], /--keep-env requires --clean-env/],
+]) {
+  const workDir = h.freshRepo(`work-${name.replace(/\s+/g, "-")}-commandcode`);
+  const outDir = join(h.scratch, `out-${name.replace(/\s+/g, "-")}-commandcode`);
+  const bad = spawnSync(process.execPath, [
+    h.relayPath("commandcode"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    ...args,
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check(`commandcode ${name}: exits 2 before dispatch`,
+    bad.status === 2 && pattern.test(bad.stderr) && !existsSync(join(outDir, "result.json")));
+}
+for (const [mode, expectedStatus, expectedExit, timeout] of [
+  ["commandcode-version-hang", "timeout", 124, "1s"],
+  // No 1s cap on the failure case: the probe is expected to exit on its own, and under a
+  // loaded suite a 1s bound turns a slow-starting fake into a timeout instead.
+  ["commandcode-version-fail", "failed", 7, "30s"],
+]) {
+  const workDir = h.freshRepo(`work-${mode}`);
+  const outDir = join(h.scratch, `out-${mode}`);
+  const preflight = spawnSync(process.execPath, [
+    h.relayPath("commandcode"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--timeout", timeout,
+  ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 15_000 });
+  const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+  h.check(`commandcode preflight: ${mode} is explicit and prevents dispatch`,
+    preflight.status === expectedExit &&
+    value.status === expectedStatus &&
+    value.error?.includes("version preflight") &&
+    value.error?.includes("was not dispatched"));
+}
+{
+  const workDir = h.freshRepo("work-unavailable-commandcode");
+  const outDir = join(h.scratch, "out-unavailable-commandcode");
+  mkdirSync(outDir);
+  writeFileSync(join(outDir, "result.json"), "{\"status\":\"stale\"}\n");
+  const missing = spawnSync(process.execPath, [
+    h.relayPath("commandcode"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+  ], {
+    // No PATH and no COMMANDCODE_BIN: the binary genuinely cannot be found.
+    env: { ...process.env, PATH: "", COMMANDCODE_BIN: "" },
+    encoding: "utf8",
+  });
+  h.check("commandcode unavailable: structured result replaces the stale one",
+    missing.status === 127 && h.result(outDir).status === "commandcode_unavailable");
+}
+if (h.WIN) {
+  // The binary name IS the shell there, so guessing is refused outright.
+  const workDir = h.freshRepo("work-win-guard-commandcode");
+  const outDir = join(h.scratch, "out-win-guard-commandcode");
+  const guarded = spawnSync(process.execPath, [
+    h.relayPath("commandcode"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+  ], { env: { ...h.baseEnv, COMMANDCODE_BIN: "" }, encoding: "utf8" });
+  h.check("commandcode windows guard: refuses to run without COMMANDCODE_BIN",
+    guarded.status === 2 &&
+    /COMMANDCODE_BIN/.test(guarded.stderr) &&
+    !existsSync(join(outDir, "result.json")));
+}
+}

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { delimiter, dirname, join, relative } from "node:path";
 
 // Every dispatch carries these, in this order: JSON output is what makes the run
@@ -66,10 +66,8 @@ if (h.WIN) {
   const outDir = join(h.scratch, "out-reused-commandcode");
   const resultPath = join(outDir, "result.json");
   const finalPath = join(outDir, "final.txt");
-  const staleResultPath = join(outDir, "stale-result.json");
   mkdirSync(outDir);
-  writeFileSync(staleResultPath, "{\"status\":\"stale\"}\n");
-  symlinkSync(staleResultPath, resultPath);
+  writeFileSync(resultPath, "{\"schema\":\"delegate-relay.result.v1\"}\n");
   writeFileSync(finalPath, "stale report\n");
   const child = spawn(process.execPath, [
     h.relayPath("commandcode"),
@@ -83,6 +81,46 @@ if (h.WIN) {
   const exitCode = await new Promise((resolve) => child.on("close", resolve));
   h.check("commandcode reused out-dir: current run publishes its own terminal result",
     exitCode === 124 && h.result(outDir).status === "timeout");
+}
+{
+  const workDir = h.freshRepo("work-untrusted-out-dir-commandcode");
+  const outDir = join(h.scratch, "out-untrusted-commandcode");
+  mkdirSync(outDir);
+  const finalPath = join(outDir, "final.txt");
+  writeFileSync(finalPath, "user report\n");
+  const rejected = spawnSync(process.execPath, [
+    h.relayPath("commandcode"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir,
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("commandcode untrusted out-dir: existing artifacts are rejected untouched",
+    rejected.status === 2 && readFileSync(finalPath, "utf8") === "user report\n");
+}
+{
+  const workDir = h.freshRepo("work-result-symlink-commandcode");
+  const outDir = join(h.scratch, "out-result-symlink-commandcode");
+  const victimPath = join(h.scratch, "result-symlink-victim-commandcode");
+  mkdirSync(outDir);
+  writeFileSync(victimPath, "protected\n");
+  const resultPath = join(outDir, "result.json");
+  symlinkSync(victimPath, resultPath);
+  const rejected = spawnSync(process.execPath, [
+    h.relayPath("commandcode"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir,
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("commandcode result symlink: rejects without replacing the link or target",
+    rejected.status === 2 && lstatSync(resultPath).isSymbolicLink() && readFileSync(victimPath, "utf8") === "protected\n");
+}
+{
+  const workDir = h.freshRepo("work-result-case-alias-commandcode");
+  const outDir = join(h.scratch, "out-result-case-alias-commandcode");
+  mkdirSync(outDir);
+  const aliasPath = join(outDir, "RESULT.JSON");
+  writeFileSync(aliasPath, "user result\n");
+  if (existsSync(join(outDir, "result.json"))) {
+    const rejected = spawnSync(process.execPath, [
+      h.relayPath("commandcode"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir,
+    ], { env: h.baseEnv, encoding: "utf8" });
+    h.check("commandcode result case alias: rejects before replacing the alias",
+      rejected.status === 2 && readFileSync(aliasPath, "utf8") === "user result\n");
+  }
 }
 {
   const commandCodeBin = `./${relative(process.cwd(), h.baseEnv.COMMANDCODE_BIN)}`;
@@ -238,6 +276,20 @@ for (const [mode, expectedStatus, expectedExit, timeout] of [
     value.error?.includes("was not dispatched"));
 }
 if (!h.WIN) {
+  const workDir = h.freshRepo("work-result-temp-symlink-commandcode");
+  const outDir = join(h.scratch, "out-result-temp-symlink-commandcode");
+  const victimPath = join(h.scratch, "result-temp-victim-commandcode");
+  writeFileSync(victimPath, "protected\n");
+  const preflight = h.runRelay("commandcode", workDir, outDir, [], { SMOKE_MODE: "commandcode-version-hang" });
+  h.check("commandcode result temp symlink: run artifacts are prepared",
+    await h.until(() => existsSync(join(outDir, "events.jsonl")), 2_000));
+  symlinkSync(victimPath, `${join(outDir, "result.json")}.${preflight.pid}.tmp`);
+  preflight.kill("SIGTERM");
+  await new Promise((resolve) => preflight.on("close", resolve));
+  h.check("commandcode result temp symlink: target is not overwritten",
+    readFileSync(victimPath, "utf8") === "protected\n");
+}
+if (!h.WIN) {
   const workDir = h.freshRepo("work-snapshot-abort-commandcode");
   const outDir = join(h.scratch, "out-snapshot-abort-commandcode");
   const shimDir = join(h.scratch, "slow-git-commandcode");
@@ -302,7 +354,7 @@ if (!h.WIN) {
   spawnSync("git", ["-C", workDir, "add", "victim.txt"]);
   const victimCommitted = spawnSync("git", ["-C", workDir, "-c", "user.name=Smoke", "-c", "user.email=smoke@example.invalid", "commit", "-qm", "fixture"]).status === 0;
   mkdirSync(outDir);
-  writeFileSync(join(outDir, "result.json"), "{\"status\":\"stale\"}\n");
+  writeFileSync(join(outDir, "result.json"), "{\"schema\":\"delegate-relay.result.v1\"}\n");
   symlinkSync(victimPath, join(outDir, "brief.txt"));
   const missing = spawnSync(process.execPath, [
     h.relayPath("commandcode"),

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { delimiter, dirname, join, relative } from "node:path";
 
 // Every dispatch carries these, in this order: JSON output is what makes the run
 // machine-readable, and the other three keep an automated run from stalling on
@@ -236,6 +236,39 @@ for (const [mode, expectedStatus, expectedExit, timeout] of [
     value.status === expectedStatus &&
     value.error?.includes("version preflight") &&
     value.error?.includes("was not dispatched"));
+}
+if (!h.WIN) {
+  const workDir = h.freshRepo("work-snapshot-abort-commandcode");
+  const outDir = join(h.scratch, "out-snapshot-abort-commandcode");
+  const shimDir = join(h.scratch, "slow-git-commandcode");
+  const readyPath = join(h.scratch, "slow-git-ready-commandcode");
+  mkdirSync(shimDir);
+  const realGit = spawnSync("which", ["git"], { env: h.baseEnv, encoding: "utf8" }).stdout.trim();
+  const gitShim = join(shimDir, "git");
+  writeFileSync(gitShim, `#!/bin/sh
+if [ "$1" = status ]; then
+  : > ${JSON.stringify(readyPath)}
+  sleep 1
+fi
+exec ${JSON.stringify(realGit)} "$@"
+`);
+  chmodSync(gitShim, 0o755);
+  const snapshot = h.runRelay("commandcode", workDir, outDir, ["--read-only"], {
+    PATH: `${shimDir}${delimiter}${h.baseEnv.PATH}`,
+  });
+  h.check("commandcode snapshot abort: Git snapshot is in progress",
+    await h.until(() => existsSync(readyPath), 2_000));
+  snapshot.kill("SIGTERM");
+  const exited = await new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), 5_000);
+    snapshot.on("close", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+  const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+  h.check("commandcode snapshot abort: result exists with an unknown read-only verdict",
+    exited && value.status === "aborted" && value.signal === "SIGTERM" && value.readOnlyViolation === null);
 }
 if (!h.WIN) {
   const workDir = h.freshRepo("work-abort-preflight-commandcode");

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 
 // Every dispatch carries these, in this order: JSON output is what makes the run
@@ -66,8 +66,10 @@ if (h.WIN) {
   const outDir = join(h.scratch, "out-reused-commandcode");
   const resultPath = join(outDir, "result.json");
   const finalPath = join(outDir, "final.txt");
+  const staleResultPath = join(outDir, "stale-result.json");
   mkdirSync(outDir);
-  writeFileSync(resultPath, "{\"status\":\"stale\"}\n");
+  writeFileSync(staleResultPath, "{\"status\":\"stale\"}\n");
+  symlinkSync(staleResultPath, resultPath);
   writeFileSync(finalPath, "stale report\n");
   const child = spawn(process.execPath, [
     h.relayPath("commandcode"),

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -55,6 +55,7 @@ for (const scenario of [
     value.status === "completed" &&
     value.finalMessage === "fake commandcode completed" &&
     value.sessionId === "commandcode-session-1" &&
+    value.resultLine === "complete" &&
     value.resultSubtype === "success" &&
     value.stopReason === "end_turn" &&
     value.usage?.outputTokens === 2 &&
@@ -76,6 +77,20 @@ for (const scenario of [
     value.stopReason === "max_turns" &&
     value.error?.includes("max_turns") &&
     value.finalMessage === "ran out of turns partway");
+}
+// cmd embeds the whole transcript in run_end and exits without draining stdout, so the
+// result line is routinely lost. A successful run must survive that, with the loss named.
+{
+  const { run, outDir } = dispatch(h, "truncated-tail", [], { SMOKE_MODE: "commandcode-truncated-tail" });
+  const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+  h.check("commandcode truncated tail: exit 0 is still a completed run", run.status === 0 && value.status === "completed");
+  h.check("commandcode truncated tail: the loss is named, not hidden",
+    value.resultLine === "truncated" &&
+    value.resultSubtype === null &&
+    value.usage === null);
+  h.check("commandcode truncated tail: session id and report survive via the early events",
+    value.sessionId === "commandcode-session-1" &&
+    value.finalMessage === "fake commandcode completed");
 }
 // The read-only guarantee is the CLI's permission layer, not a sandbox, so the relay
 // proves it after the fact — both directions.

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -61,6 +61,16 @@ export function runDelegateSetup(h) {
       commandCode.missing.some(({ key }) => key === "commandcode") &&
         !commandCode.discovered.some(({ key }) => key === "commandcode"),
     );
+    const withBareCmdOverride = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+      encoding: "utf8",
+      env: { ...h.baseEnv, COMMANDCODE_BIN: "cmd" },
+    });
+    const bareCmdOverride = JSON.parse(withBareCmdOverride.stdout);
+    h.check(
+      "discover rejects bare COMMANDCODE_BIN=cmd on Windows",
+      bareCmdOverride.missing.some(({ key }) => key === "commandcode") &&
+        !bareCmdOverride.discovered.some(({ key }) => key === "commandcode"),
+    );
     const withConfiguredCommandCode = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
       encoding: "utf8",
       env: h.baseEnv,

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -55,6 +55,18 @@ export function runDelegateSetup(h) {
       configuredCommandCode.discovered.some(({ key, path }) =>
         key === "commandcode" && path === h.baseEnv.COMMANDCODE_BIN),
     );
+    const commandCodeShim = join(h.scratch, "commandcode.cmd");
+    writeFileSync(commandCodeShim, "@exit /b 0\r\n");
+    const withCommandCodeShim = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+      encoding: "utf8",
+      env: { ...h.baseEnv, COMMANDCODE_BIN: commandCodeShim },
+    });
+    const shimmedCommandCode = JSON.parse(withCommandCodeShim.stdout);
+    h.check(
+      "discover rejects a Command Code .cmd shim that the relay cannot launch",
+      shimmedCommandCode.missing.some(({ key }) => key === "commandcode") &&
+        !shimmedCommandCode.discovered.some(({ key }) => key === "commandcode"),
+    );
   }
 
   const agyProbeDir = join(h.scratch, "discover-agy");

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -34,6 +34,22 @@ export function runDelegateSetup(h) {
         [...h.SKILLS].sort().join(","),
   );
 
+  if (!h.WIN) {
+    const commandCodeOverride = join(h.scratch, "commandcode-override");
+    writeFileSync(commandCodeOverride, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo override-commandcode; exit 0; fi\nexit 1\n");
+    chmodSync(commandCodeOverride, 0o755);
+    const overrideDiscover = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+      encoding: "utf8",
+      env: { ...process.env, PATH: "", COMMANDCODE_BIN: commandCodeOverride },
+    });
+    const overrideReport = JSON.parse(overrideDiscover.stdout);
+    h.check(
+      "discover honors COMMANDCODE_BIN outside Windows",
+      overrideReport.discovered.some(({ key, path, version }) =>
+        key === "commandcode" && path === commandCodeOverride && version === "override-commandcode"),
+    );
+  }
+
   if (h.WIN) {
     const withoutConfiguredCommandCode = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
       encoding: "utf8",

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -61,16 +61,22 @@ export function runDelegateSetup(h) {
       commandCode.missing.some(({ key }) => key === "commandcode") &&
         !commandCode.discovered.some(({ key }) => key === "commandcode"),
     );
-    const withBareCmdOverride = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
-      encoding: "utf8",
-      env: { ...h.baseEnv, COMMANDCODE_BIN: "cmd" },
-    });
-    const bareCmdOverride = JSON.parse(withBareCmdOverride.stdout);
-    h.check(
-      "discover rejects bare COMMANDCODE_BIN=cmd on Windows",
-      bareCmdOverride.missing.some(({ key }) => key === "commandcode") &&
-        !bareCmdOverride.discovered.some(({ key }) => key === "commandcode"),
-    );
+    const comspec = h.baseEnv.ComSpec || h.baseEnv.COMSPEC;
+    for (const [name, commandCodeBin] of [
+      ["bare COMMANDCODE_BIN=cmd", "cmd"],
+      ...(comspec ? [["COMMANDCODE_BIN=COMSPEC", comspec]] : []),
+    ]) {
+      const rejectedOverride = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+        encoding: "utf8",
+        env: { ...h.baseEnv, COMMANDCODE_BIN: commandCodeBin },
+      });
+      const rejectedReport = JSON.parse(rejectedOverride.stdout);
+      h.check(
+        `discover rejects ${name} on Windows`,
+        rejectedReport.missing.some(({ key }) => key === "commandcode") &&
+          !rejectedReport.discovered.some(({ key }) => key === "commandcode"),
+      );
+    }
     const withConfiguredCommandCode = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
       encoding: "utf8",
       env: h.baseEnv,
@@ -330,6 +336,21 @@ if (observation === "models") {
       "config validate rejects shell-unsafe codex model",
       rejectCodexModel.status === 2 && /unsupported characters/.test(rejectCodexModel.stderr),
     );
+    for (const [field, value] of [["model", "a b;c"], ["effort", "very fast"]]) {
+      const badCommandCodeDial = {
+        version: "delegate-fleet.v1",
+        lanes: { feature: { implementer: "commandcode", [field]: value } },
+      };
+      const badCommandCodeDialFile = join(cfgRepo, `bad-commandcode-${field}.json`);
+      writeFileSync(badCommandCodeDialFile, `${JSON.stringify(badCommandCodeDial)}\n`);
+      const rejected = spawnSync(
+        process.execPath,
+        [join(setupDir, "config.mjs"), "validate", badCommandCodeDialFile],
+        { encoding: "utf8", env: process.env },
+      );
+      h.check(`config validate rejects Command Code ${field} tokens the relay would reject`,
+        rejected.status === 2);
+    }
     const unsafeCodexFlag = spawnSync(
       process.execPath,
       [h.relayPath("codex"), "--brief", h.briefPath, "--model", "x & whoami"],

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -17,6 +17,7 @@ import { runAbort } from "./abort.mjs";
 import { runDelegateSetup } from "./delegate-setup.mjs";
 import { runAider } from "./aider.mjs";
 import { runCopilot } from "./copilot.mjs";
+import { runCommandcode } from "./commandcode.mjs";
 
 export const runners = [
   ["package-shape", runPackageShape],
@@ -34,6 +35,7 @@ export const runners = [
   ["claude", runClaude],
   ["aider", runAider],
   ["copilot", runCopilot],
+  ["commandcode", runCommandcode],
   ["read-only-tripwire", runReadOnlyTripwire],
   ["timeout-tree", runTimeoutTree],
   ["abort", runAbort],

--- a/test/relay/read-only-tripwire.mjs
+++ b/test/relay/read-only-tripwire.mjs
@@ -112,9 +112,13 @@ async function runScenario(h, skill, scenario) {
   const expectedExit = skill === "commandcode" && scenario.commandcodeExit !== undefined
     ? scenario.commandcodeExit
     : 0;
+  const expectedResult = skill === "commandcode" && scenario.commandcodeResult !== undefined
+    ? scenario.commandcodeResult
+    : true;
   h.check(`${skill} ${scenario.name}: relay close wait did not time out`, outcome.exited);
   h.check(`${skill} ${scenario.name}: relay exits ${expectedExit}`, outcome.exitCode === expectedExit);
-  h.check(`${skill} ${scenario.name}: result.json exists`, existsSync(join(outDir, "result.json")));
+  h.check(`${skill} ${scenario.name}: result.json ${expectedResult ? "exists" : "is not created"}`,
+    existsSync(join(outDir, "result.json")) === expectedResult);
   if (existsSync(join(outDir, "result.json"))) {
     const verdict = h.result(outDir).readOnlyViolation;
     const expected = skill === "commandcode" && scenario.commandcodeExpected !== undefined
@@ -122,10 +126,10 @@ async function runScenario(h, skill, scenario) {
       : scenario.expected;
     h.check(`${skill} ${scenario.name}: verdict is ${String(expected)} (got ${String(verdict)})`,
       verdict === expected);
-    if (skill === "commandcode" && scenario.artifactSymlink) {
-      h.check("commandcode artifact-symlink-target-write: final report does not overwrite the symlink target",
-        readFileSync(join(workDir, "already-dirty.txt"), "utf8") === "pre-existing\n");
-    }
+  }
+  if (skill === "commandcode" && scenario.artifactSymlink) {
+    h.check("commandcode artifact-symlink-target-write: final report does not overwrite the symlink target",
+      readFileSync(join(workDir, "already-dirty.txt"), "utf8") === "pre-existing\n");
   }
   if (outcome.exitCode !== 0) console.error(`${skill} ${scenario.name} relay stderr:\n${outcome.stderr}`);
 }
@@ -166,11 +170,11 @@ export async function runReadOnlyTripwire(h) {
       caseDistinctUserWrite: true,
       expected: true,
     }] : []),
-    { name: "preexisting-artifact-rename", artifactsInside: true, preexistingArtifactRename: true, expected: false },
+    { name: "preexisting-artifact-rename", artifactsInside: true, preexistingArtifactRename: true, expected: false, commandcodeExit: 2, commandcodeResult: false },
     { name: "artifact-endpoint-rename", artifactsInside: true, artifactEndpointRename: true, expected: true, commandcodeExit: 1 },
     { name: "relay-artifacts-plus-write", artifactsInside: true, dirty: true, expected: true },
     ...(!h.WIN ? [{ name: "raw-symlink-target-write", rawSymlinkTarget: true, expected: true }] : []),
-    ...(!h.WIN ? [{ name: "artifact-symlink-target-write", artifactsInside: true, artifactSymlink: true, expected: true, commandcodeExpected: false }] : []),
+    ...(!h.WIN ? [{ name: "artifact-symlink-target-write", artifactsInside: true, artifactSymlink: true, expected: true, commandcodeExit: 2, commandcodeResult: false }] : []),
   ];
   const tripwireSkills = ["claude", "grok", ...(!h.WIN ? ["commandcode"] : [])];
   if (h.WIN) console.log("  skip  commandcode tripwire scenarios: native Windows launch is unverified");

--- a/test/relay/read-only-tripwire.mjs
+++ b/test/relay/read-only-tripwire.mjs
@@ -109,13 +109,23 @@ async function runScenario(h, skill, scenario) {
     } : {}),
   });
   const outcome = await waitFor(child);
+  const expectedExit = skill === "commandcode" && scenario.commandcodeExit !== undefined
+    ? scenario.commandcodeExit
+    : 0;
   h.check(`${skill} ${scenario.name}: relay close wait did not time out`, outcome.exited);
-  h.check(`${skill} ${scenario.name}: relay exits zero`, outcome.exitCode === 0);
+  h.check(`${skill} ${scenario.name}: relay exits ${expectedExit}`, outcome.exitCode === expectedExit);
   h.check(`${skill} ${scenario.name}: result.json exists`, existsSync(join(outDir, "result.json")));
   if (existsSync(join(outDir, "result.json"))) {
     const verdict = h.result(outDir).readOnlyViolation;
-    h.check(`${skill} ${scenario.name}: verdict is ${String(scenario.expected)} (got ${String(verdict)})`,
-      verdict === scenario.expected);
+    const expected = skill === "commandcode" && scenario.commandcodeExpected !== undefined
+      ? scenario.commandcodeExpected
+      : scenario.expected;
+    h.check(`${skill} ${scenario.name}: verdict is ${String(expected)} (got ${String(verdict)})`,
+      verdict === expected);
+    if (skill === "commandcode" && scenario.artifactSymlink) {
+      h.check("commandcode artifact-symlink-target-write: final report does not overwrite the symlink target",
+        readFileSync(join(workDir, "already-dirty.txt"), "utf8") === "pre-existing\n");
+    }
   }
   if (outcome.exitCode !== 0) console.error(`${skill} ${scenario.name} relay stderr:\n${outcome.stderr}`);
 }
@@ -148,8 +158,8 @@ export async function runReadOnlyTripwire(h) {
     ...(invalidUtf8Filenames ? [{ name: "invalid-utf8-filename", invalidUtf8: true, expected: null }] : []),
     { name: "new-file-in-untracked-directory", untrackedDirectory: true, expected: true },
     { name: "relay-artifacts", artifactsInside: true, expected: false },
-    { name: "case-aliased-relay-artifact", artifactsInside: true, caseAliasedArtifact: true, expected: false },
-    { name: "case-renamed-relay-artifact", artifactsInside: true, caseRenamedArtifact: true, expected: false },
+    { name: "case-aliased-relay-artifact", artifactsInside: true, caseAliasedArtifact: true, expected: false, ...(!caseSensitiveFilenames ? { commandcodeExit: 1 } : {}) },
+    { name: "case-renamed-relay-artifact", artifactsInside: true, caseRenamedArtifact: true, expected: false, ...(!caseSensitiveFilenames ? { commandcodeExit: 1 } : {}) },
     ...(caseSensitiveFilenames ? [{
       name: "case-distinct-user-write",
       artifactsInside: true,
@@ -157,10 +167,10 @@ export async function runReadOnlyTripwire(h) {
       expected: true,
     }] : []),
     { name: "preexisting-artifact-rename", artifactsInside: true, preexistingArtifactRename: true, expected: false },
-    { name: "artifact-endpoint-rename", artifactsInside: true, artifactEndpointRename: true, expected: true },
+    { name: "artifact-endpoint-rename", artifactsInside: true, artifactEndpointRename: true, expected: true, commandcodeExit: 1 },
     { name: "relay-artifacts-plus-write", artifactsInside: true, dirty: true, expected: true },
     ...(!h.WIN ? [{ name: "raw-symlink-target-write", rawSymlinkTarget: true, expected: true }] : []),
-    ...(!h.WIN ? [{ name: "artifact-symlink-target-write", artifactsInside: true, artifactSymlink: true, expected: true }] : []),
+    ...(!h.WIN ? [{ name: "artifact-symlink-target-write", artifactsInside: true, artifactSymlink: true, expected: true, commandcodeExpected: false }] : []),
   ];
   const tripwireSkills = ["claude", "grok", ...(!h.WIN ? ["commandcode"] : [])];
   if (h.WIN) console.log("  skip  commandcode tripwire scenarios: native Windows launch is unverified");

--- a/test/relay/read-only-tripwire.mjs
+++ b/test/relay/read-only-tripwire.mjs
@@ -92,7 +92,9 @@ async function runScenario(h, skill, scenario) {
   const child = h.runRelay(skill, workDir, outDir, ["--read-only"], {
     SMOKE_MODE: skill === "grok"
       ? "grok-read-only"
-      : appendFile ? "claude-read-only-append" : "claude-read-only-clean",
+      : skill === "commandcode"
+        ? (appendFile ? "commandcode-read-only-append" : "commandcode-read-only-clean")
+        : appendFile ? "claude-read-only-append" : "claude-read-only-clean",
     ...(appendFile ? { SMOKE_APPEND_FILE: appendFile } : {}),
     ...(scenario.untrackedDirectory ? { SMOKE_WRITE_FILE: join("loose", "new.txt") } : {}),
     ...(scenario.invalidUtf8 ? { SMOKE_APPEND_INVALID_UTF8: "696e76616c69642dff" } : {}),
@@ -160,7 +162,7 @@ export async function runReadOnlyTripwire(h) {
     ...(!h.WIN ? [{ name: "raw-symlink-target-write", rawSymlinkTarget: true, expected: true }] : []),
     ...(!h.WIN ? [{ name: "artifact-symlink-target-write", artifactsInside: true, artifactSymlink: true, expected: true }] : []),
   ];
-  for (const skill of ["claude", "grok"]) {
+  for (const skill of ["claude", "grok", "commandcode"]) {
     for (const scenario of scenarios) await runScenario(h, skill, scenario);
   }
 

--- a/test/relay/timeout-bounds.mjs
+++ b/test/relay/timeout-bounds.mjs
@@ -28,7 +28,15 @@ for (const skill of h.SKILLS) {
     "--out-dir", join(h.scratch, `out-max-timeout-${skill}`),
     "--timeout", "596h31m23s",
     ...h.EXTRA_ARGS[skill],
-  ], { env: { ...h.baseEnv, PATH: "" }, encoding: "utf8", timeout: 10_000 });
+  ], {
+    env: {
+      ...process.env,
+      PATH: "",
+      ...(skill === "commandcode" ? { COMMANDCODE_BIN: join(h.scratch, "missing-commandcode") } : {}),
+    },
+    encoding: "utf8",
+    timeout: 10_000,
+  });
   h.check(`${skill} timeout: the largest schedulable duration is accepted`, accepted.status !== 2);
 }
 // agy's own --print-timeout carries a 60s grace into the same watchdog, so its ceiling sits

--- a/test/relay/timeout-bounds.mjs
+++ b/test/relay/timeout-bounds.mjs
@@ -28,7 +28,7 @@ for (const skill of h.SKILLS) {
     "--out-dir", join(h.scratch, `out-max-timeout-${skill}`),
     "--timeout", "596h31m23s",
     ...h.EXTRA_ARGS[skill],
-  ], { env: { ...process.env, PATH: "" }, encoding: "utf8", timeout: 10_000 });
+  ], { env: { ...h.baseEnv, PATH: "" }, encoding: "utf8", timeout: 10_000 });
   h.check(`${skill} timeout: the largest schedulable duration is accepted`, accepted.status !== 2);
 }
 // agy's own --print-timeout carries a 60s grace into the same watchdog, so its ceiling sits


### PR DESCRIPTION
Adds a delegate skill for the [Command Code](https://commandcode.ai/docs/headless) CLI (`cmd`). No open claim or PR existed for this implementer when I started — checked both lists per CONTRIBUTING.

## What it is

The usual loop — brief → dispatch → poll → review → commit, with the orchestrator owning the commit. `SKILL.md`, the four references, and one `relay.mjs` (Node built-ins only, never commits).

## What is specific to Command Code

**Headless autonomy has exactly two states, and this is the thing worth reviewing first.** A `-p` run withholds the write, edit, and shell tools; `--yolo` (alias `--dangerously-skip-permissions`) allows every tool with **no filesystem sandbox and no path restriction**. I verified live against `cmd` 1.26.0 that `--permission-mode auto-accept` and `--tools-all` do *not* lift the headless write gate — in both runs `write_file`, `shell_command`, and `edit_file` were all refused, and the CLI's own error names `--yolo` as the only opener. So the relay passes `--yolo` for implementation runs and omits it (adding `--permission-mode plan`) for `--read-only`. The README footnote, `SKILL.md`, and `writing-the-brief.md` all lead with that rather than implying containment the CLI does not provide; the brief's path list is doing the job a sandbox does elsewhere.

**Read-only is the CLI's permission layer, not an OS sandbox**, which puts it in the same class as `claude` and `grok`. Rather than ship a weaker lookalike under the same field name, the relay carries the fingerprint-based tripwire byte-identically from `claude-delegate` and joins `READ_ONLY_TRIPWIRE_RELAYS` in `relay-parity.mjs` plus the full scenario matrix in `read-only-tripwire.mjs` (already-dirty, index-only, symlink retarget, case-aliased artifacts, invalid UTF-8 filenames, submodules — all green).

**No `-o` flag exists**, so the report is lifted from `finalText` on the NDJSON `result` line and the relay writes `final.txt` itself. `sessionId` comes from that line, with the nested `run_end` state as a fallback for runs that die early.

**A zero exit is not a completed task.** `cmd` exits 0 for a run that ended cleanly with the work unfinished — including the case where every write was refused for want of `--yolo`. `status: "completed"` therefore requires exit 0 **and** `subtype: "success"`; anything else is `failed` with the subtype named in `error`. Documented exit codes (3 auth, 5 rate limit, 8 turn cap, 10 credits) become summary hints.

**The binary name collides with Windows `cmd.exe`.** The relay never launches through a shell and refuses to run on win32 unless `COMMANDCODE_BIN` names a real executable (a `.cmd` wrapper cannot start without the shell it refuses). Windows is untested and says so.

## Also included

- `delegate-setup` registration: `cmd status` auth probe, a `--list-models` parser (`vendor/name` rows under section headers; 41 models resolved locally), and the `~/.commandcode/projects/<slug>/<uuid>.jsonl` usage probe with a UUID-anchored match so the sibling `.checkpoints.jsonl` files are not counted as sessions. Dials are `model`/`effort`/`timeout`/`readOnly` — deliberately no `sandbox` or `permissionMode`, since neither changes headless behavior.
- `test/relay/commandcode.mjs`: argv exactness across seven flag combinations, stdin-only brief delivery, result parsing, the unfinished-run mapping, both read-only verdict directions plus the not-applicable case, and five usage-error paths.
- Harness wiring: `COMMANDCODE_BIN` pins the relay to the fake rather than to whatever `cmd` PATH resolves to — mandatory on Windows, and the honest choice on POSIX too.

## Verification

- **Live, macOS, `cmd` 1.26.0:** a `--read-only` dispatch against a throwaway repo returned `status: "completed"`, exit 0, `readOnlyViolation: false`, `resultSubtype: "success"`, session id captured, report extracted. `--help` also exercised.
- **Live autonomy probes:** the three runs behind the `--yolo` claim (default refused, `--tools-all` refused, `--permission-mode auto-accept` refused, `--yolo` wrote the file), plus a `--resume <sessionId>` run against the raw CLI confirming context carries and the id is stable.
- **Contract:** full `node test/relay-smoke.mjs` — every commandcode check green, including the timeout, abort, atomic, preflight, timeout-bounds and tripwire matrices. `node test/relay-parity.mjs` green with commandcode in both lists. `npx skills add . --list` lists the skill.
- **Not yet verified end to end through the relay:** a write-capable edit run and a `--session` rework. Both paths were exercised live against the raw CLI while mapping its contract, and are contract-tested in the smoke module, but I have not put a real implementation task through the relay itself — happy to do that and update this line before merge if you would rather not take it as-is.

Three pre-existing failures (`cursor`/`vibe`/`copilot` "preflight abort") reproduce on clean `master` here and are untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fitv473zK7eawn5jNyQxpB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Command Code, Oh My Pi, and ZCode as supported CLI delegation options.
  - Added configurable read-only reviews, session resumption, model selection, execution limits, and recovery handling.
  - Added safeguards against unintended changes and automatic commits during delegated runs.
  - Added workflows for briefing, queued tasks, verification, and review.

- **Documentation**
  - Expanded guidance for setup, permissions, platform support, CLI behavior, and safe delegation.

- **Tests**
  - Added coverage for discovery, dispatching, failures, truncated output, read-only enforcement, and cross-platform execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->