### PR TITLE
Add omp-delegate for Oh My Pi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Fourteen implementer skills ship today: `claude-delegate` (Claude Code),
+and land the result. Fifteen implementer skills ship today: `claude-delegate` (Claude Code),
 `cline-delegate` (Cline CLI), `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode),
 `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code),
 `qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI),
-`pi-delegate` (Pi CLI), `aider-delegate` (Aider), `copilot-delegate` (GitHub Copilot CLI), and
+`pi-delegate` (Pi CLI), `omp-delegate` (Oh My Pi), `aider-delegate` (Aider), `copilot-delegate` (GitHub Copilot CLI), and
 `warp-delegate` (Warp Agent CLI); siblings like `gemini-delegate` can be added
 later without renaming the repo. One **utility** skill
 ships alongside them: `delegate-setup` (configure fleet lanes — setup only, never dispatches).
@@ -20,7 +20,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Aider, Copilot, Warp) | "worker", "sub-agent", "executor" |
+| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Oh My Pi, Aider, Copilot, Warp) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -41,6 +41,7 @@ jargon. Use these terms; don't invent synonyms.
 | `agent run`, `conversation` / `--conversation`, `run_id`, `run_url`, `--cwd`, `--output-format ndjson`, `--profile`, `--skill`, `--no-snapshot`, `run-cloud` | Warp Agent CLI's own terms — use verbatim when discussing `oz` | never call `oz` "the warp CLI" in a launch context — `warp` is the interactive TUI and cannot be relayed; don't invent a Warp sandbox or permission-mode enum (`oz agent run` has neither) |
 | `--prompt`, `--output` (`streaming`/`json`/`text`), `--agent` (`plan`/`accept-edits`/`auto-approve`), `--max-turns`, `--max-price`, `--max-tokens`, `--trust`, `--resume`, `--continue`, `--enabled-tools`, `--disabled-tools` | Mistral Vibe's own terms — use verbatim when discussing `vibe` | don't invent a Vibe sandbox enum; `--trust` is not a permission mode |
 | `session`, `--continue`, `--session`, `print mode`, `--mode json`, `tools`, `context files`, `project trust` | Pi's own terms — use verbatim when discussing `pi` | don't paraphrase them |
+| `session`, `--continue`, `--resume` / `--session`, `--print`, `--mode json`, `omp models`, `--thinking`, `approvalMode` (`always-ask`/`write`/`yolo`), `--yolo` / `--auto-approve`, `--tools`, `--no-extensions` / `--no-skills` / `--no-rules`, `--max-time`, `--profile` | Oh My Pi's own terms — use verbatim when discussing `omp` | never call `omp` "pi" in a launch context — `pi` is a different CLI (`pi-delegate`); don't invent an omp sandbox enum; `--yolo` is `tools.approvalMode: yolo`, not a permission-mode enum |
 | `--message-file`, `--yes-always`, `--suggest-shell-commands`, `--auto-commits`/`--dirty-commits`, `--dry-run`, `--edit-format`, `--architect`, `--file`/`--read`, `chat history` | Aider's own terms — use verbatim when discussing `aider` | Aider has no sandbox, no permission modes, and no session ids; don't imply any. `--file`/`--read` scope the chat context — never call them a boundary |
 | `session`, `-p`/`--prompt`, `--output-format json` (JSONL), `tools`, `--allow-all-tools`, `mode plan`, `--resume`/`--continue`, `--model`, `--effort`, `copilot login` / env tokens, `sandbox` (experimental, MXC) | GitHub Copilot CLI's own terms — use verbatim when discussing `copilot` | don't paraphrase them |
 
@@ -51,7 +52,7 @@ version a run was made against is what makes the claim checkable; and claims tha
 ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
 `cline` / `codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi` /
-`aider` / `copilot` / `oz`) and the skill's `relay.mjs`.
+`aider` / `copilot` / `oz` / `omp`) and the skill's `relay.mjs`.
 
 ## Conventions
 
@@ -91,7 +92,7 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   child process cwd; the other launches quote spaceable args, and all value flags are token-validated.
   The `claude` and `cursor-agent` launches serialize a pre-joined
   command string through the shell on win32 for the same shim reason; `agy`, `kimi`, current
-  `qodercli`, `vibe`, `aider`, and `oz` installs use native binaries (pip puts a real `aider.exe` in
+  `qodercli`, `vibe`, `aider`, `oz`, and `omp` installs use native binaries (pip puts a real `aider.exe` in
   Scripts, so that launch needs no `shell:true`). The `oz` launch must never gain a shell on any
   platform: `oz agent run` takes the brief as its `--prompt` argv value (its `-f/--file` config path
   does not satisfy the required prompt group), and a shell would reinterpret that text. Each changed

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`kimi-delegate`](skills/kimi-delegate/SKILL.md) | [Kimi Code](https://moonshotai.github.io/kimi-code/en/) (`kimi`) | `auto permission mode`, always | — [^none] | `--resume-last`, `--session <id>` |
 | [`opencode-delegate`](skills/opencode-delegate/SKILL.md) | [OpenCode](https://opencode.ai) (`opencode`) | agent `build` (`--model` required) | `--read-only` (agent `plan`) | `--resume-last`, `--session <id>` |
 | [`pi-delegate`](skills/pi-delegate/SKILL.md) | [Pi](https://github.com/earendil-works/pi-mono) (`pi`) | full local tools — no sandbox, no permission modes [^none]; project trust opt-in | `--read-only` (`read,grep,find,ls`) | `--resume-last`, `--session <id>` |
+| [`omp-delegate`](skills/omp-delegate/SKILL.md) | [Oh My Pi](https://github.com/can1357/oh-my-pi) (`omp`) | `--yolo` (`tools.approvalMode: yolo`); project `.omp` extras off unless `--approve` | `--read-only` (`read,grep,glob`) | `--resume-last`, `--session <id>` |
 | [`qoder-delegate`](skills/qoder-delegate/SKILL.md) | [Qoder](https://docs.qoder.com/en/cli/quick-start) (`qodercli`) | `auto` permission mode; bypass opt-in | `--permission-mode plan` | `--resume-last`, `--resume <id>` |
 | [`vibe-delegate`](skills/vibe-delegate/SKILL.md) | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (`vibe`) | `accept-edits`; `--full-access` opt-in | `--plan-only` (`plan` agent) | `--resume-last`, `--session <id>` |
 | [`copilot-delegate`](skills/copilot-delegate/SKILL.md) | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli) (`copilot`) | `--allow-all-tools` opt-in; headless auto-deny otherwise | `--read-only` (`--mode plan`) | `--resume-last`, `--session <id>` |
@@ -239,6 +240,12 @@ Per skill — platform, CLI version, and what the run exercised:
 - `pi-delegate` — macOS: stdin brief delivery, explicit provider and model selection, JSON
   session/provider/model/usage capture, and a `--read-only` run leaving a clean tree. Write,
   `--session`, and `--resume-last` runs are contributor-reported.
+- `omp-delegate` — contract-tested, live run pending: stdin brief delivery, `omp --mode json`
+  argv (`--yolo`, `--tools read,grep,glob`, `--no-extensions --no-skills --no-rules`, `--thinking`),
+  session header / `message_end` parsing, `--approve` omitting the project-trust flags, `--continue`
+  resume, assistant `stopReason: error` reported as failed, `omp_unavailable`/127, and bounded
+  `--version` preflight. Native Windows launch is a native `omp.exe` (no `shell:true`); that path is
+  contract-tested via the smoke matrix's compiled fake, not against a live Oh My Pi install.
 - `qoder-delegate` — macOS, `qodercli` 1.0.47, by the contributor: Lite edit run, `accept_edits`,
   explicit model and 32768-token context window, no commit.
 - `warp-delegate` — macOS, `oz` 0.2026.05.27.15.44.stable_01: **live edit run verified**. A relay
@@ -279,7 +286,7 @@ Per skill — platform, CLI version, and what the run exercised:
   (versions vary by machine). Native Windows discover smoke not yet claimed.
 
 Not yet verified: native Windows launches for `claude`, exact-head `cline`, `grok`, `kimi`,
-`pi`, `qoder`, and `vibe` (`codex`/`opencode`/`grok` have contract-tested `.cmd` shim handling;
+`pi`, `qoder`, `vibe`, and `omp` (`codex`/`opencode`/`grok` have contract-tested `.cmd` shim handling;
 Cursor serializes a pre-joined, quoted command; Qoder and Vibe target their documented native executables).
 Claude's own shell sandbox is unsupported on native Windows regardless of launch mechanics, and upstream
 Vibe officially targets UNIX. A native Linux `cursor-agent` run is unverified. The full delegate →

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -16,6 +16,7 @@
         "vibe-delegate",
         "cursor-delegate",
         "pi-delegate",
+        "omp-delegate",
         "aider-delegate",
         "copilot-delegate",
         "warp-delegate"

--- a/skills/delegate-setup/references/schema.md
+++ b/skills/delegate-setup/references/schema.md
@@ -57,11 +57,13 @@ later-edited project config fails closed until it is reviewed and written again 
 | `vibe` | vibe-delegate | `vibe` | timeout, readOnly |
 | `cursor` | cursor-delegate | `cursor-agent` | model, force, timeout, readOnly |
 | `pi` | pi-delegate | `pi` | provider, model, timeout, readOnly |
+| `omp` | omp-delegate | `omp` | provider, model, **effort** (`--thinking`), timeout, readOnly |
 | `aider` | aider-delegate | `aider` | model, timeout, readOnly |
 | `copilot` | copilot-delegate | `copilot` | model, effort, timeout, readOnly |
 | `warp` | warp-delegate | `oz` | model, timeout |
 
 OpenCode uses `variant` for reasoning intensity, not `effort`. Do not write `effort` on an `opencode` lane.
+Oh My Pi (`omp`) uses the lane `effort` dial for omp's `--thinking` (`off`, `auto`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). Do not write `thinking` as a lane field.
 OpenCode lanes **require** `model` in `provider/model` form, with a non-empty provider before the first
 `/` and at least one non-`/` character after it. Cline accepts `provider` and `model` as separate
 dials and does not impose that shape.
@@ -70,7 +72,8 @@ Boolean dials: `readOnly`, `force`. All other dials are non-empty strings. Durat
 `timeout` use `h`/`m`/`s` (e.g. `30m`) and must fit the relay watchdog ceiling (~24.8 days).
 Do not combine `readOnly: true` with a write-capable `sandbox` / `permissionMode` / `force`.
 `model` / `provider` / OpenCode `variant` must match the bound relay’s token rules (e.g. Claude
-rejects spaces; Grok/Pi/OpenCode/Codex use a shell-safe token set on Windows `shell:true` launches).
+rejects spaces; Grok/Pi/Oh My Pi/OpenCode/Codex use a shell-safe token set — Windows `shell:true`
+launches, and Oh My Pi's flag-injection defense even without a shell).
 
 ## Helpers
 

--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -31,6 +31,7 @@ import {
   ALL_DIALS,
   CLAUDE_EFFORT,
   COPILOT_EFFORT,
+  OMP_THINKING,
   CODEX_SANDBOX,
   CONFIG_VERSION,
   GROK_SANDBOX,
@@ -226,6 +227,9 @@ function validateDialValue(implementer, field, value, laneName, label) {
     if (implementer === "copilot" && !COPILOT_EFFORT.includes(value)) {
       return `${label}: lane ${laneName}.effort must be one of: ${COPILOT_EFFORT.join(", ")}`;
     }
+    if (implementer === "omp" && !OMP_THINKING.includes(value)) {
+      return `${label}: lane ${laneName}.effort must be one of: ${OMP_THINKING.join(", ")}`;
+    }
     if ((implementer === "codex" || implementer === "grok") && !/^[a-z][a-z0-9-]*$/i.test(value)) {
       return `${label}: lane ${laneName}.effort must be a bare token`;
     }
@@ -272,6 +276,7 @@ function validateModelOrProvider(implementer, field, value, laneName, label) {
   } else if (
     implementer === "grok" ||
     implementer === "pi" ||
+    implementer === "omp" ||
     implementer === "opencode" ||
     // codex (and any other win32 shell:true relay) must not accept cmd metacharacters in -m.
     implementer === "codex" ||

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -248,6 +248,27 @@ export const IMPLEMENTERS = Object.freeze([
     winShell: true,
   },
   {
+    key: "omp",
+    skill: "omp-delegate",
+    binary: "omp",
+    versionArgs: ["--version"],
+    authProbe: null,
+    // Must stay the `models` subcommand: `omp --list-models` is a stale flag and a
+    // hard error. Catalog output is grouped/JSON, not a stable identifier list, so
+    // this script does not parse it — the skill documents `omp models` instead.
+    modelProbe: null,
+    // ~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<sessionId>.jsonl.
+    usageProbe: {
+      envDir: "PI_CODING_AGENT_DIR",
+      homeSubdir: ".omp/agent",
+      path: ["sessions", "*"],
+      entry: "file",
+      match: /\.jsonl$/,
+    },
+    supports: ["provider", "model", "effort", "timeout", "readOnly"],
+    winShell: false,
+  },
+  {
     key: "aider",
     skill: "aider-delegate",
     binary: "aider",
@@ -315,6 +336,7 @@ export const IMPLEMENTER_BY_KEY = Object.freeze(
 export const CLAUDE_EFFORT = Object.freeze(["low", "medium", "high", "xhigh", "max", "ultracode"]);
 export const AGY_EFFORT = Object.freeze(["low", "medium", "high"]);
 export const COPILOT_EFFORT = Object.freeze(["low", "medium", "high", "xhigh", "max"]);
+export const OMP_THINKING = Object.freeze(["off", "auto", "minimal", "low", "medium", "high", "xhigh", "max"]);
 export const CODEX_SANDBOX = Object.freeze(["read-only", "workspace-write", "danger-full-access"]);
 export const GROK_SANDBOX = Object.freeze(["workspace", "read-only", "off"]);
 export const QODER_PERMISSION = Object.freeze([

--- a/skills/delegate-setup/scripts/lane.mjs
+++ b/skills/delegate-setup/scripts/lane.mjs
@@ -105,11 +105,15 @@ function normalizeDials(implementerKey, raw) {
     if (dials.permissionMode === undefined) dials.permissionMode = "plan";
     delete dials.readOnly;
   }
+  if (implementerKey === "omp" && typeof dials.effort === "string") {
+    dials.thinking = dials.effort;
+    delete dials.effort;
+  }
   if (implementerKey === "vibe" && dials.readOnly === true) {
     dials.planOnly = true;
     delete dials.readOnly;
   }
-  // agy / claude / cursor / pi keep readOnly as a boolean on opts
+  // agy / claude / cursor / pi / omp keep readOnly as a boolean on opts
   return dials;
 }
 
@@ -141,6 +145,7 @@ export function mergeDials(opts, dials, flagged) {
       continue;
     }
     if (field === "force" && flagged.has("force")) continue;
+    if (field === "thinking" && flagged.has("thinking")) continue;
     opts[field] = value;
   }
 }

--- a/skills/omp-delegate/SKILL.md
+++ b/skills/omp-delegate/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: omp-delegate
+description: >-
+  Delegate a coding task to Oh My Pi (`omp`) as a background implementer, then review its
+  diff and land it yourself. Use this whenever the user wants to delegate implementation work to
+  Oh My Pi / omp - phrasings like "have omp implement X", "delegate this to oh my pi", "run it
+  through omp", "use oh-my-pi to implement/fix/refactor" - or wants to run a queue of coding
+  tasks through omp while staying the reviewer. DO NOT USE for tasks small enough to do inline,
+  when the user wants the code written directly without delegating, or when they mean the original
+  Pi CLI (`pi`) — that is pi-delegate.
+license: MIT
+compatibility: Requires the `omp` CLI installed and authenticated (`/login` inside omp, or a provider API-key environment variable), Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+
+# Oh My Pi Delegate
+
+You are the **orchestrator**. Delegate a bounded coding task to a separate **implementer** - Oh My
+Pi (`omp`) - then review what it produced and land it yourself. You write the brief and own the
+judgment; the implementer makes changes in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## The binary is `omp`, not `pi`
+
+Oh My Pi is a fork of Pi. This skill drives **`omp`** (`@oh-my-pi/pi-coding-agent`). The original
+Pi CLI is a different binary (`pi`) with a different skill (`pi-delegate`). If `omp` is missing but
+`pi` is installed, you have Pi, not Oh My Pi.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `omp` CLI is not installed or authenticated.
+- The user asked for the original Pi CLI (`pi`) — use `pi-delegate`.
+- You need a sandboxed implementer. Oh My Pi has no sandbox. `--read-only` restricts the tool
+  surface; a write-capable run executes without prompts (`--yolo`).
+
+## Prerequisites (check once)
+
+1. Install omp with `bun install -g @oh-my-pi/pi-coding-agent` (or the install path from
+   https://omp.sh).
+2. Authenticate: `/login` inside omp for a subscription provider, or an API-key environment
+   variable for an API-key provider. Credentials live under `~/.omp/`.
+3. Confirm `omp --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model (optional)
+
+Omit `--model` (and `--provider`) to use omp's configured default for this project / profile. The
+catalog is **this install's** authenticated providers — not a fixed list in this skill.
+
+To pick another model:
+
+1. **List what this install can actually run.** Do **not** pass `omp --list-models` — that flag is
+   gone and omp treats it as an unknown flag (exit 2). Use the `models` subcommand:
+   - `omp models` — every available model, grouped by provider
+   - `omp models --json` — the same catalog, machine-readable
+   - `omp models find <substring>` — filter by provider, id, or name (example:
+     `omp models find sonnet`)
+   - `omp models <provider>` — one provider's models
+2. **Pass that id to the relay.** `--model <pattern>` is omp's own `--model`: a fuzzy match against
+   the catalog (provider/id, a bare id, or a unique substring). `--provider <name>` pins the
+   provider when the pattern is ambiguous.
+3. The relay forwards only letters, digits, and `. _ : / -`. Glob patterns with `*` are rejected.
+
+`--thinking <level>` is a separate reasoning dial, not a model id. Allowed values: `off`, `auto`,
+`minimal`, `low`, `medium`, `high`, `xhigh`, `max`. The relay rejects anything else (including
+`inherit`) before dispatch — omp would otherwise warn and ignore a bad value.
+
+A fleet lane (`--lane`) can set `provider`, `model`, and `effort`. Lane `effort` becomes
+`--thinking`; an explicit `--thinking` / `--model` / `--provider` flag wins over the lane.
+
+The relay does not forward `--api-key`, `--smol`, `--slow`, or `--plan`. Those stay omp's own CLI.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Oh My Pi sees only the text you send plus what it can inspect in the workspace - no chat history or
+shared context. Include the goal, current state, what to change, what to leave untouched, the
+project's **actual** gates, and a report contract. Tell omp not to commit. Keep one task per brief.
+omp auto-loads `AGENTS.md`/`CLAUDE.md` context files from the workspace and its parents, so repo
+instructions reach it without inlining. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled relay. It pipes the brief to `omp --mode json` on stdin, captures the JSON event
+stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing this
+`SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# list models first:                       omp models   (or: omp models --json)
+# choose a model:                          add --model <id from omp models>
+# choose a provider:                       add --provider <name>
+# set thinking level:                      add --thinking high
+# read-only run (review/diagnosis):        add --read-only
+# trust project .omp resources:            add --approve
+# resume the most recent session:          add --resume-last  (delta brief only)
+# resume a specific session:               add --session <id> (delta brief only)
+# hard time limit (watchdog):              add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                         node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. The relay writes artifacts under the system temp dir
+by default and never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until omp finishes. Run it with the orchestrator's background-command facility,
+or background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes
+no result; a missing `omp` exits 127 and writes `status: "omp_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process
+exited and `result.json` exists. omp's full report is the `finalMessage` field in `result.json`
+(also printed in full on stdout between the report markers).
+
+### 4. Review - do not trust the self-report
+
+Treat omp's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates
+pass and the diff holds. If rework is needed, send a delta brief with `--resume-last` or
+`--session <id>`, then review again.
+
+## Autonomy and permissions
+
+Oh My Pi has **no sandbox**. Print mode has no approval UI, so a write-capable relay run always
+passes `--yolo` (`tools.approvalMode: yolo`) — otherwise a user's `always-ask` or `write` config
+would stall until the watchdog. The other controls are:
+
+1. `--read-only` restricts omp's callable tools to `--tools read,grep,glob`. It does not pass
+   `--yolo`. Installed extension code still runs with the user's host permissions if project
+   resources are trusted.
+2. The relay passes `--no-extensions --no-skills --no-rules` by default, so project `.omp`
+   extensions, skills, and rules stay undiscovered. `--approve` is the explicit opt-in for a
+   repository the user trusts.
+3. `touchedFiles` and the diff are the record of what changed. Inspect them after every run.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"),
+committing verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't
+absorb** (report omp's design decisions, defensible-but-unasked turns, and non-blocking nitpicks)
+and **stop for scope changes** (if correct completion needs going beyond the brief, ask instead of
+expanding the mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, report contract,
+  real gates, stdin delivery, model listing, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist, commit
+  boundary, and rework through omp sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues,
+  constraint carry-forward, progress tracking, and the final coherence pass.

--- a/skills/omp-delegate/references/dispatch-and-poll.md
+++ b/skills/omp-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,155 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps omp's non-interactive JSON print mode, captures its event stream, and
+writes a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v omp
+omp --version
+omp models            # list models this install can run; then pass one id as --model
+# omp models --json   # machine-readable catalog
+# omp models find sonnet
+```
+
+Do **not** run `omp --list-models`. That flag is a hard error.
+
+Install with `bun install -g @oh-my-pi/pi-coding-agent`. Authenticate with `/login` inside omp
+(subscription providers) or an API-key environment variable; omp stores credentials in `~/.omp/`.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. A lane `effort` value becomes `--thinking`. |
+| `--provider <name>` | omp `--provider` (default: omp's own default). Token-validated. |
+| `--model <pattern>` | omp `--model` id or fuzzy pattern (default: omp's own default). Token-validated: letters, digits, `. _ : / -`. Pick the value from `omp models`, not from memory. |
+| `--thinking <level>` | omp `--thinking`: `off`, `auto`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. |
+| `--session <id>` | Resume a specific omp session (`--session` / `--resume`); send only the delta brief. A value is required — bare `--resume` would open omp's picker and hang. |
+| `--resume-last` | Continue the most recent omp session for this cwd (`omp --continue`); send only the delta brief. |
+| `--read-only` | Restrict omp to `--tools read,grep,glob`. |
+| `--approve` | Load project-local `.omp` extensions, skills, and rules. The default passes `--no-extensions --no-skills --no-rules`. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). The relay does not forward omp's `--max-time`. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The child cwd pins the workspace; omp's
+`--cwd` is not passed. omp has no sandbox, so reachability is simply the filesystem.
+
+A run without `--read-only` can write and execute anything the user account can: the relay passes
+`--yolo` so print mode does not stall on tool approval. `--read-only` removes write/edit/bash (and
+the rest of omp's default tool surface) from the callable tools; installed extension code still
+runs with the user's host permissions when `--approve` is set.
+
+The relay never forwards `--api-key`.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an
+`--out-dir` inside the worktree can make the artifacts appear there:
+
+- `brief.txt` - the exact brief.
+- `events.jsonl` - raw omp stdout events (the session header, then every agent event).
+- `final.txt` - assistant text joined with a blank line between chunks; absent if none was emitted.
+- `stderr.txt` - complete stderr.
+- `result.json` - the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"omp"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `omp_unavailable`), `exitCode`, and
+  `signal` (`null` unless the child died on a signal).
+- `workdir`, requested `provider`/`model`/`thinking`, `projectTrusted`, `readOnly`, `yolo`, `resumed`, `ompVersion`,
+  `sessionId`, `startedAt`, and `finishedAt`.
+- `actualProvider`, `actualModel`, `usage`, and `stopReason` from omp's final assistant event.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `sessionId` - parsed from the JSON stream's `session` header. Resume with `--session <id>`.
+  Note: `--continue` may mint a new session id for the continued run; the result always reports
+  the id of the run that just happened.
+- `finalMessage` - assistant text parts joined with `"\n\n"`; tool calls and tool results are
+  excluded.
+- `touchedFiles` - `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of omp's edits: anything already dirty before dispatch shows up too. Dispatch
+  from a clean tree when you want the list to read as "what omp changed". `null` means git could
+  not report; `[]` means git ran and the tree is clean.
+- `stderrTail` - the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
+- `error` - present for launch failures, preflight failures, when the relay watchdog fires
+  (`timeout`), and on an `aborted` run.
+
+omp's stream carries thinking and message-update events the relay archives but does not parse.
+
+## Waiting for completion
+
+The relay blocks. Use the orchestrator's background-command facility, or background it in a
+shell and poll for `result.json`. The run is done only when the process exits and the file
+contains a `status`. The result file is written atomically, so a partial read is impossible.
+
+A pre-run usage error exits 2 and writes no result. A missing `omp` exits 127 and writes
+`status: "omp_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "omp_unavailable"` (exit 127):** install omp (`bun install -g @oh-my-pi/pi-coding-agent`),
+  authenticate, and re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
+  causes: an unknown `--model`, an expired login, or a provider error.
+  A final assistant event with `stopReason: "error"` or `"aborted"` is failed even if omp exits zero.
+- **`status: "failed"` with an `error` mentioning `version preflight`:** the bounded `omp --version`
+  probe failed or hung, so omp was never dispatched. Check the install (`omp --version` yourself).
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to omp. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through
+  the OOM killer or a supervisor timeout. This is not an omp error; check host memory and
+  re-dispatch, or split the task into smaller briefs.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `omp did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout`
+  or split the task. On POSIX the relay sends SIGTERM to the process group, waits 10 seconds,
+  then sends SIGKILL if needed; on Windows there is no escalation phase — the whole process tree
+  is felled immediately with `taskkill /pid <pid> /t /f`.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Tool execution events carry the write/edit arguments, but treat any
+reconstruction as unverified until it matches a working-tree diff — when the tree still holds the
+work, preserve the tree rather than replaying the log.
+
+## What the relay runs
+
+The launch is equivalent to:
+
+```bash
+cat brief.txt | omp --mode json [--provider <name>] [--model <pattern>] [--thinking <level>] \
+  [--session <id> | --continue] [--yolo] \
+  [--no-extensions --no-skills --no-rules] [--tools read,grep,glob]
+```
+
+`--yolo` is omitted on `--read-only`. The three `--no-*` flags are omitted when `--approve` is
+set.
+
+The brief rides stdin, so it is not visible in the host process list and no argv size cap
+applies. `omp` is a native binary (bun / install script / Homebrew), so the relay never launches
+it through a shell. Before dispatch the relay runs a bounded `omp --version` preflight (10s cap)
+so a hung or crashing CLI fails fast and explicitly instead of hanging the run.
+
+## The commit boundary
+
+The relay never commits. omp edits the working tree; the orchestrator reviews, re-runs the gates,
+and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/omp-delegate/references/multi-task-queues.md
+++ b/skills/omp-delegate/references/multi-task-queues.md
@@ -1,0 +1,59 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is
+the default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh omp sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture
+location, or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed omp session only for rework on the same task. Send a delta brief with
+`--resume-last`, or with `--session <id>` from that task's `result.json`. Start unrelated queue
+items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** - queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** - what landed, what you verified, and gate outcomes.
+- **Needs your eyes** - design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** - the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/omp-delegate/references/review-and-land.md
+++ b/skills/omp-delegate/references/review-and-land.md
@@ -1,0 +1,95 @@
+# Review and land
+
+The implementer made the changes; you own the judgment. Verify against reality, never the self-report, and read
+the diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries omp's claims, not evidence. Re-run the project's actual test, lint, and build
+commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** - changes the brief excluded.
+- **Scope shortfall** - missed behavior, edges, or cleanup.
+- **Quiet judgment calls** - defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to omp as a delta brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer.
+Write a clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`,
+`git diff --cached` for anything the implementer staged (plain `git diff` is blind to the index),
+and open any untracked files (`??` in `git status`) directly — they are the implementer's new
+files, and no diff shows their contents. The tree is evidence, not clutter. After that inspection
+the verdict can legitimately be to discard — work built on a premise you have since corrected,
+for example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json` - the stable
+handle, since `--continue` may mint a new id for each continued run. The relay rejects
+`--resume-last` plus `--session` before launch. Rework gets the same gate rerun, test review,
+diff review, and implementer sweep.
+
+A write-capable rework run passes `--yolo` and executes with no prompts - keep rework briefs as
+narrow as the original. A `--read-only` run restricts omp to `read,grep,glob`; installed extension
+code still runs with the user's host permissions when `--approve` is set, so inspect `touchedFiles`
+and the tree after every run.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep
+them in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/omp-delegate/references/writing-the-brief.md
+++ b/skills/omp-delegate/references/writing-the-brief.md
@@ -72,6 +72,9 @@ Add extra blocks only when the task needs them:
   unknown).
 - **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences,
   and open questions), and dispatch with `--read-only` so omp cannot invoke write/edit/bash tools.
