### PR TITLE
feat: add dsh-delegate (DeepSeek Harness)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,13 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Seventeen implementer skills ship today: `claude-delegate` (Claude Code),
+and land the result. Eighteen implementer skills ship today: `claude-delegate` (Claude Code),
 `cline-delegate` (Cline CLI), `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode),
 `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code),
 `qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI),
 `pi-delegate` (Pi CLI), `omp-delegate` (Oh My Pi), `aider-delegate` (Aider), `copilot-delegate` (GitHub Copilot CLI),
-`warp-delegate` (Warp Agent CLI), `zcode-delegate` (Z.AI ZCode), and `commandcode-delegate` (Command Code); siblings like
+`warp-delegate` (Warp Agent CLI), `zcode-delegate` (Z.AI ZCode), `commandcode-delegate` (Command Code),
+and `dsh-delegate` (DeepSeek Harness); siblings like
 `gemini-delegate` can be added
 later without renaming the repo. One **utility** skill
 ships alongside them: `delegate-setup` (configure fleet lanes — setup only, never dispatches).
@@ -21,7 +22,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Oh My Pi, Aider, Copilot, Warp, ZCode, Command Code) | "worker", "sub-agent", "executor" |
+| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Oh My Pi, Aider, Copilot, Warp, ZCode, Command Code, DeepSeek Harness) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -47,6 +48,7 @@ jargon. Use these terms; don't invent synonyms.
 | `--message-file`, `--yes-always`, `--suggest-shell-commands`, `--auto-commits`/`--dirty-commits`, `--dry-run`, `--edit-format`, `--architect`, `--file`/`--read`, `chat history` | Aider's own terms — use verbatim when discussing `aider` | Aider has no sandbox, no permission modes, and no session ids; don't imply any. `--file`/`--read` scope the chat context — never call them a boundary |
 | `session`, `-p`/`--prompt`, `--output-format json` (JSONL), `tools`, `--allow-all-tools`, `mode plan`, `--resume`/`--continue`, `--model`, `--effort`, `copilot login` / env tokens, `sandbox` (experimental, MXC) | GitHub Copilot CLI's own terms — use verbatim when discussing `copilot` | don't paraphrase them |
 | `mode` (`build`/`edit`/`plan`/`yolo`), `session` (`sess_…`), `goal` (`--target`), `--attach`, `app-server`, `plugins`, `skills` | ZCode's own terms — use verbatim when discussing `zcode` | don't call `mode` a sandbox or a permission mode; never present `build`/`edit` as usable headlessly |
+| `--profile headless`, `profile`, `bundle`, `patch` / `--patch`, `workspace root`, `DSH_PERMISSION_MODE` (`read-only` / `workspace-write` / `danger-full-access`), `approval policy` (`ask` / `never`), `agent-default-model`, `$DSH_HOME` | DeepSeek Harness's own terms — use verbatim when discussing `dsh` | don't call `DSH_PERMISSION_MODE` a permission-mode flag (it is an environment override), don't invent a `dsh` session/resume vocabulary, and don't call a `--patch` overlay a "config merge" (it replaces the row's whole `config`) |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -55,7 +57,7 @@ version a run was made against is what makes the claim checkable; and claims tha
 ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
 `cline` / `codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi` /
-`aider` / `copilot` / `oz` / `omp` / `zcode` / `cmd`) and the skill's `relay.mjs`.
+`aider` / `copilot` / `oz` / `omp` / `zcode` / `cmd` / `dsh`) and the skill's `relay.mjs`.
 
 ## Conventions
 
@@ -90,7 +92,7 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - Smoke-test any changed script directly (e.g. `node skills/<skill>/scripts/relay.mjs --help`, and a
   no-write or read-only run against a throwaway repo) before relying on it.
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
-  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, `grok`, `pi`, `cline`, and `copilot` launches
+  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, `grok`, `pi`, `cline`, `copilot`, and `dsh` launches
   need `shell:true` on win32 to resolve the `.cmd` shim. Cline streams its brief on stdin and uses the
   child process cwd; the other launches quote spaceable args, and all value flags are token-validated.
   The `claude` and `cursor-agent` launches serialize a pre-joined

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`copilot-delegate`](skills/copilot-delegate/SKILL.md) | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli) (`copilot`) | `--allow-all-tools` opt-in; headless auto-deny otherwise | `--read-only` (`--mode plan`) | `--resume-last`, `--session <id>` |
 | [`warp-delegate`](skills/warp-delegate/SKILL.md) | [Warp Agent CLI](https://docs.warp.dev/cli/) (`oz`) | full local tools — no sandbox, no permission modes [^none] | — [^none] | `--conversation <id>` |
 | [`zcode-delegate`](skills/zcode-delegate/SKILL.md) | [Z.AI ZCode](https://zcode.z.ai) (`zcode`) [^zcode] | `--mode yolo` | `--read-only` (`plan` mode) | `--resume-last`, `--session <id>` |
+| [`dsh-delegate`](skills/dsh-delegate/SKILL.md) | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) — developer preview | `workspace-write` (`read-only` / `danger-full-access` via `DSH_PERMISSION_MODE`) | `--read-only` (`read-only` mode, tripwire) | — (no resume; `sessionId: null`) |
 
 [^commandcode]: Command Code's headless mode has two states and nothing between them: a `-p` run
 withholds the write, edit, and shell tools, and `--yolo` (alias `--dangerously-skip-permissions`)
@@ -325,6 +326,25 @@ Per skill — platform, CLI version, and what the run exercised:
 - `codex-delegate`, `opencode-delegate`, `vibe-delegate` — contract-tested only: argument validation,
   bounded version preflight, missing binary, result parsing, and whole-process-tree timeout/abort
   cleanup. No end-to-end run is recorded here.
+- `dsh-delegate` — Windows 11, `dsh` 0.1.0-rc.7 (npm global install), driven from both Git
+  Bash and native PowerShell: live `dsh --profile headless` runs through the relay in both
+  postures, each posture run from each shell, which exercises the `shell:true` `.cmd` shim path.
+  A default-posture run applied the briefed one-line edit and left it uncommitted, with
+  `touchedFiles` reporting the modified file
+  and `dshVersion` captured from the bounded preflight; a `--read-only` run whose brief ordered an
+  immediate file write was refused by the harness itself — "the current sandbox is read-only, and
+  the required write-access approval is unavailable" — leaving `touchedFiles` empty and
+  `readOnlyViolation` false, which exercises both the sandbox and the fail-closed approval seam.
+  Both runs proved the pointer-file brief delivery, since the task positional carries only the path.
+  Direct CLI probes covered the launcher and app help, the no-task usage error, and a generated
+  `agent-default-model` overlay landing in `--dump-config`. That overlay is a request, not a
+  guarantee: a stored selection in `$DSH_HOME/settings.yaml` outranks the composition entry,
+  measured by a run whose overlay named a nonexistent model and completed on the stored selection
+  anyway — hence `modelOverlay` reports what was requested, never what ran. Contract-tested against
+  the shared smoke matrix besides: argument validation and usage errors exiting 2 with no result
+  file, a missing binary exiting 127 with one, `result.json` shape, and whole-process-tree
+  timeout/abort cleanup. Not run: macOS or Linux, `cmd.exe` as the launching shell, and timeout or
+  abort against a live `dsh` rather than the smoke matrix's compiled fake.
 - `cline-delegate` — macOS, `cline` 3.0.52: current-binary unauthenticated plan probe reached
   `run_start` with the fixed positional instruction plus the real brief on stdin, accepted a
   provider-local model id, parsed the failing `run_result`, and left the tree clean. Contract-tested:

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -21,7 +21,8 @@
         "copilot-delegate",
         "warp-delegate",
         "zcode-delegate",
-        "commandcode-delegate"
+        "commandcode-delegate",
+        "dsh-delegate"
       ]
     },
     {

--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -34,6 +34,7 @@ import {
   OMP_THINKING,
   CODEX_SANDBOX,
   CONFIG_VERSION,
+  DSH_PERMISSION,
   GROK_SANDBOX,
   IMPLEMENTER_BY_KEY,
   LANE_NAME,
@@ -169,6 +170,11 @@ function validateLane(name, lane, label) {
       return `${label}: lane ${name}.model must be provider/model (e.g. opencode/grok)`;
     }
   }
+  // The relay derives one agent-default-model overlay from both halves and exits 2
+  // on a provider with no model, so a lane must not be able to store that pair.
+  if (impl.key === "dsh" && typeof lane.provider === "string" && typeof lane.model !== "string") {
+    return `${label}: lane ${name}: dsh provider needs model`;
+  }
   const autonomyError = validateAutonomyConsistency(impl.key, lane, name, label);
   if (autonomyError) return autonomyError;
   return null;
@@ -186,6 +192,13 @@ function validateAutonomyConsistency(implementer, lane, laneName, label) {
     implementer === "qoder" &&
     typeof lane.permissionMode === "string" &&
     lane.permissionMode !== "plan"
+  ) {
+    return `${label}: lane ${laneName}: readOnly contradicts permissionMode ${JSON.stringify(lane.permissionMode)}`;
+  }
+  if (
+    implementer === "dsh" &&
+    typeof lane.permissionMode === "string" &&
+    lane.permissionMode !== "read-only"
   ) {
     return `${label}: lane ${laneName}: readOnly contradicts permissionMode ${JSON.stringify(lane.permissionMode)}`;
   }
@@ -255,6 +268,9 @@ function validateDialValue(implementer, field, value, laneName, label) {
   // have no permission client, so they change nothing and still exit 0.
   if (field === "permissionMode" && implementer === "zcode" && !ZCODE_MODE.includes(value)) {
     return `${label}: lane ${laneName}.permissionMode must be one of: ${ZCODE_MODE.join(", ")}`;
+  }
+  if (field === "permissionMode" && implementer === "dsh" && !DSH_PERMISSION.includes(value)) {
+    return `${label}: lane ${laneName}.permissionMode must be one of: ${DSH_PERMISSION.join(", ")}`;
   }
   if (field === "variant") {
     // OpenCode appends --variant on win32 shell:true; reject cmd metacharacters.

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -424,6 +424,12 @@ export const QODER_PERMISSION = Object.freeze([
  * the same reason, so a lane must not be able to select one either.
  */
 export const ZCODE_MODE = Object.freeze(["plan", "yolo"]);
+/**
+ * dsh's DSH_PERMISSION_MODE, carried as the `permissionMode` dial. These are the
+ * harness's own preset names; the relay rejects anything else with exit 2, so a
+ * lane must not be able to select one either.
+ */
+export const DSH_PERMISSION = Object.freeze(["read-only", "workspace-write", "danger-full-access"]);
 /** Positive h/m/s duration, same shape relays accept. */
 export const TIMEOUT_RE = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/;
 

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -380,6 +380,19 @@ export const IMPLEMENTERS = Object.freeze([
     winShell: false,
 
   },
+  {
+    key: "dsh",
+    skill: "dsh-delegate",
+    binary: "dsh",
+    versionArgs: ["--version"],
+    // No auth-status command; credentials resolve from env / $DSH_HOME files.
+    authProbe: null,
+    modelProbe: null,
+    // Sessions persist under $DSH_HOME but headless prints no id; unknown not guessed.
+    usageProbe: null,
+    supports: ["provider", "model", "timeout", "readOnly", "permissionMode"],
+    winShell: true,
+  },
 ]);
 
 /** Prototype-free map so names like "toString" cannot pass as implementers. */

--- a/skills/dsh-delegate/SKILL.md
+++ b/skills/dsh-delegate/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: dsh-delegate
+description: >-
+  Delegate a coding task to the DeepSeek Harness CLI (`dsh`) as a background implementer, then review its diff and land it yourself. Use this whenever the user wants to hand implementation work to DeepSeek Harness — phrasings like "have DeepSeek do X", "delegate this to dsh", "run it through DeepSeek Harness", or "use dsh to implement/fix/refactor" — or wants to run a queue of coding tasks through dsh while staying the reviewer. DO NOT USE for tasks small enough to do inline, or when the user wants the code written directly without delegating.
+license: MIT
+compatibility: Requires the `dsh` CLI installed (`npm i -g @deepseek-ai/dsh` or `npx @deepseek-ai/dsh`), a provider credential such as `DEEPSEEK_API_KEY` (no `dsh auth` command — credentials resolve from the inherited environment, `$DSH_HOME/.credentials.yaml`, then `.env` files), Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+
+# DeepSeek Harness Delegate
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the DeepSeek Harness CLI (`dsh --profile headless`) — then review what it produced
+and land it yourself. You write the brief and own the judgment; DeepSeek Harness does the typing in its own
+fresh Agent; you verify and commit.
+
+> DeepSeek Harness is in **developer preview** and its README states there will be
+> compatibility-breaking changes. Treat any dsh behavior as provisional.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so any agent with those two capabilities — Claude Code, OpenCode driving a
+sibling session, or a comparable one — can drive it. (It is designed for and run on Claude Code; treat
+other orchestrators as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- `dsh` is not installed or no provider credential is available (`DEEPSEEK_API_KEY` or equivalent).
+- You want to write the code yourself, or you only need a review (use `--read-only`).
+
+## Prerequisites (check once)
+
+1. `dsh --version` succeeds. If not, install (`npm i -g @deepseek-ai/dsh`) and set a provider
+   credential (`DEEPSEEK_API_KEY`); there is no `dsh auth` command.
+2. **Confirm which `dsh` is on PATH.** `command -v dsh` shows the active binary and
+   `dsh --version` its version. The relay records the version it ran into `result.json`, so a stale
+   binary is visible after the fact.
+3. A provider credential is available — `DEEPSEEK_API_KEY` in the environment or the Harness
+   credential files.
+4. You are in (or will point `--cd` at) the target git repository.
+
+## Choose the implementer model
+
+`dsh` has a composed deployment default in the `agent-default-model` row. A per-run override is a
+generated `--patch` overlay, not a CLI flag — and the effective model is not observable from the run:
+
+- **No `--model` flag on this surface.** Pass `--model <name>` (and optionally `--provider <name>`,
+  defaulting to the harness's own default provider id) to the relay and it writes a patch file:
+
+  ```yaml
+  - id: agent-default-model
+    config:
+      provider: <provider>
+      model: <model>
+  ```
+
+  and passes it as `dsh --profile headless --patch <file> "<pointer task>"`. A `--patch` overlay
+  replaces the targeted row's complete `config` rather than deep-merging keys. That composition entry
+  is the base of the `agent-default-model` Settings section; a stored selection in
+  `$DSH_HOME/settings.yaml` layers over it and wins, so `--model`/`--provider` are a request, not a
+  guarantee. The relay records what was requested as `modelOverlay` in `result.json` and never reads
+  or writes the user's settings.
+
+- The usable set of models is the human's to state — ideally once in the repo's `AGENTS.md` or
+  `CLAUDE.md`. If none is stated, ask before dispatching rather than guessing. Do not make the brief
+  depend on a particular model being the one that runs.
+
+More depth: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+`dsh` sees **only** the text you send plus what it can read from the working tree — no chat history,
+no shared context. Everything the task needs goes in the brief: the goal, the current state, what to
+change, what to leave untouched, the project's **actual** gate commands (discover them from the repo's
+AGENTS.md/CLAUDE.md/Makefile — do not assume), and a report contract. Tell `dsh` it will **not**
+commit (you will). Keep one task per brief. `dsh` also loads applicable `AGENTS.md` / `CLAUDE.md`
+from the workspace with a 65,536-byte render budget, so don't restate what those already say. Full
+guidance and a template: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to `dsh` with the bundled helper. It writes the brief to `<out-dir>/brief.md`,
+passes a short pointer task as the positional (`dsh --profile headless` takes the task only as
+a positional argv value — the file is readable because the `workspace-write` sandbox leaves reads
+and the system temp roots unrestricted), captures the run, and writes a structured `result.json` —
+so your only job is "run a command, read a file." (`<skill-dir>` below is this skill's installed
+directory — the folder containing this `SKILL.md`. Claude Code prints it as "Base directory for
+this skill" when the skill loads; on other orchestrators use that same directory — if unsure
+where it landed, run `find ~ -name relay.mjs -path '*dsh-delegate*'` and substitute the directory
+above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a non-default model:        add --model <name> [--provider <name>]
+# fleet lane from delegate-setup:    add --lane <name>  (dials apply; flags still win)
+# read-only (review/diagnosis):      add --read-only     (DSH_PERMISSION_MODE=read-only)
+# extra composition patch:            add --patch ./overlay.yml  (repeatable)
+# hard time limit (watchdog):        add --timeout 2h  (default: off)
+# see all options:                   node .../relay.mjs --help
+```
+
+The helper writes its artifacts to a temp dir by default, so the repo under review stays clean. It
+**never commits** — see step 5. Mechanics, flags, pointer-file delivery, and the `result.json` shape:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until `dsh` finishes, so back it with whatever your orchestrator offers and resume
+when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job`
+  in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a `status`. (A
+  pre-run usage error — bad args or an empty brief — instead exits with code 2 and writes no result
+  file, so check the exit code too. A missing `dsh` binary exits 127 but *does* write a
+  `result.json` with status `dsh_unavailable`.)
+- **There is no resume.** The headless surface exposes no session id; `result.json` reports
+  `sessionId: null`. Rework is a fresh, self-contained brief — see step 5.
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line. The implementer's full report is
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
+
+### 4. Review — do not trust the self-report
+
+`dsh`'s `result.json` includes its own final message and any gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did `dsh` do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Committing should be the act of
+the party that verified the work. Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a fresh, fully self-contained brief (there is no `--resume-last`;
+  `dsh` starts from a clean session each time and remembers nothing from the previous run) and review
+  again.
+
+## Autonomy model
+
+`dsh`'s autonomy is the **`DSH_PERMISSION_MODE`** posture in the child's environment, mapped to the
+`sandbox-policy` row's `mode` with `workspaceRoot` bound to `process.cwd()`:
+
+| `DSH_PERMISSION_MODE` | sandbox `mode` | `approval` `policy` | Confinement |
+| --- | --- | --- | --- |
+| unset (default) | `workspace-write` | `ask` | Bash and filesystem **mutations** are confined to the session workspace and the platform temporary roots. Reads, network access, and process visibility are **not** confined. |
+| `read-only` | `read-only` | `ask` | Enforced by the sandbox, not by prompt wording. |
+| `danger-full-access` | `danger-full-access` | `never` | Removes the workspace boundary **and** sets approval to `never`. Present it as what it is; do not present it as the ordinary posture. |
+
+The **approval seam fails closed** when no answerer is composed — the headless case — so an
+escalation beyond the sandbox is rejected, not left hanging on a prompt nobody can answer. This is
+why a headless `dsh` run does not need an auto-approve flag and cannot hang on a permission prompt.
+
+The relay exposes this as `--permission-mode <mode>` (the exact `DSH_PERMISSION_MODE` names above)
+and `--read-only` as sugar for `read-only` (which also arms the Git tripwire). Leaving the flag off
+leaves the variable unset so the harness's own composed default applies.
+
+The **invoking directory is the workspace root.** There is no workspace flag — the relay sets the
+child process `cwd` from `--cd` and that becomes the sandbox's `workspaceRoot`. Reads are not
+confined and the system temp roots are writable, so the pointer-file brief under that temp root is
+readable despite the mutation boundary.
+
+Session telemetry stays local by default and is opt-in through `DSH_TELEMETRY_MODE`. The relay does
+not set, change, or defeat any telemetry variable.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report `dsh`'s design decisions, defensible-but-unasked turns,
+and non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if correct
+completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
+is in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief `dsh` can
+  execute blind: structure, XML blocks, the report contract, embedding the real gate commands, and
+  why the brief reaches `dsh` as a file it is told to read.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, the pointer-file mechanic and why, the
+  SIGTERM-exits-0 trap, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the rework cycle as a fresh self-contained brief.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check under no-resume.

--- a/skills/dsh-delegate/references/dispatch-and-poll.md
+++ b/skills/dsh-delegate/references/dispatch-and-poll.md
@@ -63,13 +63,20 @@ exits 1 with `error: a task is required, for example: dsh --profile headless "ru
 the relay writes the brief verbatim to `<out-dir>/brief.md` and passes a short, single-line,
 ASCII-only pointer as the positional:
 
