### PR TITLE
Compare discover key sets, not entry counts

### DIFF
--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -30,7 +30,8 @@ export function runDelegateSetup(h) {
     "discover covers every implementer in the smoke matrix",
     Array.isArray(report?.discovered) &&
       Array.isArray(report?.missing) &&
-      report.discovered.length + report.missing.length === h.SKILLS.length,
+      [...report.discovered, ...report.missing].map((entry) => entry.key).sort().join(",") ===
+        [...h.SKILLS].sort().join(","),
   );
 
   const agyProbeDir = join(h.scratch, "discover-agy");


### PR DESCRIPTION
## What's wrong

`test/relay/delegate-setup.mjs` names a check "discover covers every implementer in the smoke matrix", but the assertion only compares a count:

```js
report.discovered.length + report.missing.length === h.SKILLS.length,
```

Any registry with the right number of entries passes regardless of which entries they are. A renamed or mistyped key in `skills/delegate-setup/scripts/implementers.mjs` keeps CI green while making that implementer undispatchable via `--lane`.

## Reproduction

Changed `key: "warp"` to `key: "warpp"` in `implementers.mjs`, leaving the entry count at 14. On master, every gate stays green:

```
$ node test/relay-smoke.mjs --only delegate-setup
  ok   discover covers every implementer in the smoke matrix
relay smoke: all green
EXIT=0

$ node test/relay-parity.mjs
relay parity: all checks passed
EXIT=0

$ node test/relay-isolated.mjs
relay isolated install: all checks passed
EXIT=0
```

The user-visible symptom, same corrupted tree:

```
$ node skills/delegate-setup/scripts/discover.mjs
keys: agy aider claude cline codex copilot cursor grok kimi opencode pi qoder vibe warpp
(14 keys; "warpp" present, "warp" absent)

$ node skills/delegate-setup/scripts/config.mjs validate fleet-warp.json
config.mjs: fleet-warp.json: lane ui needs implementer (one of: claude, cline, codex,
opencode, agy, grok, kimi, qoder, vibe, cursor, pi, aider, copilot, warpp)
EXIT=2
```

where `fleet-warp.json` is `{"version":"delegate-fleet.v1","lanes":{"ui":{"implementer":"warp"}}}`. On a clean tree the same file validates `{"ok": true}` with `EXIT=0`. So a `warp` lane becomes unwritable while the suite reports all green.

## What changed

```diff
-      report.discovered.length + report.missing.length === h.SKILLS.length,
+      [...report.discovered, ...report.missing].map((entry) => entry.key).sort().join(",") ===
+        [...h.SKILLS].sort().join(","),
```

Comparing the sorted key set instead of the cardinality catches renames, drops, additions, and duplicates alike; a count only catches the last two, and only when they change the total. `h.SKILLS` is copied before sorting because `Array.prototype.sort` mutates in place and `SKILLS` is shared across the whole smoke run. Check name unchanged — it already described the intended behaviour.

## What ran

macOS (Darwin 25.5.0), Node v26.5.0. Both directions:

**Clean tree, with the fix — green:**

```
$ node test/relay-parity.mjs        relay parity: all checks passed          EXIT=0
$ node test/relay-isolated.mjs      relay isolated install: all checks passed EXIT=0
$ node test/event-scanner.mjs       event-scanner: 23 passed, 0 failed        EXIT=0
$ node test/relay-smoke.mjs         relay smoke: all green                    EXIT=0
                                    (1011 ok, 0 FAIL)
$ npx skills add . --list           Found 15 skills                           EXIT=0
```

**Corrupted tree (`warpp` re-applied), with the fix — now fails:**

```
$ node test/relay-smoke.mjs --only delegate-setup
  FAIL  discover covers every implementer in the smoke matrix
1 FAILED
EXIT=1
```

Exactly one check fails, and it is the right one. Restored `implementers.mjs` with `git checkout` and re-confirmed `relay smoke: all green`, `EXIT=0`.

Not run: Windows. This touches a test assertion only — no relay, skill, or registry code changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved smoke-test validation to ensure all configured skills are correctly accounted for, including both discovered and missing implementer keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->