+  That restricts the tool surface; it is not a sandbox. Leave `--approve` off unless the user
+  trusts this repo's `.omp` extras (the relay already passes `--no-extensions --no-skills
+  --no-rules` unless `--approve` is set).
 
 ## Always ask for the report explicitly
 

--- a/skills/omp-delegate/references/writing-the-brief.md
+++ b/skills/omp-delegate/references/writing-the-brief.md
@@ -72,9 +72,11 @@ Add extra blocks only when the task needs them:
   unknown).
 - **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences,
   and open questions), and dispatch with `--read-only` so omp cannot invoke write/edit/bash tools.
-  That restricts the tool surface; it is not a sandbox. Leave `--approve` off unless the user
-  trusts this repo's `.omp` extras (the relay already passes `--no-extensions --no-skills
-  --no-rules` unless `--approve` is set).
+  That restricts the tool surface; it is not a sandbox. `AGENTS.md` and `CLAUDE.md` are also
+  repository-controlled instructions and may load without `--approve`. Use read-only dispatches
+  for untrusted repositories. Leave `--approve` off unless the user trusts this repo's `.omp`
+  extras (the relay already passes `--no-extensions --no-skills --no-rules` unless `--approve`
+  is set).
 
 ## Always ask for the report explicitly
 

--- a/skills/omp-delegate/references/writing-the-brief.md
+++ b/skills/omp-delegate/references/writing-the-brief.md
@@ -1,0 +1,144 @@
+# Writing the brief
+
+A brief is the entire task as omp will see it. It runs in a separate session with **no memory of
+your conversation, no access to prior notes, and no shared context** - only the text you send and
+whatever it can inspect in the workspace. If a constraint is not in the brief or discoverable in
+the repo, it does not exist for omp.
+
+One shortcut: omp auto-loads `AGENTS.md` and `CLAUDE.md` context files from the workspace and its
+parent directories, so conventions written there reach omp without inlining. Restate the
+load-bearing rules in the brief anyway - the brief is the contract. Project `.omp` skills, rules,
+and extensions stay undiscovered unless the dispatch passed `--approve`.
+
+## Model choice and resumed sessions
+
+omp uses its configured default model when `--model` is omitted, so a fresh dispatch does not
+require it. Pass `--model <id>` only when the human asked for a specific model.
+
+**How to choose an id:**
+
+1. Run `omp models` (human table) or `omp models --json`. Narrow with `omp models find <substring>`
+   or `omp models <provider>`.
+2. Copy a catalog id (often `provider/model-id`, sometimes a unique substring omp can fuzzy-match).
+3. Pass it as the relay's `--model`. Add `--provider <name>` when two providers share a short name.
+
+Do **not** run `omp --list-models`. That flag was removed; omp exits 2 with `unknown flag:
+--list-models`. Do **not** pass `--api-key` through the relay.
+
+`--thinking` is independent of `--model`. Use `off`, `auto`, `minimal`, `low`, `medium`, `high`,
+`xhigh`, or `max`. The relay rejects any other value before dispatch.
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report omp must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** - add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences,
+  and open questions), and dispatch with `--read-only` so omp cannot invoke write/edit/bash tools.
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from assistant text in omp's JSON event stream. Without a closing
+summary, the edits may exist but the result is hard to review. The `<structured_output_contract>`
+block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy
+the actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. omp can inspect the workspace (and auto-loads
+context files), but the important constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one omp run -> one reviewed commit keeps the diff and
+rollback clean. Split mixed implementation, review, documentation, and roadmap requests into
+separate dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Stdin delivery
+
+The relay pipes the brief to omp on stdin. Unlike CLIs that take the brief as an argument, there
+is no OS argv size cap and the brief never appears in the host process list. Large context can be
+inlined, but prefer pointing omp at workspace files it can read itself. Keep secrets out of the
+brief anyway on shared machines - reference environment variables or files with tight permissions.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/omp-delegate/scripts/relay.mjs
+++ b/skills/omp-delegate/scripts/relay.mjs
@@ -1,0 +1,806 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · omp-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to Oh My Pi (`omp --mode json`), capture the
+ * JSON event stream, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every omp-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `omp` and `git`, plus the platform
+ * process-termination utility when a Windows process-tree kill requires one.
+ * The `omp` process it launches does authenticate — exactly as you do at the
+ * terminal. Read this file before you run it.
+ *
+ * The brief is piped to omp on stdin, so it never appears in the host process
+ * list and no argv size cap applies. Keep secrets out of the brief anyway on
+ * shared machines — reference workspace files or environment variables instead.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Autonomy: omp has no sandbox. Print mode has no approval UI, so a write run
+ * passes `--yolo` (`tools.approvalMode: yolo`) and executes without prompts.
+ * `--read-only` restricts the callable tool surface to `read,grep,glob`.
+ * Installed extension code still runs with the user's host permissions when
+ * project resources are trusted. The relay passes `--no-extensions --no-skills
+ * --no-rules` unless `--approve` explicitly trusts project `.omp` resources.
+ * The diff reported in `touchedFiles` is the record of what changed.
+ *
+ * omp is a native binary (bun / install script / Homebrew), including on
+ * Windows, so this relay never launches it through a shell. Only
+ * token-validated flag values ride argv (the brief never does).
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for omp (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --provider <name>       omp provider name (default: omp's own default).
+ *   --model <pattern>       omp model id or fuzzy pattern (default: omp's own
+ *                           default). List ids with `omp models`, not
+ *                           `--list-models`. Letters, digits, and . _ : / - only.
+ *   --thinking <level>      omp --thinking: off, auto, minimal, low, medium,
+ *                           high, xhigh, or max.
+ *   --session <id>          Resume a specific omp session; send only the delta brief.
+ *   --resume-last           Continue the most recent omp session for this cwd
+ *                           (`omp --continue`); send only the delta brief.
+ *   --approve               Trust project-local .omp extensions, skills, and
+ *                           rules. By default the relay passes --no-extensions
+ *                           --no-skills --no-rules.
+ *   --read-only             Restrict omp to read,grep,glob (no write/edit/bash).
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). Durations use
+ *                           h/m/s strings. omp's --max-time is not forwarded.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, ompVersion, sessionId, finalMessage (omp's own
+ *   report), requested/actual provider and model, thinking, usage, touchedFiles
+ *   (git porcelain, null if git cannot report), readOnly, yolo, projectTrusted,
+ *   and paths to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `omp` binary exits 127;
+ * otherwise the exit code mirrors omp's own (0 success, non-zero failure), except
+ * a final assistant `error`/`aborted` event exits 1 even if omp exits 0. If the
+ * child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome — completed, failed, timeout (the --timeout watchdog
+ * fired, or the bounded --version preflight hung), aborted (the relay itself
+ * was killed and forwarded the kill to omp), or omp_unavailable.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const VERSION_TIMEOUT_MS = 10_000;
+const READ_ONLY_TOOLS = "read,grep,glob";
+const THINKING_LEVELS = new Set(["off", "auto", "minimal", "low", "medium", "high", "xhigh", "max"]);
+// --model, --provider, and --session values must not look like flags. omp is
+// launched without a shell, so this is flag-injection defense, not quoting.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "omp";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    if (field === "effort") {
+      if (flagged.has("thinking")) continue;
+      opts.thinking = value;
+      continue;
+    }
+    if (field === "thinking" && flagged.has("thinking")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    provider: null,
+    model: null,
+    thinking: null,
+    session: null,
+    resumeLast: false,
+    readOnly: false,
+    approve: false,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--provider": opts.provider = next(); flagged.add("provider"); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--thinking": opts.thinking = next(); flagged.add("thinking"); break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--approve": opts.approve = true; break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  for (const flag of ["model", "provider", "session"]) {
+    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  if (opts.thinking !== null && !THINKING_LEVELS.has(opts.thinking)) {
+    fail(`invalid --thinking "${opts.thinking}" (expected: ${[...THINKING_LEVELS].join(", ")})`);
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
+  // setTimeout overflows past 2^31 - 1 ms (~24.8 days) and fires immediately,
+  // which would read as an instant spurious timeout — reject it up front.
+  if (parseDuration(opts.timeout) > 2_147_483_647) {
+    fail(`--timeout "${opts.timeout}" exceeds the maximum schedulable watchdog (~24.8 days)`);
+  }
+  if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to omp --mode json\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+async function ompVersion(timeoutMs, onChild) {
+  const limit = Math.min(timeoutMs, VERSION_TIMEOUT_MS);
+  const runProbe = (command, argv, options = {}) => new Promise((resolveProbe) => {
+    const child = spawn(command, argv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      ...options,
+    });
+    onChild(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timer;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveProbe({ stdout, stderr, ...result });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => finish({ code: null, error, timedOut: false }));
+    child.on("close", (code) => finish({ code, error: null, timedOut }));
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+    }, limit);
+  });
+
+  const probe = await runProbe("omp", ["--version"]);
+  if (probe.timedOut) {
+    return { version: null, error: Object.assign(new Error("omp --version timed out"), { code: "ETIMEDOUT", stderr: probe.stderr }) };
+  }
+  if (probe.error && probe.error.code === "ENOENT") return { version: null, error: null };
+  if (probe.error) return { version: null, error: probe.error };
+  if (probe.code !== 0) {
+    return { version: null, error: Object.assign(new Error("omp --version failed"), { status: probe.code, stderr: probe.stderr }) };
+  }
+  return { version: probe.stdout.trim() || "unknown", error: null };
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts) {
+  // The brief rides stdin, never argv. --mode json is print mode: omp reads
+  // the piped brief, streams events, and exits.
+  const argv = ["--mode", "json"];
+  if (opts.provider) argv.push("--provider", opts.provider);
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.thinking) argv.push("--thinking", opts.thinking);
+  if (opts.session) argv.push("--session", opts.session);
+  else if (opts.resumeLast) argv.push("--continue");
+  if (!opts.readOnly) argv.push("--yolo");
+  if (opts.readOnly) argv.push("--tools", READ_ONLY_TOOLS);
+  if (!opts.approve) argv.push("--no-extensions", "--no-skills", "--no-rules");
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  // A reused --out-dir must not leak a previous run's artifacts into this one.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "omp",
+      workdir: opts.cd,
+      provider: opts.provider,
+      model: opts.model,
+      thinking: opts.thinking,
+      readOnly: opts.readOnly,
+      yolo: !opts.readOnly,
+      projectTrusted: opts.approve,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      ompVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Atomic write: a polling orchestrator never reads a half-written result.
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "omp_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    stopReason: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `omp` not found on PATH. Install with `bun install -g @oh-my-pi/pi-coding-agent`, then authenticate (`/login`, or an API-key environment variable).\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(writeResult, run, error, timeoutMs) {
+  const timedOut = error && error.code === "ETIMEDOUT";
+  const stderr = String((error && error.stderr) || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `omp --version preflight timed out after ${Math.min(timeoutMs, VERSION_TIMEOUT_MS)}ms; omp was not dispatched`
+    : `omp --version preflight failed${Number.isInteger(error && error.status) ? ` with exit ${error.status}` : ""}; omp was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error && error.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    stopReason: null,
+    finalMessage: "",
+    touchedFiles: null,
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: null,
+        actualProvider: null,
+        actualModel: null,
+        usage: null,
+        stopReason: null,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the omp version preflight; omp was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
+function dispatchToOmp(opts, brief, run, writeResult) {
+  const child = spawn("omp", buildArgv(opts), {
+    cwd: opts.cd,
+    stdio: ["pipe", "pipe", "pipe"],
+    // Native binary on every platform, including Windows. Never shell: a shell
+    // would reinterpret the (already stdin-delivered) session, and omp.exe is
+    // not a .cmd shim.
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = null;
+  let actualProvider = null;
+  let actualModel = null;
+  let usage = null;
+  let stopReason = null;
+  let assistantError = null;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (event.type === "session" && typeof event.id === "string") {
+      sessionId = event.id;
+    }
+    if (event.type === "message_end" && event.message && event.message.role === "assistant") {
+      const content = event.message.content;
+      if (typeof content === "string") textChunks.push(content);
+      if (Array.isArray(content)) {
+        for (const part of content) {
+          if (part && part.type === "text" && typeof part.text === "string") textChunks.push(part.text);
+        }
+      }
+      if (typeof event.message.provider === "string") actualProvider = event.message.provider;
+      if (typeof event.message.model === "string") actualModel = event.message.model;
+      if (event.message.usage && typeof event.message.usage === "object") usage = event.message.usage;
+      if (typeof event.message.stopReason === "string") stopReason = event.message.stopReason;
+      if (typeof event.message.errorMessage === "string") assistantError = event.message.errorMessage;
+    }
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  // A fast-exiting omp (usage error, crashed startup) closes the pipe before
+  // the write; swallow EPIPE here — the exit code reports the failure.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the omp child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        actualProvider,
+        actualModel,
+        usage,
+        stopReason,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; omp was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      stopReason,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if omp handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code.
+    const assistantFailed = stopReason === "error" || stopReason === "aborted";
+    const succeeded = code === 0 && !watchdogFired && !assistantFailed;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      stopReason,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `omp did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...(!watchdogFired && assistantFailed ? { error: assistantError || `omp ended with stopReason "${stopReason}"` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const run = prepareRunDir(opts, brief);
+  let writeResult = makeResultWriter(opts, null, run);
+  let preflightChild = null;
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const probe = await ompVersion(timeoutMs, (child) => { preflightChild = child; });
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (!probe.version) {
+    clearPreflightSignals();
+    reportVersionFailure(writeResult, run, probe.error, timeoutMs);
+    return;
+  }
+  clearPreflightSignals();
+  dispatchToOmp(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  omp ${result.ompVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an omp error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated omp (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.readOnly) lines.push(`mode: read-only (tools ${READ_ONLY_TOOLS})`);
+  if (result.yolo) lines.push("mode: --yolo (tools.approvalMode yolo)");
+  if (result.projectTrusted) lines.push("mode: project resources trusted (--approve)");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.thinking) lines.push(`thinking: ${result.thinking}`);
+  if (result.actualModel) lines.push(`model: ${result.actualProvider ? `${result.actualProvider}/` : ""}${result.actualModel}`);
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- omp final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -140,7 +140,31 @@ if (process.env.SMOKE_MODE === "grok-read-only") {
   console.log(JSON.stringify({ type: "end", sessionId: "grok-session-1" }));
   process.exit(0);
 }
-if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
+if (["omp-success", "omp-error"].includes(process.env.SMOKE_MODE)) {
+  let brief = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => { brief += chunk; });
+  process.stdin.on("end", () => {
+    const failed = process.env.SMOKE_MODE === "omp-error";
+    fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify({ args, brief }));
+    console.log(JSON.stringify({ type: "session", version: 3, id: "omp-session-1", timestamp: "2026-01-01T00:00:00.000Z", cwd: process.cwd() }));
+    console.log(JSON.stringify({ type: "agent_start" }));
+    console.log(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: failed ? "fake omp failed" : "fake omp completed" }],
+        provider: "google",
+        model: "fake-model",
+        usage: { input: 7, output: 2, cacheRead: 1, cacheWrite: 0, totalTokens: 10, cost: { total: 0.001 } },
+        stopReason: failed ? "error" : "stop",
+        ...(failed ? { errorMessage: "fake provider failure" } : {}),
+      },
+    }));
+    console.log(JSON.stringify({ type: "agent_end", messages: [] }));
+    process.exit(0);
+  });
+} else if (["pi-success", "pi-error"].includes(process.env.SMOKE_MODE)) {
   let brief = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (chunk) => { brief += chunk; });

--- a/test/fixtures/fake-cli.cs
+++ b/test/fixtures/fake-cli.cs
@@ -5,7 +5,7 @@ using System.Threading;
 class FakeCli {
   static int Main(string[] args) {
     // Mirrors the .cjs fake: any probe form, and hang/fail selected by the mode's suffix,
-    // so a native-binary relay (agy, kimi, qoder, vibe) enters the same preflight matrix.
+    // so a native-binary relay (agy, kimi, qoder, vibe, aider, oz, omp) enters the same preflight matrix.
     var mode = Environment.GetEnvironmentVariable("SMOKE_MODE") ?? "";
     bool versionProbe = Array.IndexOf(args, "--version") >= 0
       || (args.Length > 0 && (args[0] == "version" || args[0] == "changelog"));
@@ -74,6 +74,32 @@ class FakeCli {
       Console.WriteLine("{\"role\":\"assistant\",\"content\":\"fake vibe completed\"}");
       return 0;
     }
+    if (mode == "omp-success" || mode == "omp-error") {
+      var brief = Console.In.ReadToEnd() ?? "";
+      var failed = mode == "omp-error";
+      var argsFile = Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE");
+      if (!String.IsNullOrEmpty(argsFile)) {
+        var payload = new System.Text.StringBuilder();
+        payload.Append("{\"args\":[");
+        for (int i = 0; i < args.Length; i++) {
+          if (i > 0) payload.Append(",");
+          payload.Append(JsonString(args[i]));
+        }
+        payload.Append("],\"brief\":");
+        payload.Append(JsonString(brief));
+        payload.Append("}");
+        File.WriteAllText(argsFile, payload.ToString());
+      }
+      Console.WriteLine("{\"type\":\"session\",\"version\":3,\"id\":\"omp-session-1\",\"timestamp\":\"2026-01-01T00:00:00.000Z\"}");
+      Console.WriteLine("{\"type\":\"agent_start\"}");
+      if (failed) {
+        Console.WriteLine("{\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"fake omp failed\"}],\"provider\":\"google\",\"model\":\"fake-model\",\"usage\":{\"input\":7,\"output\":2},\"stopReason\":\"error\",\"errorMessage\":\"fake provider failure\"}}");
+      } else {
+        Console.WriteLine("{\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"fake omp completed\"}],\"provider\":\"google\",\"model\":\"fake-model\",\"usage\":{\"input\":7,\"output\":2},\"stopReason\":\"stop\"}}");
+      }
+      Console.WriteLine("{\"type\":\"agent_end\",\"messages\":[]}");
+      return 0;
+    }
     var psi = new ProcessStartInfo {
       FileName = Environment.GetEnvironmentVariable("SMOKE_NODE"),
       Arguments = "-e setInterval(()=>{},1000)",
@@ -84,5 +110,9 @@ class FakeCli {
     File.WriteAllText(Environment.GetEnvironmentVariable("SMOKE_PID_FILE"), Process.GetCurrentProcess().Id.ToString());
     Thread.Sleep(Timeout.Infinite);
     return 0;
+  }
+  static string JsonString(string s) {
+    if (s == null) s = "";
+    return "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "\\r").Replace("\n", "\\n") + "\"";
   }
 }

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp"];
+export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp"];
 
 export const EXTRA_ARGS = {
   claude: [],
@@ -14,6 +14,7 @@ export const EXTRA_ARGS = {
   vibe: [],
   cursor: [],
   pi: [],
+  omp: [],
   aider: [],
   copilot: [],
   warp: [],

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -22,7 +22,7 @@ export function installShim(h) {
       join(windir, "Microsoft.NET", "Framework64", "v4.0.30319", "csc.exe"),
       join(windir, "Microsoft.NET", "Framework", "v4.0.30319", "csc.exe"),
     ].find((p) => existsSync(p));
-    h.check("windows: the in-box C# compiler exists (builds the native fake for agy/kimi/qoder/vibe/aider)", Boolean(csc));
+    h.check("windows: the in-box C# compiler exists (builds the native fake for agy/kimi/qoder/vibe/aider/oz/omp)", Boolean(csc));
     if (csc) {
       const csFile = join(shimDir, "fake-cli.cs");
       copyFileSync(join(fixturesDir, "fake-cli.cs"), csFile);
@@ -36,6 +36,7 @@ export function installShim(h) {
         // without a shell, so a .cmd shim would never be found the way the real one is.
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "aider.exe"));
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "oz.exe"));
+        copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "omp.exe"));
       } else {
         console.error(`${compiled.stdout ?? ""}${compiled.stderr ?? ""}`);
       }

--- a/test/relay-isolated.mjs
+++ b/test/relay-isolated.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp"];
 let failed = 0;
 const check = (name, condition) => {
   console.log(`${condition ? "  ok " : "  FAIL"}  ${name}`);

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "aider", "copilot", "warp"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp"];
 const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],
@@ -27,9 +27,9 @@ const SYMBOLS = [
   ["fingerprintDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["changedDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["readOnlyVerdict", "function", READ_ONLY_TRIPWIRE_RELAYS],
-  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "copilot", "cursor", "grok", "kimi", "opencode", "pi", "qoder", "vibe", "warp"]],
+  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "copilot", "cursor", "grok", "kimi", "opencode", "pi", "omp", "qoder", "vibe", "warp"]],
   ["makeLineScanner", "function", ["vibe", "copilot"]],
-  ["makeEventScanner", "function", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "qoder", "warp"]],
+  ["makeEventScanner", "function", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "omp", "qoder", "warp"]],
 ];
 let failed = 0;
 const check = (name, condition) => {

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -7,11 +7,11 @@
  * not complete:
  *
  *   1. timeout  — the watchdog kills the implementer's WHOLE process tree and
- *                 result.json reports status "timeout". Driven for all fourteen
+ *                 result.json reports status "timeout". Driven for all fifteen
  *                 relays on both platforms. On Windows, claude and cursor
  *                 launch a .cmd shim through a serialized cmd.exe invocation,
  *                 while codex/opencode/grok/pi/cline use shell:true. These are exactly the
- *                 cases a plain child.kill would miss; agy, aider, kimi, qoder, vibe, and oz spawn a
+ *                 cases a plain child.kill would miss; agy, aider, kimi, qoder, vibe, oz, and omp spawn a
  *                 native binary directly — a .cmd stand-in cannot represent them,
  *                 so the smoke compiles a real fake .exe with the C# compiler
  *                 that ships in-box with Windows (no install, no network) and
@@ -23,7 +23,7 @@
  *   2. aborted  — killing the relay itself still produces result.json with
  *                 status "aborted", and files the implementer flushes during
  *                 the shutdown grace window appear in the refreshed
- *                 touchedFiles. Driven for all fourteen relays on POSIX; Windows
+ *                 touchedFiles. Driven for all fifteen relays on POSIX; Windows
  *                 delivers no catchable SIGTERM, so the scenario cannot be
  *                 driven there (the skill docs carry the same caveat).
  *
@@ -31,10 +31,10 @@
  * `changelog`), and can be told to hang or fail that probe by mode name, so a
  * relay whose preflight is unbounded — wedging before any result.json exists —
  * or which reports a broken CLI as a missing one is caught here.
- * A shared matrix also drives all fourteen through the --timeout values no
+ * A shared matrix also drives all fifteen through the --timeout values no
  * watchdog can honour — malformed, zero, and past Node's timer ceiling — each of
  * which would otherwise fire on the next tick as a silent instant "timeout".
- * Quick Claude, Cline, Cursor, Qoder, Vibe, and Pi success cases verify brief
+ * Quick Claude, Cline, Cursor, Qoder, Vibe, Pi, and Oh My Pi success cases verify brief
  * delivery, launch arguments, environment handling, and result-event parsing. The
  * timeout/abort cases otherwise run until killed and spawn a subprocess of
  * their own; both assert that this grandchild dies with the implementer.

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -347,6 +347,19 @@ if (observation === "models") {
     h.check("config validate rejects unknown copilot effort",
       rejectCopilot.status === 2 && /low, medium, high, xhigh, max/.test(rejectCopilot.stderr));
 
+    const badOmp = {
+      version: "delegate-fleet.v1",
+      lanes: { feature: { implementer: "omp", effort: "inherit" } },
+    };
+    const badOmpFile = join(cfgRepo, "bad-omp.json");
+    writeFileSync(badOmpFile, `${JSON.stringify(badOmp)}\n`);
+    const rejectOmp = spawnSync(process.execPath, [join(setupDir, "config.mjs"), "validate", badOmpFile], {
+      encoding: "utf8",
+      env: process.env,
+    });
+    h.check("config validate rejects unknown omp thinking effort",
+      rejectOmp.status === 2 && /off, auto, minimal, low, medium, high, xhigh, max/.test(rejectOmp.stderr));
+
     const badCursorSandbox = {
       version: "delegate-fleet.v1",
       lanes: { feature: { implementer: "cursor", sandbox: "workspace-write" } },
@@ -417,6 +430,39 @@ if (observation === "models") {
         grokDials?.dials?.readOnly === undefined,
     );
     // Restore the multi-lane global map for the rest of the fleet suite.
+    spawnSync(process.execPath, [join(setupDir, "config.mjs"), "write", "--scope", "global", goodFile], {
+      encoding: "utf8",
+      env: process.env,
+    });
+
+    const ompThinking = {
+      version: "delegate-fleet.v1",
+      lanes: { feature: { implementer: "omp", effort: "high", model: "google/fake-model" } },
+    };
+    const ompThinkingFile = join(cfgRepo, "omp-thinking.json");
+    writeFileSync(ompThinkingFile, `${JSON.stringify(ompThinking)}\n`);
+    spawnSync(process.execPath, [join(setupDir, "config.mjs"), "write", "--scope", "global", ompThinkingFile], {
+      encoding: "utf8",
+      env: process.env,
+    });
+    const ompResolve = spawnSync(
+      process.execPath,
+      [join(setupDir, "lane.mjs"), "resolve", "--cwd", bare, "--lane", "feature", "--implementer", "omp"],
+      { encoding: "utf8", env: process.env },
+    );
+    let ompDials = null;
+    try {
+      ompDials = JSON.parse(ompResolve.stdout);
+    } catch {
+      ompDials = null;
+    }
+    h.check(
+      "lane resolve: omp effort → thinking",
+      ompResolve.status === 0 &&
+        ompDials?.dials?.thinking === "high" &&
+        ompDials?.dials?.effort === undefined &&
+        ompDials?.dials?.model === "google/fake-model",
+    );
     spawnSync(process.execPath, [join(setupDir, "config.mjs"), "write", "--scope", "global", goodFile], {
       encoding: "utf8",
       env: process.env,

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -10,6 +10,7 @@ import { runPreflight } from "./preflight.mjs";
 import { runTimeoutBounds } from "./timeout-bounds.mjs";
 import { runQoder } from "./qoder.mjs";
 import { runPi } from "./pi.mjs";
+import { runOmp } from "./omp.mjs";
 import { runClaude } from "./claude.mjs";
 import { runReadOnlyTripwire } from "./read-only-tripwire.mjs";
 import { runTimeoutTree } from "./timeout-tree.mjs";
@@ -31,6 +32,7 @@ export const runners = [
   ["timeout-bounds", runTimeoutBounds],
   ["qoder", runQoder],
   ["pi", runPi],
+  ["omp", runOmp],
   ["claude", runClaude],
   ["aider", runAider],
   ["copilot", runCopilot],

--- a/test/relay/omp.mjs
+++ b/test/relay/omp.mjs
@@ -1,0 +1,328 @@
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export async function runOmp(h) {
+  const outDir = join(h.scratch, "out-success-omp");
+  const workDir = h.freshRepo("work-success-omp");
+  const argsFile = join(h.scratch, "args-success-omp");
+  const run = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--provider", "google",
+    "--model", "google/fake-model",
+    "--thinking", "high",
+    "--read-only",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "omp-success", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  const capture = existsSync(argsFile) ? JSON.parse(readFileSync(argsFile, "utf8")) : {};
+  h.check("omp success: relay exits zero", run.status === 0);
+  h.check("omp success: documented argv is exact",
+    JSON.stringify(capture.args) === JSON.stringify([
+      "--mode", "json",
+      "--provider", "google",
+      "--model", "google/fake-model",
+      "--thinking", "high",
+      "--tools", "read,grep,glob",
+      "--no-extensions", "--no-skills", "--no-rules",
+    ]));
+  h.check("omp success: brief delivered through stdin", capture.brief === "smoke brief: run until killed.");
+  h.check("omp success: result.json exists", existsSync(join(outDir, "result.json")));
+  if (existsSync(join(outDir, "result.json"))) {
+    const value = h.result(outDir);
+    h.check("omp success: session header and message_end parsed",
+      value.status === "completed" &&
+      value.sessionId === "omp-session-1" &&
+      value.finalMessage === "fake omp completed" &&
+      value.readOnly === true &&
+      value.yolo === false &&
+      value.projectTrusted === false &&
+      value.provider === "google" &&
+      value.model === "google/fake-model" &&
+      value.thinking === "high" &&
+      value.actualProvider === "google" &&
+      value.actualModel === "fake-model" &&
+      value.usage?.input === 7 &&
+      value.usage?.output === 2 &&
+      value.stopReason === "stop" &&
+      value.resumed === false);
+  }
+
+  const writeOutDir = join(h.scratch, "out-write-omp");
+  const writeArgsFile = join(h.scratch, "args-write-omp");
+  const writeRun = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", writeOutDir,
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "omp-success", SMOKE_ARGS_FILE: writeArgsFile },
+    encoding: "utf8",
+  });
+  const writeCapture = existsSync(writeArgsFile) ? JSON.parse(readFileSync(writeArgsFile, "utf8")) : {};
+  h.check("omp write: --yolo and untrusted project resources",
+    writeRun.status === 0 &&
+    JSON.stringify(writeCapture.args) === JSON.stringify([
+      "--mode", "json",
+      "--yolo",
+      "--no-extensions", "--no-skills", "--no-rules",
+    ]) &&
+    existsSync(join(writeOutDir, "result.json")) &&
+    h.result(writeOutDir).yolo === true &&
+    h.result(writeOutDir).projectTrusted === false);
+
+  const approveOutDir = join(h.scratch, "out-approve-omp");
+  const approveArgsFile = join(h.scratch, "args-approve-omp");
+  const approveRun = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", approveOutDir,
+    "--approve",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "omp-success", SMOKE_ARGS_FILE: approveArgsFile },
+    encoding: "utf8",
+  });
+  const approveCapture = existsSync(approveArgsFile) ? JSON.parse(readFileSync(approveArgsFile, "utf8")) : {};
+  h.check("omp project trust: --approve omits --no-extensions/--no-skills/--no-rules",
+    approveRun.status === 0 &&
+    JSON.stringify(approveCapture.args) === JSON.stringify(["--mode", "json", "--yolo"]) &&
+    existsSync(join(approveOutDir, "result.json")) &&
+    h.result(approveOutDir).projectTrusted === true &&
+    h.result(approveOutDir).yolo === true);
+
+  const unsafeProvider = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--provider", "google & whoami",
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("omp provider: flag-unsafe value is rejected", unsafeProvider.status === 2);
+
+  const badThinking = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--thinking", "inherit",
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("omp thinking: inherit is rejected before dispatch",
+    badThinking.status === 2 && /invalid --thinking/.test(badThinking.stderr));
+
+  const listModels = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--list-models",
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("omp: --list-models is not a relay flag",
+    listModels.status === 2 && /unknown option: --list-models/.test(listModels.stderr));
+
+  const errorOutDir = join(h.scratch, "out-error-omp");
+  const errorArgsFile = join(h.scratch, "args-error-omp");
+  const errorRun = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", errorOutDir,
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "omp-error", SMOKE_ARGS_FILE: errorArgsFile },
+    encoding: "utf8",
+  });
+  const errorResult = existsSync(join(errorOutDir, "result.json")) ? h.result(errorOutDir) : {};
+  h.check("omp assistant error: exit-zero event is reported as failed",
+    errorRun.status === 1 &&
+    errorResult.status === "failed" &&
+    errorResult.exitCode === 1 &&
+    errorResult.stopReason === "error" &&
+    errorResult.error === "fake provider failure");
+
+  const resumeOutDir = join(h.scratch, "out-resume-last-omp");
+  const resumeArgsFile = join(h.scratch, "args-resume-last-omp");
+  const resume = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", resumeOutDir,
+    "--resume-last",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "omp-success", SMOKE_ARGS_FILE: resumeArgsFile },
+    encoding: "utf8",
+  });
+  const resumeCapture = existsSync(resumeArgsFile) ? JSON.parse(readFileSync(resumeArgsFile, "utf8")) : {};
+  h.check("omp resume-last: uses documented --continue",
+    resume.status === 0 &&
+    Array.isArray(resumeCapture.args) &&
+    resumeCapture.args.includes("--continue") &&
+    !resumeCapture.args.includes("--session") &&
+    existsSync(join(resumeOutDir, "result.json")) &&
+    h.result(resumeOutDir).resumed === true);
+
+  const sessionOutDir = join(h.scratch, "out-session-omp");
+  const sessionArgsFile = join(h.scratch, "args-session-omp");
+  const session = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", sessionOutDir,
+    "--session", "omp-session-1",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "omp-success", SMOKE_ARGS_FILE: sessionArgsFile },
+    encoding: "utf8",
+  });
+  const sessionCapture = existsSync(sessionArgsFile) ? JSON.parse(readFileSync(sessionArgsFile, "utf8")) : {};
+  h.check("omp session: uses documented --session <id>",
+    session.status === 0 &&
+    JSON.stringify(sessionCapture.args) === JSON.stringify([
+      "--mode", "json",
+      "--session", "omp-session-1",
+      "--yolo",
+      "--no-extensions", "--no-skills", "--no-rules",
+    ]) &&
+    existsSync(join(sessionOutDir, "result.json")) &&
+    h.result(sessionOutDir).resumed === true);
+
+  const bothResume = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--resume-last",
+    "--session", "omp-session-1",
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("omp resume: --resume-last and --session are mutually exclusive",
+    bothResume.status === 2 && /mutually exclusive/.test(bothResume.stderr));
+
+  {
+    const setupDir = join(h.testDir, "..", "skills", "delegate-setup", "scripts");
+    const cfgHome = join(h.scratch, "home-lane-omp");
+    mkdirSync(cfgHome, { recursive: true });
+    const laneFile = join(workDir, "omp-lane.json");
+    writeFileSync(laneFile, `${JSON.stringify({
+      version: "delegate-fleet.v1",
+      lanes: {
+        feature: {
+          implementer: "omp",
+          provider: "google",
+          model: "google/fake-model",
+          effort: "high",
+        },
+      },
+    })}\n`);
+    const fleetEnv = { ...h.baseEnv, HOME: cfgHome, USERPROFILE: cfgHome };
+    delete fleetEnv.XDG_CONFIG_HOME;
+    const writeCfg = spawnSync(process.execPath, [join(setupDir, "config.mjs"), "write", "--scope", "global", laneFile], {
+      encoding: "utf8",
+      env: fleetEnv,
+    });
+    h.check("omp lane: global model/thinking lane is written", writeCfg.status === 0);
+    const laneOutDir = join(h.scratch, "out-lane-omp");
+    const laneArgsFile = join(h.scratch, "args-lane-omp");
+    const laneRun = spawnSync(process.execPath, [
+      h.relayPath("omp"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", laneOutDir,
+      "--lane", "feature",
+    ], {
+      env: { ...fleetEnv, SMOKE_MODE: "omp-success", SMOKE_ARGS_FILE: laneArgsFile },
+      encoding: "utf8",
+    });
+    const laneCapture = existsSync(laneArgsFile) ? JSON.parse(readFileSync(laneArgsFile, "utf8")) : {};
+    h.check("omp lane: provider/model/effort become --provider/--model/--thinking",
+      writeCfg.status === 0 &&
+      laneRun.status === 0 &&
+      JSON.stringify(laneCapture.args) === JSON.stringify([
+        "--mode", "json",
+        "--provider", "google",
+        "--model", "google/fake-model",
+        "--thinking", "high",
+        "--yolo",
+        "--no-extensions", "--no-skills", "--no-rules",
+      ]) &&
+      h.result(laneOutDir).thinking === "high" &&
+      h.result(laneOutDir).model === "google/fake-model");
+    const overrideOutDir = join(h.scratch, "out-lane-override-omp");
+    const overrideArgsFile = join(h.scratch, "args-lane-override-omp");
+    const overrideRun = spawnSync(process.execPath, [
+      h.relayPath("omp"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", overrideOutDir,
+      "--lane", "feature",
+      "--thinking", "low",
+    ], {
+      env: { ...fleetEnv, SMOKE_MODE: "omp-success", SMOKE_ARGS_FILE: overrideArgsFile },
+      encoding: "utf8",
+    });
+    const overrideCapture = existsSync(overrideArgsFile) ? JSON.parse(readFileSync(overrideArgsFile, "utf8")) : {};
+    h.check("omp lane: explicit --thinking wins over lane effort",
+      overrideRun.status === 0 &&
+      overrideCapture.args?.includes("--thinking") &&
+      overrideCapture.args[overrideCapture.args.indexOf("--thinking") + 1] === "low" &&
+      h.result(overrideOutDir).thinking === "low");
+  }
+
+  const missingOutDir = join(h.scratch, "out-unavailable-omp");
+  const missing = spawnSync(process.execPath, [
+    h.relayPath("omp"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", missingOutDir,
+  ], { env: { ...process.env, PATH: "" }, encoding: "utf8" });
+  h.check("omp unavailable: missing binary writes the structured result",
+    missing.status === 127 &&
+    existsSync(join(missingOutDir, "result.json")) &&
+    h.result(missingOutDir).status === "omp_unavailable");
+
+  for (const [mode, expectedStatus, expectedExit] of [
+    ["omp-version-fail", "failed", 7],
+    ["omp-version-hang", "timeout", 124],
+  ]) {
+    const preflightOutDir = join(h.scratch, `out-${mode}`);
+    const preflight = spawnSync(process.execPath, [
+      h.relayPath("omp"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", preflightOutDir,
+      "--timeout", "1s",
+    ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
+    const preflightResult = existsSync(join(preflightOutDir, "result.json"))
+      ? h.result(preflightOutDir)
+      : {};
+    h.check(`omp preflight: ${mode} is explicit and prevents dispatch`,
+      preflight.status === expectedExit &&
+      preflightResult.status === expectedStatus &&
+      preflightResult.error?.includes("version preflight") &&
+      preflightResult.error?.includes("was not dispatched"));
+  }
+
+  if (!h.WIN) {
+    const preflightOutDir = join(h.scratch, "out-abort-preflight-omp");
+    const preflight = h.runRelay("omp", workDir, preflightOutDir, ["--timeout", "1s"], {
+      SMOKE_MODE: "omp-version-hang",
+    });
+    h.check("omp preflight abort: run artifacts are prepared",
+      await h.until(() => existsSync(join(preflightOutDir, "events.jsonl")), 2000));
+    preflight.kill("SIGTERM");
+    const exited = await new Promise((resolveExit) => {
+      const timer = setTimeout(() => {
+        preflight.kill("SIGKILL");
+        resolveExit(false);
+      }, 5000);
+      preflight.on("close", () => {
+        clearTimeout(timer);
+        resolveExit(true);
+      });
+    });
+    const value = existsSync(join(preflightOutDir, "result.json")) ? h.result(preflightOutDir) : {};
+    h.check("omp preflight abort: result is aborted and dispatch never starts",
+      exited &&
+      value.status === "aborted" &&
+      value.signal === "SIGTERM" &&
+      value.error?.includes("version preflight") &&
+      value.error?.includes("was not dispatched"));
+  }
+}

--- a/test/relay/timeout-tree.mjs
+++ b/test/relay/timeout-tree.mjs
@@ -12,6 +12,7 @@ const TIMEOUT_CASES = [
   { skill: "kimi", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "qoder", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "pi", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "omp", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "cursor", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "vibe", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "agy", flags: ["--timeout", "6s"], exitDeadline: 45_000 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Claim:** none — no open implementer issue for Oh My Pi. Research and implementation happened in this run. `omp` is a Pi fork (`@oh-my-pi/pi-coding-agent`) and is not folded into `pi-delegate`.

**What ran:** Linux (6.12, Node 22.23.2), contract-tested, live run pending. `omp` is not installed in this environment. After merging `master` (`zcode-delegate`):

- `node test/relay-parity.mjs`
- `node test/relay-isolated.mjs`
- `node test/event-scanner.mjs`
- `node test/relay-smoke.mjs` (all green, including omp and zcode)
- `npx skills add . --list` (17 skills: 16 implementers + `delegate-setup`)

Native Windows launch is a native `omp.exe` (no `shell:true`); that path is contract-tested via the smoke matrix's compiled fake on `windows-latest` CI, not against a live Oh My Pi install.

## CodeRabbit (advisory)

Judged the 5 inline comments plus the SKILL.md-lean nitpick against sibling skills and CONTRIBUTING. Applied one: the research-brief bullet now states `--read-only` is a tool-surface limit, not a sandbox, and `--approve` stays off unless the user trusts the repo. The rest would diverge from the family contract (verification-line wording, “background implementer” trigger phrase, queue PR closeout, extra HITL on `--yolo`) or are generic SkillSpector EA2/RA2; replies are on the threads.

## Why a separate skill

Oh My Pi meets the four CONTRIBUTING invariants (local working tree, relay never commits, Node built-ins only, autonomy in the CLI's own terms). It is not the original Pi CLI: different binary (`omp` vs `pi`), different catalog command (`omp models` vs `pi --list-models`), different write autonomy (`--yolo`), different read-only tool surface (`read,grep,glob`).

## Model selection

The catalog is **this install's** authenticated providers — not a pin in the skill.

1. List: `omp models`, `omp models --json`, `omp models find <substring>`, `omp models <provider>`.
2. Dispatch: `--model <pattern>` (omp fuzzy match) and optional `--provider <name>`. Omit both for omp's configured default.
3. Do **not** pass `omp --list-models` — that flag is a hard error.
4. `--thinking` is a separate reasoning dial (`off`, `auto`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). A fleet lane's `effort` maps to it; an explicit `--thinking` wins.

## Merge checklist

- [x] `skills/omp-delegate/SKILL.md` — triggers on Oh My Pi / `omp`, not on `pi`
- [x] Four references
- [x] `scripts/relay.mjs` — Node built-ins, never commits, stdin brief, no shell
- [x] `delegate-relay.result.v1` including `omp_unavailable`
- [x] Smoke matrix + `skills.sh.json` + README row + AGENTS.md vocabulary
- [x] Merged current `master` (keeps `zcode-delegate`); count is sixteen implementers
- [x] Verification line: contract-tested, live run pending

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01c35-5763-7a00-a68d-f353797c40dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01c35-5763-7a00-a68d-f353797c40dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oh My Pi (`omp`) as a supported coding-agent delegation option.
  * Added controls for provider, model, effort, timeout, read-only access, approvals, and session continuation.
  * Added task dispatch, progress tracking, result reporting, recovery guidance, and native Windows support.
* **Documentation**
  * Added setup, briefing, queue management, review, verification, and safety guidance.
* **Tests**
  * Added coverage for successful runs, errors, validation, timeouts, sessions, recovery, and platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->