-```
+```text
 Read the task brief at /tmp/delegate-relay/.../brief.md and execute it fully.
 ```
 
 It contains no quotes, newlines, or shell metacharacters beyond the path itself, and is quoted
 only where `shell: true` requires it. The brief file is readable because reads are not confined by
 the sandbox and the system temp dir is among the platform temporary roots the sandbox allows writing.
+
+Quoting is not a boundary on win32: `cmd.exe` expands `%` inside double quotes, expands `!`
+under delayed expansion, and still reads `&`, `|`, `^`, `<`, and `>`. A `.cmd` shim cannot be
+launched without a shell, so the relay rejects rather than escapes — `--patch`, `--out-dir`, and
+the resolved run directory (which borrows `basename(--cd)`) are checked for those characters on
+win32 and exit 2 with the offending character named. POSIX spawns argv directly and skips the
+check.
 
 ## The result
 

--- a/skills/dsh-delegate/references/dispatch-and-poll.md
+++ b/skills/dsh-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,191 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `dsh --profile headless`, runs the brief as a
+pointer task, captures everything, and writes a structured `result.json`. Your job collapses to: run
+one command, then read one file. Everything `dsh`-specific lives in the helper, which is what keeps
+the loop portable across orchestrators.
+
+## Before the first run: check the binary
+
+Two gotchas, both worth 30 seconds:
+
+```bash
+command -v dsh    # the active binary on PATH
+dsh --version     # the relay records this in result.json too
+# no auth subcommand — set DEEPSEEK_API_KEY (or the provider's key) in the
+# environment or in $DSH_HOME/.credentials.yaml / .env
+```
+
+`dsh` has no `dsh auth` or credential-listing command. Credentials resolve from the inherited
+environment, then `$DSH_HOME/.credentials.yaml`, then the invoking directory's `.env`, then
+`$DSH_HOME/.env`. `DEEPSEEK_API_KEY` is the ordinary one for the default provider.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for `dsh` (default: current directory). Becomes the child `cwd` and the harness's `workspaceRoot`; there is no workspace flag. |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Model for the generated `agent-default-model` patch overlay that overrides the composed default. A stored selection in `$DSH_HOME/settings.yaml` layers over that entry and wins (`packages/core/agent-default-model/README.md`: "That composition entry is the base of the `agent-default-model` Settings section; a mounted settings provider layers the user's choice over it"), so this is a request, not a guarantee; the effective model is not observable from the run. `modelOverlay` in `result.json` records what was requested. `--provider` defaults to `deepseek-official` (the harness's own default provider id). |
+| `--provider <name>` | Provider for that overlay. Requires `--model`; pass both or neither. Same precedence as `--model`: a stored `$DSH_HOME` selection outranks it, and `modelOverlay` records the request. |
+| `--permission-mode <mode>` | `DSH_PERMISSION_MODE` for the child: `read-only` \| `workspace-write` \| `danger-full-access`. Default: leave the variable unset so the harness's composed default (`workspace-write` + `ask`) applies. |
+| `--read-only` | Sugar for `--permission-mode read-only`, and arms the Git tripwire. Rejected if combined with a conflicting `--permission-mode`. |
+| `--patch <file>` | Extra `--patch` overlay, repeatable, passed straight through as `dsh --patch <file>` in argv order. Launcher flags (`--profile`, `--patch`) precede the positional, always. |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. `dsh` has no timeout flag of its own, so the watchdog is relay-only. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only `dsh`'s edits and nothing of the helper's own. The briefing file
+itself (`<out-dir>/brief.md`) also lives there, which is safe: the `workspace-write` sandbox
+confines filesystem **mutations** but leaves reads and the platform temporary roots unrestricted, so
+`dsh` can read it.
+
+### The pointer-file mechanic and why
+
+`dsh --profile headless` takes the task **only as a positional argv value** — there is no
+`--message-file`, no prompt flag, and no stdin for the task. `dsh --profile headless --help`
+documents that positional as `[task...]` — multiple words are joined by spaces — which is a second,
+independent reason a multi-line brief cannot ride argv: it would be space-joined. Passing it as a
+shell token would also be mangled by `cmd.exe` under `shell: true` on win32 (the relay uses
+`shell: true` on win32 to resolve the `dsh.cmd` npm shim). With an empty positional the harness
+exits 1 with `error: a task is required, for example: dsh --profile headless "run the tests"`. So
+the relay writes the brief verbatim to `<out-dir>/brief.md` and passes a short, single-line,
+ASCII-only pointer as the positional:
+
+```
+Read the task brief at /tmp/delegate-relay/.../brief.md and execute it fully.
+```
+
+It contains no quotes, newlines, or shell metacharacters beyond the path itself, and is quoted
+only where `shell: true` requires it. The brief file is readable because reads are not confined by
+the sandbox and the system temp dir is among the platform temporary roots the sandbox allows writing.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `dsh_unavailable`
+- `exitCode` — mirrors `dsh`'s exit code; `128` plus the signal number if the child was killed; `127` if `dsh` isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
+- `signal` — the signal that killed the child, otherwise `null`
+- `dshVersion` — the binary that actually ran (from a bounded `dsh --version` preflight)
+- `permissionMode` — the `DSH_PERMISSION_MODE` the run actually used, or `null` when the variable was left unset so the harness default applied
+- `readOnly` — whether this was a read-only run (`--read-only` / `read-only` mode)
+- `sessionId` — always `null`; the headless surface exposes none and has no resume or continue flag
+- `finalMessage` — `dsh`'s assembled final stdout text (the `<structured_output_contract>` you asked for). Empty if `dsh` stopped without emitting a closing summary — ask for the report explicitly
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report — `git` missing, or a non-repo run; `[]` means git ran and the tree is clean
+- `readOnlyViolation` — tri-state: `true` if the Git tripwire saw a write during a `--read-only` run, `false` if it proved clean, `null` when it could not be determined (only meaningful on read-only runs; `null` otherwise)
+- `briefPath` / `outputPath` / `finalPath` — the exact brief, the raw stdout capture, and the final-message file
+- `patches` — the user-supplied `--patch` files passed through (does not include the generated model overlay)
+- `modelOverlay` — `{ provider, model }` the relay requested via the generated `agent-default-model` overlay, or `null` if no `--model` was given. This is what was requested, not the effective model — a stored selection in `$DSH_HOME/settings.yaml` outranks the overlay and the relay cannot observe which model actually served the request, so no field reports "the model that ran."
+- `workdir`, `lane`, `laneSource`, `startedAt`, `finishedAt`
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed` and `dsh_unavailable`
+- `error` — present on a launch failure, and on `timeout` and `aborted` runs
+
+The helper also prints a summary to stdout and exits with `dsh`'s exit code, so a wrapping script can
+branch on success/failure directly. `finalMessage` is also written to `<out-dir>/final.txt` and echoed
+in full between report markers.
+
+There is **no resume path**. `dsh --profile headless` creates one fresh persisted Agent, prints no
+session id, and offers no `--resume-last` or `--session`. Rework is a fresh, fully self-contained
+brief — the next dispatch starts from a clean session and remembers nothing from the previous run.
+
+## Waiting for completion
+
+The helper blocks until `dsh` finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job` in PowerShell,
+  `start /b` in cmd). A run is done when `result.json` exists with a `status`. **But** a pre-run usage
+  error (bad args, empty brief, conflicting flags) exits with code 2 *before* writing any file — so
+  check the exit code too, don't only watch for the file. (A missing `dsh` binary exits 127 but *does*
+  write a `result.json` with status `dsh_unavailable`.)
+- **No resume:** `result.json` always carries `sessionId: null`; don't look for a resume id.
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## The SIGTERM-exits-0 trap
+
+`dsh` gives the plugin tree up to five seconds to dispose and **`SIGTERM` exits 0 on every surface**
+(`SIGINT` reports 130; a second signal forces immediate exit). This is a trap for the watchdog: a
+timed-out or aborted run can exit 0. The relay therefore classifies `timeout` (the `--timeout`
+watchdog fired) and `aborted` (the relay itself was killed and forwarded the kill) **from its own
+state, never from the child's exit code**, and never reports `completed` for a run it killed.
+
+## When a run misbehaves
+
+- **`status: dsh_unavailable` (exit 127):** `dsh` isn't on PATH or isn't found. Install
+  (`npm i -g @deepseek-ai/dsh`, or `npx @deepseek-ai/dsh`) and set a provider credential, then
+  re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `dsh --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter),
+  so `dsh` was never dispatched; only the relay's own artifacts may already exist under
+  `--out-dir`. Check the install by running `dsh --version` yourself.
+- **`status: failed`:** read `result.json`'s `stderrTail` and `finalMessage` for the cause. Common
+  causes: a missing credential, an unknown model/provider, or a patch file that failed to parse. Fix
+  the cause and re-dispatch; don't paper over it by doing the work yourself unless that's what the
+  user wants.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a fresh dispatch.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to `dsh`. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written —
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree directly.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
+- **Empty `finalMessage`:** `dsh` finished without emitting a closing text summary (common when it
+  completes purely through tool calls). The edits may still be correct — check `touchedFiles` and the
+  diff. To get a report next time, add a `<structured_output_contract>` block (see
+  [writing-the-brief.md](writing-the-brief.md)).
+- **A run hangs:** `dsh` headlessly does **not** hang on a permission prompt — the approval seam
+  fails closed when no answerer is composed, so an escalation beyond the sandbox is rejected rather
+  than left awaiting input. A hang therefore means the `dsh` process itself is stuck, not a prompt;
+  use the `--timeout` watchdog and inspect the tree.
+
+## Recovering lost work
+
+`output.txt` in the run directory records the raw stdout. The working tree itself is the
+authoritative copy — `touchedFiles` and `git diff` show what was actually written.
+
+## What the helper is doing (and the alternatives)
+
+Under the hood the helper runs roughly:
+
+```bash
+dsh --profile headless --patch <generated-model-overlay> --patch ./overlay.yml "Read the task brief at /tmp/.../brief.md and execute it fully."
+```
+
+Launcher flags (`--profile`, `--patch`) come first and end at the first token the launcher does not
+recognize; everything after that is the headless app's positional task text. The brief file travels
+outside argv; the positional is only the pointer. `DSH_PERMISSION_MODE` is set in the child's
+environment when `--permission-mode` / `--read-only` was given, otherwise left unset. The invoking
+directory (`--cd` / `process.cwd()`) is the workspace root — there is no workspace flag.
+
+If you ever want it, raw `dsh --profile headless "…"` is fine for one-offs — you just give up the
+captured `result.json`, touched-files summary, and version capture the helper does for you.
+
+There is **no `--resume-last` or `--session`** — the headless surface has no resume. Every dispatch
+is a fresh Agent; rework means a fresh, fully self-contained brief.
+
+## The commit boundary
+
+The helper never commits — by design, not omission. The robust contract is: `dsh` edits the working
+tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/dsh-delegate/references/multi-task-queues.md
+++ b/skills/dsh-delegate/references/multi-task-queues.md
@@ -1,0 +1,75 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism. With `dsh` the added constraint is that
+there is **no resume**: every task in the queue is a standalone brief in a fresh Agent that remembers
+nothing from the previous run except what is on disk.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential. (Each
+`relay.mjs` dispatch starts a new `dsh` session and `dsh` retains no memory of the earlier run, so
+independent tasks don't share context even if you dispatched them together — fold any shared constraint
+into each brief, see below.)
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. A fresh `dsh` Agent has no memory of the earlier run, so a
+constraint that emerged in task 2 must be restated in task 5's brief or it won't hold. Nothing is
+inherited from the previous run except what is on disk (the working tree after the commit). This is
+the queue equivalent of keeping briefs self-contained.
+
+In practice that means after each commit, update the next task's brief template with the concrete
+names, paths, and decisions that landed — don't assume the implementer will infer them.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions `dsh` made, non-blocking nitpicks, anything you want the
+  human to overrule or confirm. This is the section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/dsh-delegate/references/review-and-land.md
+++ b/skills/dsh-delegate/references/review-and-land.md
@@ -1,0 +1,138 @@
+# Review and land
+
+`dsh` did the typing; you own the judgment. This is where delegation earns its keep or quietly ships
+a mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
+reality, never against the self-report — and read the diff as generated code, which fails in ways a
+green gate can't see.**
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries `dsh`'s own claim that the gates passed. Treat that as a claim, not evidence —
+re-run the project's actual test/lint/build commands in the working tree and read the output. And keep
+the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a gate,
+not just misreport it — that is what the test check above and the sweep below exist to catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+**Read-only runs exit 0 on refusal — inspect the tree, not the status.** With
+`DSH_PERMISSION_MODE=read-only`, a run whose task ordered an immediate file write wrote nothing,
+left the tree clean, and **exited 0** with final message "the current sandbox is read-only, and the
+required write-access approval is unavailable." That is a `completed` run, not `failed` — the harness
+refused the write and reported it. Exit code and `status: completed` therefore never tell you whether
+the work happened; `touchedFiles` and the diff do. Both the `read-only` sandbox and the fail-closed
+approval seam are real enforcement, not advisory prompt wording.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Scope creep** — did `dsh` change things the brief said to leave untouched? Unasked refactors,
+  renames, "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version?
+- **Quiet judgment calls** — sometimes `dsh` makes a defensible decision the brief didn't anticipate.
+  Don't just accept it because it looks reasonable; understand it and decide.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If `dsh` couldn't implement something,
+  the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to `dsh` as a fresh brief (below) or gets fixed in the tree
+before commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never the implementer. The
+headless profile can write the working tree, but committing should be the act of the party that verified
+the work, not the one that produced it. Write a clear message describing what landed. If your project
+attributes co-authorship, that's the place for it.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`,
+`git diff --cached` for anything the implementer staged (plain `git diff` is blind to the index), and
+open any untracked files (`??` in `git status`) directly — they are the implementer's new files, and
+no diff shows their contents. The tree is evidence, not clutter. After that inspection the verdict can
+legitimately be to discard — work built on a premise you have since corrected, for example — and then
+`git checkout`/`clean` is the right tool. The ban is on reflexive cleanup before anyone has looked.
+
+## Reworking: send a fresh full brief
+
+If the review turns up problems, don't try to resume. `dsh --profile headless` has **no
+`--resume-last` and no `--session`** — the headless surface exposes no session id
+(`result.json` reports `sessionId: null`), and every dispatch creates one fresh persisted Agent.
+Rework is therefore a fresh, fully self-contained brief that restates the whole task plus the
+correction:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief-v2.txt --cd /path/to/repo
+# brief-v2.txt contains the full task again, plus:
+# "The previous attempt did X; fix it by doing Y, keeping Z. Leave ... untouched."
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
+
+`dsh` starts from a clean session each time and remembers nothing from the previous run; only what
+is on disk (the working tree you just inspected) persists. So the rework brief must be
+self-contained — don't rely on a session memory that doesn't exist. Then review again — rework gets
+the same gate-rerun, test check, diff-read, and sweep as the original, no shortcuts. Repeat until
+it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** `dsh` made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or `dsh`'s.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/dsh-delegate/references/writing-the-brief.md
+++ b/skills/dsh-delegate/references/writing-the-brief.md
@@ -1,0 +1,151 @@
+# Writing the brief
+
+A brief is the entire task as `dsh` will see it. `dsh --profile headless` runs in a **fresh,
+persisted Agent with no memory of your conversation, no access to your prior notes, and no shared
+context** — only the text you send and whatever it can read from the working tree. If a constraint
+isn't in the brief or discoverable in the repo, it doesn't exist for the implementer. The single
+most common failure is a brief that assumes context `dsh` doesn't have.
+
+## What `dsh` already reads — don't restate it
+
+`dsh` loads applicable `AGENTS.md` / `CLAUDE.md` from the workspace root (the relay's `--cd`, which
+becomes the child's `cwd` and the harness's `workspaceRoot`) with a **65,536-byte render budget**.
+House rules there — style, forbidden patterns, commit conventions — already apply and need not be
+copied into the brief. Restate only the load-bearing few the task depends on, because compliance is
+only as reliable as what's in front of the model; everything else the file already says stays out of
+the brief to save the budget for the task.
+
+## How the brief reaches `dsh`
+
+`dsh --profile headless` takes the task **only as a positional argv value** — no stdin, no
+`--message-file`, no prompt flag. `dsh --profile headless --help` documents that positional as
+`[task...]` — multiple words are joined by spaces — which is a second, independent reason a
+multi-line brief cannot ride argv. To avoid that space-joining and argv mangling (especially under
+`shell: true` on win32 for the `dsh.cmd` shim), the relay writes your brief verbatim to
+`<out-dir>/brief.md` (under the system temp dir, which is a platform temporary root the
+`workspace-write` sandbox allows reading and writing — reads are not confined) and passes a short,
+single-line, ASCII-only pointer task as the positional, naming the absolute path and instructing
+`dsh` to read it and execute it fully. With an empty positional the harness exits 1 with
+`error: a task is required, for example: dsh --profile headless "run the tests"`. The brief is
+therefore a file `dsh` is told to read, not inline prompt text. Keep it self-contained and explicit;
+`dsh` has no other channel to ask for clarification.
+
+## The shape that works
+
+`dsh` responds well to compact, block-structured prompts with XML tags rather than long prose. State
+the task, what "done" looks like, how to behave by default, and the few constraints that actually
+matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps the
+implementer from wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+The effective model is not observable from the run: `--model`/`--provider` write a
+`agent-default-model` overlay that overrides the composed default, but a stored selection in
+`$DSH_HOME/settings.yaml` layers over that entry and wins (`packages/core/agent-default-model/README.md`:
+"That composition entry is the base of the `agent-default-model` Settings section; a mounted settings
+provider layers the user's choice over it"). The relay records what was requested as `modelOverlay` in
+`result.json` and never reads or writes the user's settings, so do not make the brief depend on a
+particular model being the one that runs — state model preferences as capacity hints, not as
+guarantees.
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences) and dispatch with `--read-only` so the run is confined to `read-only`.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Always ask for the report explicitly
+
+The relay assembles `dsh`'s final message from the stdout it prints when it stops. If the agent
+finishes a task purely through tool calls and stops without a closing summary, `finalMessage` comes
+back empty — not a relay defect, just nothing said. The `<structured_output_contract>` block is what
+guarantees a report you can read: it tells `dsh` to end with a written summary, so the result file
+carries one.
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you an implementer that guesses — or skips.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and suggest
+a roadmap" produces a muddled run; split it into separate dispatches. One brief → one `dsh` run →
+one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+Because there is no resume, each brief must be fully self-contained — a fresh Agent is created for
+every dispatch.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/dsh-delegate/scripts/relay.mjs
+++ b/skills/dsh-delegate/scripts/relay.mjs
@@ -1,0 +1,948 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · dsh-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the DeepSeek Harness CLI (`dsh
+ * --profile headless`), capture the run, and write a structured result the
+ * orchestrating agent can review. The orchestrator runs this one command and
+ * reads the result JSON — every dsh-specific mechanic lives in here, which
+ * keeps the skill orchestrator-agnostic. Verified on Claude Code; other
+ * shell-capable agents (OpenCode, Cursor, …) are designed-for but not yet
+ * verified.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `dsh` and `git`. The `dsh` process it launches
+ * does authenticate — exactly as you do at the terminal. Read this file before
+ * you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's
+ * job — after it reviews the diff and re-runs the project gates.
+ *
+ * Brief delivery: `dsh --profile headless` takes the task ONLY as a positional
+ * argv value — no stdin, no --message-file, no prompt flag. `dsh --profile
+ * headless --help` documents that positional as `[task...]` — multiple words
+ * are joined by spaces — which is a second, independent reason a multi-line
+ * brief cannot ride argv: it would be space-joined and mangled. Under
+ * shell:true on win32 it would be mangled by cmd.exe as well, so the brief is
+ * written verbatim to <out-dir>/brief.md (under the system temp dir, which is
+ * a platform temporary root the harness's workspace-write sandbox allows
+ * reading and writing — reads are not confined) and the positional carries a
+ * short, single-line, ASCII-only pointer that names the absolute path and
+ * instructs dsh to read it and execute it fully. The pointer text contains no
+ * quotes, newlines, or shell metacharacters beyond the path itself.
+ *
+ * There is NO session id and NO resume on this surface. The headless app
+ * persists the session under $DSH_HOME but prints no id and offers no resume or
+ * continue flag, so this relay ships no --resume-last and no --session and
+ * reports sessionId: null. Rework is a fresh full brief, not a delta.
+ *
+ * Autonomy, in dsh's own terms: DSH_PERMISSION_MODE (read-only /
+ * workspace-write / danger-full-access) in the child's environment, mapped to
+ * the sandbox-policy row's mode with workspaceRoot bound to process.cwd(). The
+ * approval seam fails closed when no answerer is composed — the headless case —
+ * so an escalation beyond the sandbox is rejected rather than left hanging on a
+ * prompt nobody can answer. This is why a headless dsh run does not need an
+ * auto-approve flag and cannot hang on a permission prompt.
+ *
+ * Model selection has no flag on this surface. The deployment default lives in
+ * the composition row agent-default-model (provider + model), and a per-run
+ * override is a generated --patch overlay that replaces that row's whole config.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for dsh; becomes the child cwd and the
+ *                           harness's workspace root (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Model for the generated agent-default-model patch overlay
+ *                           that overrides the composed default; a stored selection
+ *                           in $DSH_HOME/settings.yaml outranks it, so this is a
+ *                           request, not a guarantee, and the effective model is
+ *                           not observable from the run.
+ *   --provider <name>       Provider for that overlay (default: deepseek-official,
+ *                           the harness's own default provider id); same
+ *                           precedence as --model.
+ *   --permission-mode <m>   DSH_PERMISSION_MODE for the child: read-only |
+ *                           workspace-write | danger-full-access. Default: leave the
+ *                           variable unset so the harness's composed default applies.
+ *   --read-only             Sugar for --permission-mode read-only, and arms the tripwire.
+ *   --patch <file>          Extra --patch overlay, repeatable, passed straight through.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the dsh child is killed
+ *                           and result.json gets status "timeout". dsh has no timeout
+ *                           flag of its own, so the watchdog is relay-only.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, dshVersion, permissionMode, sessionId (always
+ *   null — the headless surface exposes none), finalMessage (dsh's own final
+ *   stdout text), touchedFiles (git porcelain, null if git can't report),
+ *   readOnlyViolation, modelOverlay (the requested {provider, model} or null),
+ *   and the paths to the brief and final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief, a rejected
+ * --permission-mode) exits 2 before any run and writes no result file; a dsh
+ * CLI that cannot be found exits 127 and DOES write one; otherwise the exit
+ * code mirrors dsh's own (0 success, non-zero failure). If the child dies on a
+ * signal, the exit code is 128 plus the signal number and result.json records
+ * the signal. Once the brief validates, result.json is written on every outcome
+ * — completed, failed, timeout (the --timeout watchdog fired), aborted (the
+ * relay itself was killed and forwarded the kill to dsh), or dsh_unavailable.
+ * An orchestrator that polls for the file must therefore also treat a non-zero
+ * exit with no file as a usage error.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync, statSync, readlinkSync, lstatSync, openSync, readSync, closeSync, realpathSync, readdirSync } from "node:fs";
+import {join, resolve, basename, dirname, sep, isAbsolute, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir, homedir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+import { createHash } from "node:crypto";
+
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+const SCHEMA = "delegate-relay.result.v1";
+const DEFAULT_PROVIDER = "deepseek-official";
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:\/-]*$/;
+const PERMISSION_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
+
+const IMPLEMENTER_KEY = "dsh";
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && (flagged.has("readOnly") || flagged.has("permissionMode"))) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+    if (field === "sandbox") opts.sandboxConfigured = true;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    provider: null,
+    permissionMode: null,
+    readOnly: false,
+    patches: [],
+    timeout: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--provider": opts.provider = next(); flagged.add("provider"); break;
+      case "--permission-mode": opts.permissionMode = next(); flagged.add("permissionMode"); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--patch": opts.patches.push(next()); flagged.add("patch"); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  // Normalize lane aliases: delegate-setup may carry the permission mode as
+  // `permissionMode` or the readOnly boolean; adopt them before validation.
+  if (opts.readOnly && opts.permissionMode === null) opts.permissionMode = "read-only";
+  if (opts.readOnly && opts.permissionMode !== "read-only") {
+    fail(`--read-only conflicts with --permission-mode ${opts.permissionMode}; read-only runs use permission mode read-only`);
+  }
+  if (opts.readOnly) opts.permissionMode = "read-only";
+  if (opts.permissionMode !== null && !PERMISSION_MODES.has(opts.permissionMode)) {
+    fail(`invalid --permission-mode "${opts.permissionMode}" (expected: ${[...PERMISSION_MODES].join(", ")})`);
+  }
+  if (opts.model !== null && !SAFE_TOKEN.test(opts.model)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, . _ : / -)");
+  }
+  if (opts.provider !== null && !SAFE_TOKEN.test(opts.provider)) {
+    fail("--provider contains unsupported characters (allowed: letters, digits, . _ : / -)");
+  }
+  if (opts.provider !== null && opts.model === null) {
+    fail("--provider requires --model; pass both or neither for the agent-default-model overlay");
+  }
+  // --timeout validation: the watchdog is relay-only (dsh has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  for (const patch of opts.patches) {
+    if (!existsSync(patch)) fail(`--patch file not found: ${patch}`);
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to dsh --profile headless\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once dsh is running, so the preflight needs a bound of
+  // its own: a `dsh --version` that never returns would wedge the relay here, before
+  // any result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function dshVersion(probeTimeoutMs) {
+  try {
+    // On Windows, npm installs `dsh` as a .cmd shim; Node's CreateProcess only
+    // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
+    // ENOENTs on a working install. POSIX is unaffected.
+    const version = execFileSync("dsh", ["--version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+      env: process.env,
+    }).trim();
+    return { version: version || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+    // exit rather than ENOENT; that is still "not installed", not a broken install.
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    // Anything else — a hung probe we killed, or a real non-zero exit — means dsh is
+    // installed but not usable. Reporting that as "unavailable" would send the caller
+    // off to reinstall a CLI that is already there.
+    return { version: null, error };
+  }
+}
+
+const FINGERPRINT_UNREADABLE = "<unreadable>";
+const FINGERPRINT_DIRECTORY = "<directory>";
+
+function gitRepoRoot(cwd) {
+  // Porcelain paths are relative to the repository ROOT, not to the directory git ran in
+  // (--porcelain forces status.relativePaths off). Joining them against a --cd that is a
+  // subdirectory would look for <repo>/src/src/file and find nothing at either end.
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).replace(/\n$/, "") || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitStatusEntries(cwd) {
+  // -z so a path containing a space, a quote, or a newline stays one field rather than being
+  // quoted and escaped; -uall so an untracked directory is expanded into its files, because a
+  // collapsed "?? dir/" line never changes when a file inside it does.
+  try {
+    const output = execFileSync("git", ["status", "--porcelain", "-z", "-uall"], {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const fields = new TextDecoder("utf-8", { fatal: true }).decode(output)
+      .split("\0").filter((field) => field.length > 0);
+    const entries = [];
+    for (let i = 0; i < fields.length; i += 1) {
+      const entry = fields[i];
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      // R and C can sit in EITHER status column, and under -z such an entry is followed by its
+      // origin path as its own unprefixed field. Consume that field in both cases. A rename
+      // origin belongs in the dirty set (the file moved away from it); a copy origin does not,
+      // since a copy source can be a perfectly clean file.
+      const renamed = status.includes("R");
+      const copied = status.includes("C");
+      let origin = null;
+      if (renamed || copied) {
+        i += 1;
+        origin = fields[i] ?? null;
+      }
+      entries.push({ status, path, origin });
+    }
+    return entries;
+  } catch {
+    return null;
+  }
+}
+
+function dirtyPaths(cwd) {
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const paths = [];
+  for (const entry of entries) {
+    paths.push(entry.path);
+    if (entry.status.includes("R") && entry.origin !== null) paths.push(entry.origin);
+  }
+  return paths;
+}
+
+function asciiFold(value) {
+  return value.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+}
+
+function canonicalFilePath(path) {
+  const absolute = resolve(path);
+  let parent;
+  try { parent = realpathSync.native(dirname(absolute)); } catch { return absolute; }
+  const leaf = basename(absolute);
+  const canonical = join(parent, leaf);
+  try { lstatSync(canonical); } catch { return canonical; }
+  try {
+    const entries = readdirSync(parent);
+    if (entries.includes(leaf)) return canonical;
+    const matches = entries.filter((entry) => asciiFold(entry) === asciiFold(leaf));
+    return join(parent, matches.length === 1 ? matches[0] : leaf);
+  } catch {
+    return canonical;
+  }
+}
+
+function gitPathKey(root, path) {
+  let canonicalRoot;
+  try { canonicalRoot = realpathSync.native(root); } catch { canonicalRoot = resolve(root); }
+  const key = relative(canonicalRoot, canonicalFilePath(path));
+  return process.platform === "win32" ? key.replaceAll("\\", "/") : key;
+}
+
+function gitPathIsExcluded(root, path, excluded, foldedExcluded) {
+  return excluded.has(path) ||
+    (foldedExcluded.has(asciiFold(path)) && excluded.has(gitPathKey(root, join(root, path))));
+}
+
+function gitTripwireState(cwd, excludedPaths) {
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return entries.flatMap((entry) => [
+    [entry.status, "path", entry.path],
+    ...(entry.origin === null ? [] : [[entry.status.replace(/[^RC]/g, " "), "origin", entry.origin]]),
+  ]
+    .filter(([, , path]) => !gitPathIsExcluded(root, path, excluded, foldedExcluded)));
+}
+
+function pathFingerprint(absolutePath) {
+  // Identity, not just bytes: a retargeted symlink, a flipped mode bit, or a file replaced by a
+  // directory are all writes, and none of them change file contents.
+  let stats;
+  try {
+    stats = lstatSync(absolutePath);
+  } catch (error) {
+    // Absence is a state, not a failure - it differs from every real fingerprint, so a deletion
+    // or a re-creation still registers. Any other errno means we genuinely cannot tell.
+    return error && error.code === "ENOENT" ? "absent" : FINGERPRINT_UNREADABLE;
+  }
+  if (stats.isSymbolicLink()) {
+    try {
+      return `symlink:${readlinkSync(absolutePath, { encoding: "buffer" }).toString("hex")}`;
+    } catch {
+      return FINGERPRINT_UNREADABLE;
+    }
+  }
+  // A directory in the dirty set is a submodule, whose contents belong to another repository.
+  // Reported as unknown coverage rather than silently passed off as unchanged.
+  if (stats.isDirectory()) return FINGERPRINT_DIRECTORY;
+  if (!stats.isFile()) return FINGERPRINT_UNREADABLE;
+  let fd;
+  try {
+    // Streamed rather than read whole: an unignored multi-gigabyte artifact must not be pulled
+    // into memory just to answer whether it changed.
+    const hash = createHash("sha256");
+    fd = openSync(absolutePath, "r");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      const read = readSync(fd, buffer, 0, buffer.length, null);
+      if (read <= 0) break;
+      hash.update(buffer.subarray(0, read));
+    }
+    return `file:${(stats.mode & 0o7777).toString(8)}:${hash.digest("hex")}`;
+  } catch {
+    return FINGERPRINT_UNREADABLE;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+  }
+}
+
+function gitIndexFingerprints(root, paths) {
+  if (paths.length === 0) return new Map();
+  try {
+    const output = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const wanted = new Set(paths);
+    const prints = new Map(paths.map((path) => [path, []]));
+    for (const field of new TextDecoder("utf-8", { fatal: true }).decode(output).split("\0")) {
+      if (!field) continue;
+      const separator = field.indexOf("\t");
+      if (separator === -1) return null;
+      const path = field.slice(separator + 1);
+      if (wanted.has(path)) prints.get(path).push(field.slice(0, separator));
+    }
+    return prints;
+  } catch {
+    return null;
+  }
+}
+
+function fingerprintPaths(root, paths) {
+  // `complete` goes false the moment one path cannot be fingerprinted, so the caller reports
+  // "unknown" instead of an unearned clean bill of health.
+  const indexPrints = gitIndexFingerprints(root, paths);
+  const prints = new Map();
+  let complete = indexPrints !== null;
+  for (const path of paths) {
+    const file = pathFingerprint(join(root, path));
+    if (file === FINGERPRINT_UNREADABLE || file === FINGERPRINT_DIRECTORY) complete = false;
+    prints.set(path, { file, index: indexPrints?.get(path) ?? null });
+  }
+  return { prints, complete };
+}
+
+function fingerprintDirtyPaths(cwd, excludedPaths) {
+  // Only the already-dirty set is covered. A path that is clean at dispatch and gets written
+  // surfaces as a brand-new porcelain line anyway, and fingerprinting a whole repository per run
+  // would cost far more than the case it covers.
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const paths = dirtyPaths(cwd);
+  if (paths === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return {
+    root,
+    ...fingerprintPaths(root, paths.filter((path) => !gitPathIsExcluded(root, path, excluded, foldedExcluded))),
+  };
+}
+
+function changedDirtyPaths(before) {
+  // Re-fingerprint exactly the baseline paths, not whatever happens to be dirty now: a path the
+  // run newly dirtied is already reported by the porcelain comparison, and letting an unreadable
+  // one of those blind this signal would be a regression, not caution.
+  if (!before) return { changed: [], complete: false };
+  const now = fingerprintPaths(before.root, [...before.prints.keys()]);
+  const changed = [];
+  for (const [path, print] of before.prints) {
+    const current = now.prints.get(path);
+    const fileKnown = print.file !== FINGERPRINT_UNREADABLE && current.file !== FINGERPRINT_UNREADABLE;
+    const fileChanged = fileKnown &&
+      !(print.file === FINGERPRINT_DIRECTORY && current.file === FINGERPRINT_DIRECTORY) &&
+      current.file !== print.file;
+    const indexChanged = print.index !== null && current.index !== null &&
+      JSON.stringify(current.index) !== JSON.stringify(print.index);
+    if (fileChanged || indexChanged) changed.push(path);
+  }
+  return { changed: changed.sort(), complete: before.complete && now.complete };
+}
+
+function readOnlyVerdict(beforeTree, afterTree, beforeFingerprints) {
+  // Three-valued on purpose. Proof of a write settles it even when the other signal is unknown;
+  // only when nothing is proven AND coverage is incomplete is the answer genuinely unknown.
+  // Collapsing that last case to false is the false assurance a tripwire must never give.
+  const changed = changedDirtyPaths(beforeFingerprints);
+  const porcelainMoved =
+    beforeTree !== null && afterTree !== null && JSON.stringify(beforeTree) !== JSON.stringify(afterTree);
+  if (porcelainMoved || changed.changed.length > 0) return true;
+  if (beforeTree === null || afterTree === null || !changed.complete) return null;
+  return false;
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, pointerTask, patchOverlayPath) {
+  // Spaceable values reach cmd.exe unquoted when a .cmd shim forces shell:true
+  // (a temp path under C:\Users\First Last\... would otherwise split — issue #3),
+  // so quote exactly those there. The pointer task is a single positional argv
+  // value; quoting keeps it intact on win32.
+  const shellQuoted = process.platform === "win32";
+  const quote = (value) => (shellQuoted ? `"${value.replaceAll('"', '\\"')}"` : value);
+  const argv = ["--profile", "headless"];
+  if (patchOverlayPath) argv.push("--patch", quote(patchOverlayPath));
+  for (const patch of opts.patches) argv.push("--patch", quote(patch));
+  argv.push(pointerTask);
+  // Quote the pointer task itself on win32 shell path so spaces in the temp
+  // brief path survive cmd.exe's tokenization.
+  if (shellQuoted) argv[argv.length - 1] = quote(argv[argv.length - 1]);
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only dsh's edits, not relay's artifacts.
+  // This temp root is writable and readable under the workspace-write sandbox,
+  // which is why the pointer-file mechanic is safe: the implementer can read it.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    outDir,
+    briefPath: join(outDir, "brief.md"),
+    finalPath: join(outDir, "final.txt"),
+    outputPath: join(outDir, "output.txt"),
+    resultPath: join(outDir, "result.json"),
+    patchOverlayPath: null,
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  // If a model (and thus a provider) was requested, generate the patch overlay
+  // that replaces the agent-default-model row's whole config. A patch replaces
+  // the targeted row's complete config rather than deep-merging keys, so the
+  // file must contain both provider and model.
+  // Precedence: that composition entry is the base of the agent-default-model
+  // Settings section; a stored selection in $DSH_HOME/settings.yaml layers over
+  // it and wins (see packages/core/agent-default-model/README.md). The relay
+  // deliberately does not read, parse, or modify the user's settings — the
+  // overlay is a request, not a guarantee, and the effective model is not
+  // observable from the run.
+  const needsOverlay = opts.model !== null;
+  if (needsOverlay) {
+    const provider = opts.provider || DEFAULT_PROVIDER;
+    const overlay = `- id: agent-default-model\n  config:\n    provider: ${provider}\n    model: ${opts.model}\n`;
+    run.patchOverlayPath = join(outDir, "model-overlay.yml");
+    writeFileSync(run.patchOverlayPath, overlay, "utf8");
+  }
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  // sessionId is always null: the headless surface exposes none.
+  // modelOverlay is the requested {provider, model} or null — not the
+  // effective model, which the relay cannot observe and which a stored
+  // $DSH_HOME/settings.yaml selection outranks.
+  const modelOverlay = opts.model !== null
+    ? { provider: opts.provider || DEFAULT_PROVIDER, model: opts.model }
+    : null;
+  return (extra) => {
+    const result = {
+      schema: SCHEMA,
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      workdir: opts.cd,
+      permissionMode: opts.permissionMode,
+      readOnly: opts.readOnly,
+      patches: opts.patches,
+      modelOverlay,
+      dshVersion: version,
+      // The headless surface exposes no session id; rework is a fresh brief.
+      sessionId: null,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      outputPath: existsSync(run.outputPath) ? run.outputPath : null,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "dsh_unavailable", exitCode: 127, signal: null, finalMessage: "", touchedFiles: null, readOnlyViolation: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `dsh` not found on PATH. Install it with `npm i -g @deepseek-ai/dsh` (or `npx @deepseek-ai/dsh`) and set DEEPSEEK_API_KEY.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `dsh --version preflight timed out after ${probeTimeoutMs}ms; dsh was not dispatched`
+    : `dsh --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; dsh was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    readOnlyViolation: null,
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, relayArtifacts) {
+  // The pointer task is a single-line, ASCII-only instruction naming the
+  // absolute brief path. The brief itself is the file; dsh reads no stdin.
+  const pointerTask = `Read the task brief at ${run.briefPath} and execute it fully.`;
+  const argv = buildArgv(opts, pointerTask, run.patchOverlayPath);
+  // DSH_PERMISSION_MODE is the harness's own autonomy term: read-only |
+  // workspace-write | danger-full-access. Leave it unset when the caller did
+  // not specify a mode so the harness's composed default (workspace-write)
+  // applies; otherwise set it in the child's environment only.
+  const childEnv = { ...process.env };
+  if (opts.permissionMode !== null) childEnv.DSH_PERMISSION_MODE = opts.permissionMode;
+  else delete childEnv.DSH_PERMISSION_MODE;
+  // shell:true only for the .cmd shim on win32 (see dshVersion). Safe either
+  // way: the brief travels as a file, and argv holds only launcher flags,
+  // patch paths, and the single-line pointer task.
+  // detached on POSIX: the child leads a new process group so killChild can fell the whole tree
+  const child = spawn("dsh", argv, {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32",
+    env: childEnv,
+  });
+
+  let stdoutBuf = "";
+  let stderrBuf = "";
+  const stderrTail = [];
+
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    const text = stdoutDecoder.write(chunk);
+    stdoutBuf += text;
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    const text = stderrDecoder.write(chunk);
+    stderrBuf += text;
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the dsh child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      // stdoutBuf + decoder flush may still hold the final report
+      stdoutBuf += stdoutDecoder.end();
+      stderrBuf += stderrDecoder.end();
+      const finalMessage = stdoutBuf.trim();
+      if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
+      if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        finalMessage,
+        touchedFiles: gitTouchedFiles(opts.cd),
+        readOnlyViolation: null,
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; dsh was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    stdoutBuf += stdoutDecoder.end();
+    stderrBuf += stderrDecoder.end();
+    const finalMessage = stdoutBuf.trim();
+    if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
+    if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
+    const result = writeResult({ status: "failed", exitCode: 1, signal: null, finalMessage, touchedFiles: gitTouchedFiles(opts.cd), readOnlyViolation: null, stderrTail: stderrTail.slice(-20), error: String(err && err.message ? err.message : err) });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    stdoutBuf += stdoutDecoder.end();
+    stderrBuf += stderrDecoder.end();
+    if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
+    const finalMessage = stdoutBuf.trim();
+    if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
+    // A timed-out or aborted run is never completed even if dsh handles SIGTERM by
+    // exiting 0 — SIGTERM exits 0 on every surface, so the relay must classify
+    // timeout and aborted from its own state, never from the child's exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    // Only a read-only run makes a read-only claim worth measuring.
+    const readOnlyViolation = opts.readOnly
+      ? readOnlyVerdict(beforeTree, gitTripwireState(opts.cd, relayArtifacts), beforeFingerprints)
+      : null;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      readOnlyViolation,
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `dsh did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = dshVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+
+  // Fingerprint before dispatch so a read-only run has something to compare
+  // against. The relay's own artifacts are excluded.
+  const relayArtifacts = [run.briefPath, run.outputPath, run.finalPath, run.resultPath, run.patchOverlayPath].filter(Boolean);
+  const beforeTree = opts.readOnly ? gitTripwireState(opts.cd, relayArtifacts) : null;
+  const beforeFingerprints = opts.readOnly ? fingerprintDirtyPaths(opts.cd, relayArtifacts) : null;
+
+  dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, relayArtifacts);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  dsh ${result.dshVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a dsh error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated dsh (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.permissionMode) {
+    if (result.readOnly) lines.push("permission mode: read-only (DSH_PERMISSION_MODE=read-only)");
+    else lines.push(`permission mode: ${result.permissionMode}`);
+  } else if (result.readOnly) lines.push("permission mode: read-only (DSH_PERMISSION_MODE=read-only)");
+  if (result.readOnlyViolation === true) lines.push("READ-ONLY VIOLATION: the tree changed during a read-only run — inspect it before trusting this result.");
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- dsh final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/dsh-delegate/scripts/relay.mjs
+++ b/skills/dsh-delegate/scripts/relay.mjs
@@ -112,6 +112,8 @@ const SCHEMA = "delegate-relay.result.v1";
 const DEFAULT_PROVIDER = "deepseek-official";
 const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:\/-]*$/;
 const PERMISSION_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
+const STDERR_REMAINDER_LIMIT = 64 * 1024;
+const STDERR_TRUNCATION_MARKER = "[truncated] ";
 
 const IMPLEMENTER_KEY = "dsh";
 
@@ -778,6 +780,9 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
   // A stderr line can span data chunks. Holding the trailing fragment until the
   // next chunk keeps the tail one entry per logical line, so a long unterminated
   // line cannot evict complete lines from the 20-line window.
+  // The tail bounds whole lines, not the fragment held between chunks, so a dsh
+  // process emitting one very long unterminated line would otherwise grow this
+  // string without limit. Keep a bounded suffix — the tail is a tail — and say so.
   let stderrRemainder = "";
 
   const stdoutDecoder = new StringDecoder("utf8");
@@ -794,7 +799,10 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
   const pushStderr = (text, flush = false) => {
     const lines = `${stderrRemainder}${text}`.split("\n");
     // On flush the decoder is done, so the trailing fragment is a complete line.
-    stderrRemainder = flush ? "" : lines.pop();
+    const remainder = flush ? "" : (lines.pop() ?? "");
+    stderrRemainder = remainder.length > STDERR_REMAINDER_LIMIT
+      ? `${STDERR_TRUNCATION_MARKER}${remainder.slice(-(STDERR_REMAINDER_LIMIT - STDERR_TRUNCATION_MARKER.length))}`
+      : remainder;
     for (const line of lines) {
       if (line.trim()) stderrTail.push(line.trimEnd());
     }

--- a/skills/dsh-delegate/scripts/relay.mjs
+++ b/skills/dsh-delegate/scripts/relay.mjs
@@ -775,6 +775,10 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
 
   let stdoutBuf = "";
   const stderrTail = [];
+  // A stderr line can span data chunks. Holding the trailing fragment until the
+  // next chunk keeps the tail one entry per logical line, so a long unterminated
+  // line cannot evict complete lines from the 20-line window.
+  let stderrRemainder = "";
 
   const stdoutDecoder = new StringDecoder("utf8");
   const stderrDecoder = new StringDecoder("utf8");
@@ -787,8 +791,11 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
   // stderrTail is the only retained stderr: bounded to 20 lines and reported in
   // result.json. The decoder flush goes through the same path, so a trailing
   // partial line still reaches the report.
-  const pushStderr = (text) => {
-    for (const line of text.split("\n")) {
+  const pushStderr = (text, flush = false) => {
+    const lines = `${stderrRemainder}${text}`.split("\n");
+    // On flush the decoder is done, so the trailing fragment is a complete line.
+    stderrRemainder = flush ? "" : lines.pop();
+    for (const line of lines) {
       if (line.trim()) stderrTail.push(line.trimEnd());
     }
     while (stderrTail.length > 20) stderrTail.shift();
@@ -834,7 +841,7 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
       clearWatchdog();
       // stdoutBuf + decoder flush may still hold the final report
       stdoutBuf += stdoutDecoder.end();
-      pushStderr(stderrDecoder.end());
+      pushStderr(stderrDecoder.end(), true);
       const finalMessage = stdoutBuf.trim();
       if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
       if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
@@ -866,7 +873,7 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
     settled = true;
     clearWatchdog();
     stdoutBuf += stdoutDecoder.end();
-    pushStderr(stderrDecoder.end());
+    pushStderr(stderrDecoder.end(), true);
     const finalMessage = stdoutBuf.trim();
     if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
     if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
@@ -883,7 +890,7 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
     // parent is down, sweep the group (no-op where taskkill already felled the tree)
     if (watchdogFired) killChild(child, "SIGKILL");
     stdoutBuf += stdoutDecoder.end();
-    pushStderr(stderrDecoder.end());
+    pushStderr(stderrDecoder.end(), true);
     if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
     const finalMessage = stdoutBuf.trim();
     if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");

--- a/skills/dsh-delegate/scripts/relay.mjs
+++ b/skills/dsh-delegate/scripts/relay.mjs
@@ -99,7 +99,7 @@
  */
 
 import {spawn, execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync, statSync, readlinkSync, lstatSync, openSync, readSync, closeSync, realpathSync, readdirSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync, statSync, readlinkSync, lstatSync, openSync, readSync, closeSync, realpathSync, readdirSync } from "node:fs";
 import {join, resolve, basename, dirname, sep, isAbsolute, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir, homedir } from "node:os";
@@ -157,6 +157,21 @@ function fail(message, code = 2) {
   process.exit(code);
 }
 
+// Paths reach cmd.exe on win32, because a .cmd shim cannot be launched without a
+// shell and Node offers no shell-free path to one. Double quotes do NOT stop cmd
+// from expanding % or, under delayed expansion, !, and & | ^ < > still separate or
+// redirect. Quoting alone is therefore not a boundary: reject these outright rather
+// than pass a path cmd would rewrite. POSIX spawns argv directly and needs no check.
+const WIN32_SHELL_METACHARACTERS = /[%!&|^<>"]/;
+
+function assertShellSafePath(label, value) {
+  if (process.platform !== "win32") return;
+  const offending = WIN32_SHELL_METACHARACTERS.exec(value);
+  if (offending) {
+    fail(`${label} contains ${JSON.stringify(offending[0])}, which cmd.exe rewrites on win32: ${value}`);
+  }
+}
+
 function parseArgs(argv) {
   const flagged = new Set();
   const opts = {
@@ -193,9 +208,9 @@ function parseArgs(argv) {
       case "--provider": opts.provider = next(); flagged.add("provider"); break;
       case "--permission-mode": opts.permissionMode = next(); flagged.add("permissionMode"); break;
       case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
-      case "--patch": opts.patches.push(next()); flagged.add("patch"); break;
+      case "--patch": { const patch = next(); assertShellSafePath("--patch", patch); opts.patches.push(patch); flagged.add("patch"); break; }
       case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
-      case "--out-dir": opts.outDir = resolve(next()); break;
+      case "--out-dir": opts.outDir = resolve(next()); assertShellSafePath("--out-dir", opts.outDir); break;
       default:
         fail(`unknown option: ${arg}`);
     }
@@ -625,6 +640,9 @@ function prepareRunDir(opts, brief) {
   // This temp root is writable and readable under the workspace-write sandbox,
   // which is why the pointer-file mechanic is safe: the implementer can read it.
   const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  // The default out-dir borrows basename(--cd), so a repo directory carrying a cmd
+  // metacharacter would reach cmd.exe through the generated brief and overlay paths.
+  assertShellSafePath("the run directory", outDir);
   mkdirSync(outDir, { recursive: true });
   const run = {
     startedAt,
@@ -635,6 +653,13 @@ function prepareRunDir(opts, brief) {
     resultPath: join(outDir, "result.json"),
     patchOverlayPath: null,
   };
+  // A reused --out-dir must not publish a previous run's artifacts as this one's.
+  // makeResultWriter derives finalPath/outputPath from existsSync, and a polling
+  // orchestrator reads resultPath, so a run that writes no stdout would otherwise
+  // republish the earlier report and outcome (same guard as aider-delegate).
+  for (const stale of [run.finalPath, run.outputPath, run.resultPath, join(outDir, "model-overlay.yml")]) {
+    try { rmSync(stale, { force: true }); } catch { /* an unclearable path fails loudly at write time */ }
+  }
   writeFileSync(run.briefPath, brief, "utf8");
   // If a model (and thus a provider) was requested, generate the patch overlay
   // that replaces the agent-default-model row's whole config. A patch replaces
@@ -749,7 +774,6 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
   });
 
   let stdoutBuf = "";
-  let stderrBuf = "";
   const stderrTail = [];
 
   const stdoutDecoder = new StringDecoder("utf8");
@@ -760,14 +784,19 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
     stdoutBuf += text;
   });
 
-  child.stderr.on("data", (chunk) => {
-    process.stderr.write(chunk);
-    const text = stderrDecoder.write(chunk);
-    stderrBuf += text;
+  // stderrTail is the only retained stderr: bounded to 20 lines and reported in
+  // result.json. The decoder flush goes through the same path, so a trailing
+  // partial line still reaches the report.
+  const pushStderr = (text) => {
     for (const line of text.split("\n")) {
       if (line.trim()) stderrTail.push(line.trimEnd());
     }
     while (stderrTail.length > 20) stderrTail.shift();
+  };
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    pushStderr(stderrDecoder.write(chunk));
   });
 
   let settled = false;
@@ -805,7 +834,7 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
       clearWatchdog();
       // stdoutBuf + decoder flush may still hold the final report
       stdoutBuf += stdoutDecoder.end();
-      stderrBuf += stderrDecoder.end();
+      pushStderr(stderrDecoder.end());
       const finalMessage = stdoutBuf.trim();
       if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
       if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
@@ -837,7 +866,7 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
     settled = true;
     clearWatchdog();
     stdoutBuf += stdoutDecoder.end();
-    stderrBuf += stderrDecoder.end();
+    pushStderr(stderrDecoder.end());
     const finalMessage = stdoutBuf.trim();
     if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
     if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
@@ -854,7 +883,7 @@ function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, r
     // parent is down, sweep the group (no-op where taskkill already felled the tree)
     if (watchdogFired) killChild(child, "SIGKILL");
     stdoutBuf += stdoutDecoder.end();
-    stderrBuf += stderrDecoder.end();
+    pushStderr(stderrDecoder.end());
     if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
     const finalMessage = stdoutBuf.trim();
     if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -89,6 +89,15 @@ if (process.env.SMOKE_MODE === "aider-exit-nonzero") {
   console.error("fake aider nonzero exit");
   process.exit(7);
 }
+// One very long stderr line with no newline at all, delivered in many chunks, so the
+// relay's held fragment is exercised rather than its whole-line tail.
+if (process.env.SMOKE_MODE === "dsh-unterminated-stderr") {
+  for (let i = 0; i < 200; i += 1) process.stderr.write("x".repeat(10000));
+  process.stdout.write("fake dsh done\n");
+  // Exit nonzero: the relay reports stderrTail only for a run it did not call
+  // completed, and this case exists to inspect that tail.
+  process.exit(1);
+}
 if (process.env.SMOKE_MODE === "agy-permission-denied") {
   console.error('jetski: no output produced — a tool required the "write_file" permission that headless\nmode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow\nin settings.json (e.g. write_file(<target>)). Alternatively, re-run with\n--dangerously-skip-permissions to auto-approve all tools.');
   process.exit(0);

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode"];
+export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode", "dsh"];
 
 export const EXTRA_ARGS = {
   claude: [],
@@ -20,6 +20,7 @@ export const EXTRA_ARGS = {
   warp: [],
   zcode: [],
   commandcode: [],
+  dsh: [],
 };
 
 export const WIN = process.platform === "win32";

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -14,7 +14,7 @@ export function installShim(h) {
   copyFileSync(join(fixturesDir, "fake-cli.cjs"), join(shimDir, "fake-cli.cjs"));
 
   if (WIN) {
-    for (const skill of ["claude", "cline", "codex", "opencode", "grok", "cursor", "pi", "copilot", "zcode"]) {
+    for (const skill of ["claude", "cline", "codex", "opencode", "grok", "cursor", "pi", "copilot", "zcode", "dsh"]) {
       writeFileSync(join(shimDir, `${binaryName(skill)}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
     }
     const windir = process.env.WINDIR || "C:\\Windows";

--- a/test/relay-isolated.mjs
+++ b/test/relay-isolated.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode", "dsh"];
 let failed = 0;
 const check = (name, condition) => {
   console.log(`${condition ? "  ok " : "  FAIL"}  ${name}`);

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -4,8 +4,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode"];
-const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok", "zcode", "commandcode"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode", "dsh"];
+const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok", "zcode", "commandcode", "dsh"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],
   ["parseDuration", "function", RELAYS],

--- a/test/relay/dsh.mjs
+++ b/test/relay/dsh.mjs
@@ -61,6 +61,27 @@ export function runDsh(h) {
     }
   }
 
+  // 2 MB of stderr with no newline: the held fragment must stay bounded and be
+  // reported as one marked line, not grow until the relay runs out of memory.
+  const floodOut = join(h.scratch, "out-stderr-flood-dsh");
+  const flood = spawnSync(process.execPath, [
+    h.relayPath("dsh"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", floodOut,
+    // The relay echoes the child's stderr to its own, so this spawnSync needs room for
+    // all 2 MB; the default 1 MB maxBuffer would kill the relay and mask the result.
+  ], { env: { ...h.baseEnv, SMOKE_MODE: "dsh-unterminated-stderr" }, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 });
+  h.check("dsh stderr flood: relay survives an unterminated 2 MB line", flood.status === 1);
+  if (existsSync(join(floodOut, "result.json"))) {
+    const value = h.result(floodOut);
+    const tail = value.stderrTail ?? [];
+    h.check("dsh stderr flood: the tail is actually reported", tail.length === 1);
+    h.check("dsh stderr flood: the fragment is one entry, not thousands", tail.length === 1);
+    h.check("dsh stderr flood: the retained fragment is bounded and marked",
+      tail.length === 1 && tail[0].length <= 65_536 && tail[0].startsWith("[truncated] "));
+  }
+
   // A path with none of those characters must still be accepted, so the guard
   // cannot be "fixed" by rejecting everything.
   const cleanOut = join(h.scratch, "out-clean-dsh");

--- a/test/relay/dsh.mjs
+++ b/test/relay/dsh.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -18,6 +18,10 @@ export function runDsh(h) {
   for (const character of METACHARACTERS) {
     const outDir = join(h.scratch, `out-patch-metachar-${METACHARACTERS.indexOf(character)}-dsh`);
     const patch = join(h.scratch, `overlay${character}.yml`);
+    // The relay also exits 2 for a --patch file that does not exist, so on POSIX the
+    // file has to be real or that check, not the guard, would decide the exit. These
+    // names are legal on POSIX and illegal on Windows, where the guard fires first.
+    if (!h.WIN) writeFileSync(patch, "- id: agent-default-model\n", "utf8");
     const run = spawnSync(process.execPath, [
       h.relayPath("dsh"),
       "--brief", h.briefPath,
@@ -32,10 +36,9 @@ export function runDsh(h) {
       h.check(`dsh win32 --patch ${JSON.stringify(character)}: writes no result file`,
         !existsSync(join(outDir, "result.json")));
     } else {
-      // POSIX spawns argv directly, so the guard must not fire; the run fails later
-      // on the missing patch file or the absent binary, never with a usage exit.
-      h.check(`dsh posix --patch ${JSON.stringify(character)}: guard does not apply`,
-        run.status !== 2 || !run.stderr.includes("cmd.exe"));
+      // POSIX spawns argv directly, so the guard must not fire at all: any usage exit
+      // here is a failure, whatever the diagnostic says.
+      h.check(`dsh posix --patch ${JSON.stringify(character)}: no usage exit`, run.status !== 2);
     }
   }
 
@@ -54,8 +57,7 @@ export function runDsh(h) {
       h.check(`dsh win32 --out-dir ${JSON.stringify(character)}: writes no result file`,
         !existsSync(join(outDir, "result.json")));
     } else {
-      h.check(`dsh posix --out-dir ${JSON.stringify(character)}: guard does not apply`,
-        run.status !== 2 || !run.stderr.includes("cmd.exe"));
+      h.check(`dsh posix --out-dir ${JSON.stringify(character)}: no usage exit`, run.status !== 2);
     }
   }
 

--- a/test/relay/dsh.mjs
+++ b/test/relay/dsh.mjs
@@ -1,0 +1,74 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The win32 launch sends paths through cmd.exe, because a .cmd shim cannot be
+ * spawned without a shell. Quoting is not a boundary there — cmd expands % inside
+ * double quotes and ! under delayed expansion, and still reads & | ^ < > — so the
+ * relay rejects those characters instead of escaping them. These cases pin that
+ * rejection so a later change cannot quietly drop it.
+ */
+const METACHARACTERS = ["%", "!", "&", "|", "^", "<", ">", '"'];
+
+export function runDsh(h) {
+  const workDir = h.freshRepo("work-metachar-dsh");
+
+  // A rejected path must never reach a run, so no result file may appear either.
+  for (const character of METACHARACTERS) {
+    const outDir = join(h.scratch, `out-patch-metachar-${METACHARACTERS.indexOf(character)}-dsh`);
+    const patch = join(h.scratch, `overlay${character}.yml`);
+    const run = spawnSync(process.execPath, [
+      h.relayPath("dsh"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", outDir,
+      "--patch", patch,
+    ], { env: h.baseEnv, encoding: "utf8" });
+    if (h.WIN) {
+      h.check(`dsh win32 --patch ${JSON.stringify(character)}: exits 2`, run.status === 2);
+      h.check(`dsh win32 --patch ${JSON.stringify(character)}: diagnostic names the character`,
+        run.stderr.includes("--patch") && run.stderr.includes(JSON.stringify(character)));
+      h.check(`dsh win32 --patch ${JSON.stringify(character)}: writes no result file`,
+        !existsSync(join(outDir, "result.json")));
+    } else {
+      // POSIX spawns argv directly, so the guard must not fire; the run fails later
+      // on the missing patch file or the absent binary, never with a usage exit.
+      h.check(`dsh posix --patch ${JSON.stringify(character)}: guard does not apply`,
+        run.status !== 2 || !run.stderr.includes("cmd.exe"));
+    }
+  }
+
+  for (const character of METACHARACTERS) {
+    const outDir = join(h.scratch, `out-dir-metachar${character}-dsh`);
+    const run = spawnSync(process.execPath, [
+      h.relayPath("dsh"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", outDir,
+    ], { env: h.baseEnv, encoding: "utf8" });
+    if (h.WIN) {
+      h.check(`dsh win32 --out-dir ${JSON.stringify(character)}: exits 2`, run.status === 2);
+      h.check(`dsh win32 --out-dir ${JSON.stringify(character)}: diagnostic names the character`,
+        run.stderr.includes("--out-dir") && run.stderr.includes(JSON.stringify(character)));
+      h.check(`dsh win32 --out-dir ${JSON.stringify(character)}: writes no result file`,
+        !existsSync(join(outDir, "result.json")));
+    } else {
+      h.check(`dsh posix --out-dir ${JSON.stringify(character)}: guard does not apply`,
+        run.status !== 2 || !run.stderr.includes("cmd.exe"));
+    }
+  }
+
+  // A path with none of those characters must still be accepted, so the guard
+  // cannot be "fixed" by rejecting everything.
+  const cleanOut = join(h.scratch, "out-clean-dsh");
+  const clean = spawnSync(process.execPath, [
+    h.relayPath("dsh"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", cleanOut,
+    "--permission-mode", "read-only",
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("dsh clean path: guard does not reject an ordinary out-dir", clean.status !== 2);
+  h.check("dsh clean path: the run publishes a result file", existsSync(join(cleanOut, "result.json")));
+}

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -20,6 +20,7 @@ import { runAider } from "./aider.mjs";
 import { runCopilot } from "./copilot.mjs";
 import { runCommandcode } from "./commandcode.mjs";
 import { runZcode } from "./zcode.mjs";
+import { runDsh } from "./dsh.mjs";
 
 export const runners = [
   ["package-shape", runPackageShape],
@@ -43,5 +44,6 @@ export const runners = [
   ["timeout-tree", runTimeoutTree],
   ["abort", runAbort],
   ["zcode", runZcode],
+  ["dsh", runDsh],
   ["delegate-setup", runDelegateSetup],
 ];


### PR DESCRIPTION
**Claim:** #93

Adds `dsh-delegate`, driving `dsh --profile headless` (DeepSeek Harness) as an implementer.

## What ran

Windows 11, `dsh` 0.1.0-rc.7 (npm global install), from both Git Bash and native PowerShell.

Live `dsh --profile headless` runs through the relay, each posture from each shell:

- **Write run** — the briefed edit applied and left uncommitted; `touchedFiles` reported the modified
  file, `dshVersion` captured from the bounded preflight.
- **`--read-only` run** — a brief that ordered an immediate file write was refused by the harness
  itself ("the current sandbox is read-only, and the required write-access approval is unavailable"),
  leaving `touchedFiles` empty and `readOnlyViolation` false. That exercises both the sandbox and the
  fail-closed approval seam.
- **Against a real tree** — the same two postures against a 7,800-file checkout with its own
  `AGENTS.md`: a read-only analysis run cited exact files and line numbers across four source files
  and left the tree clean, and a write run added one bullet to one file and nothing else.
- **`--timeout` firing against a live `dsh`** — the watchdog killed the run on schedule and reported
  `status: "timeout"`, `exitCode: 1`, `signal: null`. The null signal is the point: `dsh` caught the
  SIGTERM, ran its graceful drain, and **exited 0**. A relay trusting the child's exit code would
  have called that run `completed`. No orphaned processes survived.
- **`failed` path** — a provider route with no active credentials produced `status: "failed"`,
  exit 1, stderr tail captured, no final message.
- Usage errors (conflicting flags, invalid `--permission-mode`, missing brief) exit 2 and write no
  result file; a missing binary exits 127 **with** one.

Gates: `relay-parity`, `relay-isolated`, `event-scanner`, full `relay-smoke`, and
`npx skills add . --list` — all green.

**Untested:** macOS and Linux; `cmd.exe` as the launching shell.

## What the surface does and does not have

Narrower than most siblings, and the skill says so rather than papering over it:

- **No structured stream.** The machine-readable contract is exit code plus final stdout text, so
  `finalMessage` is dsh's own last assistant message.
- **No session id, no resume.** The headless app persists a session under `$DSH_HOME` but prints no
  id and offers no continue flag. The relay ships neither `--resume-last` nor `--session`, reports
  `sessionId: null`, and documents rework as a fresh full brief.
- **Argv-only task delivery.** No stdin, no message-file flag, and the app space-joins a multi-token
  positional. The relay writes the brief to its temp out-dir and passes a single-line pointer, which
  also keeps a multi-line brief away from `cmd.exe` under the win32 `.cmd` shim.
- **Autonomy is `DSH_PERMISSION_MODE`** in the child env, in the harness's own preset names.
  `read-only` is enforced by the sandbox, and the approval seam fails closed with no answerer
  composed, so a headless run cannot hang on a prompt nobody can answer.
- **Model selection has no flag.** `--model` / `--provider` generate an `agent-default-model` patch
  overlay. A stored selection in `$DSH_HOME/settings.yaml` outranks that entry — measured, by a run
  whose overlay named a nonexistent model and completed on the stored selection anyway. So
  `result.json` reports `modelOverlay` as what was *requested*; the effective model is not
  observable from the run, and the docs say that rather than implying the flag decides.

`dsh` is in developer preview and its README promises compatibility-breaking changes; `SKILL.md`
leads with that.

## Registration

`skills.sh.json`, the smoke matrix and win32 `.cmd` shim list, both `relay-parity` lists (including
the read-only tripwire set), `relay-isolated`, the README table and Verification status, `AGENTS.md`
vocabulary and the Windows `shell:true` note, plus a `delegate-setup` implementers entry — without
that last one the full suite fails on `discover covers every implementer in the smoke matrix` and
`--lane` cannot resolve `dsh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Command Code and DeepSeek Harness delegation capabilities.
  * Added task briefs, model and permission options, read-only runs, timeouts, Windows support, result reporting, and change tracking.
  * Added validation for providers, models, permission modes, and unsafe Windows command paths.

* **Documentation**
  * Added guidance for brief writing, task queues, verification, review, and safely landing delegated work.
  * Updated CLI usage, configuration, verification status, and Windows launch guidance.

* **Tests**
  * Added coverage for installation, isolation, parity, read-only behavior, validation, relay failures, and Windows command handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->