### PR TITLE
feat: add dsh-delegate (DeepSeek Harness) with session-record harvest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,13 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Seventeen implementer skills ship today: `claude-delegate` (Claude Code),
+and land the result. Eighteen implementer skills ship today: `claude-delegate` (Claude Code),
 `cline-delegate` (Cline CLI), `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode),
 `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code),
 `qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI),
 `pi-delegate` (Pi CLI), `omp-delegate` (Oh My Pi), `aider-delegate` (Aider), `copilot-delegate` (GitHub Copilot CLI),
-`warp-delegate` (Warp Agent CLI), `zcode-delegate` (Z.AI ZCode), and `commandcode-delegate` (Command Code); siblings like
+`warp-delegate` (Warp Agent CLI), `zcode-delegate` (Z.AI ZCode), `commandcode-delegate` (Command Code),
+and `dsh-delegate` (DeepSeek Harness); siblings like
 `gemini-delegate` can be added
 later without renaming the repo. One **utility** skill
 ships alongside them: `delegate-setup` (configure fleet lanes — setup only, never dispatches).
@@ -21,7 +22,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Oh My Pi, Aider, Copilot, Warp, ZCode, Command Code) | "worker", "sub-agent", "executor" |
+| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Oh My Pi, Aider, Copilot, Warp, ZCode, Command Code, DeepSeek Harness) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -47,6 +48,7 @@ jargon. Use these terms; don't invent synonyms.
 | `--message-file`, `--yes-always`, `--suggest-shell-commands`, `--auto-commits`/`--dirty-commits`, `--dry-run`, `--edit-format`, `--architect`, `--file`/`--read`, `chat history` | Aider's own terms — use verbatim when discussing `aider` | Aider has no sandbox, no permission modes, and no session ids; don't imply any. `--file`/`--read` scope the chat context — never call them a boundary |
 | `session`, `-p`/`--prompt`, `--output-format json` (JSONL), `tools`, `--allow-all-tools`, `mode plan`, `--resume`/`--continue`, `--model`, `--effort`, `copilot login` / env tokens, `sandbox` (experimental, MXC) | GitHub Copilot CLI's own terms — use verbatim when discussing `copilot` | don't paraphrase them |
 | `mode` (`build`/`edit`/`plan`/`yolo`), `session` (`sess_…`), `goal` (`--target`), `--attach`, `app-server`, `plugins`, `skills` | ZCode's own terms — use verbatim when discussing `zcode` | don't call `mode` a sandbox or a permission mode; never present `build`/`edit` as usable headlessly |
+| `--profile headless`, `profile`, `bundle`, `patch` / `--patch`, `workspace root`, `DSH_PERMISSION_MODE` (`read-only` / `workspace-write` / `danger-full-access`), `approval policy` (`ask` / `never`), `agent-default-model`, `$DSH_HOME`, `settings.yaml`, session record (`$DSH_HOME/sessions/…/session.jsonl.zstd`) | DeepSeek Harness's own terms — use verbatim when discussing `dsh` | don't call `DSH_PERMISSION_MODE` a flag (it is an environment override), don't present the session record as a resume mechanism (the headless surface has none — the relay only harvests it after the run), and don't call a `--patch` overlay a "config merge" (it replaces the targeted row's whole `config`) |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -55,7 +57,7 @@ version a run was made against is what makes the claim checkable; and claims tha
 ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
 `cline` / `codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi` /
-`aider` / `copilot` / `oz` / `omp` / `zcode` / `cmd`) and the skill's `relay.mjs`.
+`aider` / `copilot` / `oz` / `omp` / `zcode` / `cmd` / `dsh`) and the skill's `relay.mjs`.
 
 ## Conventions
 
@@ -90,7 +92,7 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - Smoke-test any changed script directly (e.g. `node skills/<skill>/scripts/relay.mjs --help`, and a
   no-write or read-only run against a throwaway repo) before relying on it.
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
-  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, `grok`, `pi`, `cline`, and `copilot` launches
+  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, `grok`, `pi`, `cline`, `copilot`, and `dsh` launches
   need `shell:true` on win32 to resolve the `.cmd` shim. Cline streams its brief on stdin and uses the
   child process cwd; the other launches quote spaceable args, and all value flags are token-validated.
   The `claude` and `cursor-agent` launches serialize a pre-joined

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`codex-delegate`](skills/codex-delegate/SKILL.md) | [OpenAI Codex](https://github.com/openai/codex) (`codex`) | `--sandbox workspace-write` | `--read-only` | `--resume-last`, `--session <id>` |
 | [`commandcode-delegate`](skills/commandcode-delegate/SKILL.md) | [Command Code](https://commandcode.ai/docs/headless) (`cmd`) | `--yolo` — the only headless write state; no sandbox [^commandcode] | `--read-only` (withheld tools + `plan`) | `--continue-last`, `--session <id>` |
 | [`cursor-delegate`](skills/cursor-delegate/SKILL.md) | [Cursor Agent](https://cursor.com/cli) (`cursor-agent`) | `--force`; `--no-force` withholds command approval | `--read-only` (plan mode) | `--resume-last`, `--session <id>` |
+| [`dsh-delegate`](skills/dsh-delegate/SKILL.md) | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) — developer preview; serves hosted or local OpenAI-compatible models | `workspace-write` (`read-only` / `danger-full-access` via `DSH_PERMISSION_MODE`) | `--read-only` (sandbox-enforced, plus tripwire) | — (no headless resume; the session record is harvested for audit) [^dsh] |
 | [`grok-delegate`](skills/grok-delegate/SKILL.md) | Grok Build (`grok`) | workspace-scoped; `--full-access` opt-in | `--read-only` — best-effort [^grok] | `--resume-last`, `--session <id>` |
 | [`kimi-delegate`](skills/kimi-delegate/SKILL.md) | [Kimi Code](https://moonshotai.github.io/kimi-code/en/) (`kimi`) | `auto permission mode`, always | — [^none] | `--resume-last`, `--session <id>` |
 | [`opencode-delegate`](skills/opencode-delegate/SKILL.md) | [OpenCode](https://opencode.ai) (`opencode`) | agent `build` (`--model` required) | `--read-only` (agent `plan`) | `--resume-last`, `--session <id>` |
@@ -102,6 +103,13 @@ is configurable through it.
 
 [^grok]: `grok` cannot be prevented from writing headlessly. The relay reports a tri-state
 `readOnlyViolation` tripwire for detected Git-visible changes; it does not enforce or attribute them.
+
+[^dsh]: The `dsh` headless surface prints no session id and offers no resume flag, so rework is a
+fresh self-contained brief. The relay instead harvests the session record dsh persists under
+`$DSH_HOME/sessions` — reporting the session id, the provider/model/reasoning effort that actually
+served the run (a `--model` request is a patch overlay that a stored `settings.yaml` selection
+outranks), summed token usage, and the recorded permission preset. The harvest needs Node 22.15+
+(zlib zstd); on an older Node the dispatch still works and `sessionHarvest` says so.
 
 [^zcode]: ZCode ships its CLI **inside the desktop app** — there is no `zcode` on PATH, no npm
 package, and the public docs cover only the GUI. The relay resolves it from
@@ -294,6 +302,35 @@ Per skill — platform, CLI version, and what the run exercised:
   Windows is untested and the relay refuses to guess there (the binary name `cmd` is `cmd.exe`); it
   requires `COMMANDCODE_BIN` to be the real executable's absolute path, not the system command
   interpreter.
+- `dsh-delegate` — Linux (x86_64), `dsh` 0.1.1-rc.1 (npm install), driven from bash by Claude Code,
+  against a **live local inference server**: vLLM on loopback serving an FP8 27B Qwen model through
+  an OpenAI-compatible endpoint (not a stub). Seven live relay dispatches: a default-posture write
+  run that created exactly the briefed file, left it uncommitted, and harvested the session record —
+  `sessionId`, `actualProvider`/`actualModel`, reasoning effort, summed token usage, and the
+  recorded `workspace-write` posture; a `--read-only` run whose brief ordered an immediate write —
+  the sandbox refused it, the final message stated the approval escalation failed closed,
+  `touchedFiles` came back empty, `readOnlyViolation` false, and the record's own
+  `permission/preset` read `read-only`; a `--model nonexistent-model-xyz` run that completed on the
+  stored `settings.yaml` selection — measuring the overlay precedence on this rc — with
+  `modelOverlay` reporting the request and `actualModel` the served model, so the precedence is
+  observable per run instead of assumed; a `--timeout 25s` watchdog firing against live `dsh`,
+  which caught the SIGTERM, drained, and exited 0 (`signal: null`) — reported as
+  `status: "timeout"`, exit 1, with no orphaned processes and the interrupted session still
+  harvested; a relay-level SIGTERM abort mid-run reporting `aborted`/exit 143 with `result.json`
+  written; a fresh-`$DSH_HOME` run with no credentials failing live with `MISSING_CREDENTIAL` in
+  `stderrTail` (`failed`, exit 1); and a fresh-`$DSH_HOME` run whose single `--patch` overlay
+  defined a local OpenAI-compatible provider end-to-end and completed on it, confirmed by the
+  harvest's `actualProvider`. Direct CLI probes measured the surface the docs claim: no stdin task
+  ("a task is required", exit 1), `--resume` rejected as an unknown option, workspace `AGENTS.md`
+  auto-loaded by a headless run, and an invalid `DSH_PERMISSION_MODE` failing the plugin tree load
+  with the valid enum named. Contract-tested besides, against the shared smoke matrix: argument
+  validation and usage errors exiting 2 with no result file, an already-exported
+  `DSH_PERMISSION_MODE` honored (and an explicit flag overriding it), the multi-frame zstd
+  session-record harvest matched by the header's own `cwd`, a missing binary exiting 127 **with** a
+  result file, bounded `--version` preflight, the unterminated-stderr fragment staying bounded, the
+  win32 cmd-metacharacter rejection, and whole-process-tree timeout/abort cleanup. Not run: native
+  Windows or macOS (the win32 `.cmd`-shim launch and guards are contract-tested via the smoke
+  matrix only), and upstream had already tagged `0.1.1-rc.2` — these runs are against `0.1.1-rc.1`.
 - `warp-delegate` — macOS, `oz` 0.2026.05.27.15.44.stable_01: **live edit run verified**. A relay
   dispatch against a throwaway git repository had Warp add a function plus four assertions across
   two files; both project gates were re-run independently by the orchestrator, the diff matched the

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -21,7 +21,8 @@
         "copilot-delegate",
         "warp-delegate",
         "zcode-delegate",
-        "commandcode-delegate"
+        "commandcode-delegate",
+        "dsh-delegate"
       ]
     },
     {

--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -34,6 +34,7 @@ import {
   OMP_THINKING,
   CODEX_SANDBOX,
   CONFIG_VERSION,
+  DSH_PERMISSION,
   GROK_SANDBOX,
   IMPLEMENTER_BY_KEY,
   LANE_NAME,
@@ -169,6 +170,11 @@ function validateLane(name, lane, label) {
       return `${label}: lane ${name}.model must be provider/model (e.g. opencode/grok)`;
     }
   }
+  // The relay derives one agent-default-model overlay from both halves and exits 2
+  // on a provider with no model, so a lane must not be able to store that pair.
+  if (impl.key === "dsh" && typeof lane.provider === "string" && typeof lane.model !== "string") {
+    return `${label}: lane ${name}: dsh provider needs model`;
+  }
   const autonomyError = validateAutonomyConsistency(impl.key, lane, name, label);
   if (autonomyError) return autonomyError;
   return null;
@@ -186,6 +192,13 @@ function validateAutonomyConsistency(implementer, lane, laneName, label) {
     implementer === "qoder" &&
     typeof lane.permissionMode === "string" &&
     lane.permissionMode !== "plan"
+  ) {
+    return `${label}: lane ${laneName}: readOnly contradicts permissionMode ${JSON.stringify(lane.permissionMode)}`;
+  }
+  if (
+    implementer === "dsh" &&
+    typeof lane.permissionMode === "string" &&
+    lane.permissionMode !== "read-only"
   ) {
     return `${label}: lane ${laneName}: readOnly contradicts permissionMode ${JSON.stringify(lane.permissionMode)}`;
   }
@@ -255,6 +268,9 @@ function validateDialValue(implementer, field, value, laneName, label) {
   // have no permission client, so they change nothing and still exit 0.
   if (field === "permissionMode" && implementer === "zcode" && !ZCODE_MODE.includes(value)) {
     return `${label}: lane ${laneName}.permissionMode must be one of: ${ZCODE_MODE.join(", ")}`;
+  }
+  if (field === "permissionMode" && implementer === "dsh" && !DSH_PERMISSION.includes(value)) {
+    return `${label}: lane ${laneName}.permissionMode must be one of: ${DSH_PERMISSION.join(", ")}`;
   }
   if (field === "variant") {
     // OpenCode appends --variant on win32 shell:true; reject cmd metacharacters.

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -380,6 +380,25 @@ export const IMPLEMENTERS = Object.freeze([
     winShell: false,
 
   },
+  {
+    key: "dsh",
+    skill: "dsh-delegate",
+    binary: "dsh",
+    versionArgs: ["--version"],
+    // No auth-status command; credentials resolve from the environment
+    // (DEEPSEEK_API_KEY, or the apiKeyEnv named by a provider in
+    // $DSH_HOME/settings.yaml) and the Harness credential files.
+    authProbe: null,
+    // No --model flag or model-list command on the headless surface: a lane's
+    // provider/model pair rides a generated agent-default-model patch overlay,
+    // and a stored settings.yaml selection outranks it.
+    modelProbe: null,
+    // Sessions persist under $DSH_HOME/sessions; the relay harvests the record
+    // per run, but there is no CLI usage query to probe here.
+    usageProbe: null,
+    supports: ["provider", "model", "timeout", "readOnly", "permissionMode"],
+    winShell: true,
+  },
 ]);
 
 /** Prototype-free map so names like "toString" cannot pass as implementers. */
@@ -411,6 +430,12 @@ export const QODER_PERMISSION = Object.freeze([
  * the same reason, so a lane must not be able to select one either.
  */
 export const ZCODE_MODE = Object.freeze(["plan", "yolo"]);
+/**
+ * dsh's DSH_PERMISSION_MODE, carried as the `permissionMode` dial. These are the
+ * harness's own preset names; the relay rejects anything else with exit 2, so a
+ * lane must not be able to select one either.
+ */
+export const DSH_PERMISSION = Object.freeze(["read-only", "workspace-write", "danger-full-access"]);
 /** Positive h/m/s duration, same shape relays accept. */
 export const TIMEOUT_RE = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/;
 

--- a/skills/dsh-delegate/SKILL.md
+++ b/skills/dsh-delegate/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: dsh-delegate
+description: >-
+  Delegate a coding task to the DeepSeek Harness CLI (`dsh`) as a background implementer, then review
+  its diff and land it yourself. Use this whenever the user wants to hand implementation work to
+  DeepSeek Harness — phrasings like "have DeepSeek Harness do X", "delegate this to dsh", "run it
+  through the harness", or "use dsh to implement/fix/refactor" — including when dsh is configured to
+  serve a locally hosted model behind an OpenAI-compatible endpoint (vLLM, llama.cpp, Ollama, …), or
+  to run a queue of coding tasks through dsh while staying the reviewer. DO NOT USE for tasks small
+  enough to do inline, or when the user wants the code written directly without delegating.
+license: MIT
+compatibility: Requires the `dsh` CLI installed (`npm i -g @deepseek-ai/dsh` or `npx @deepseek-ai/dsh`) with a provider credential — `DEEPSEEK_API_KEY`, or any provider configured in `$DSH_HOME/settings.yaml`, including a local OpenAI-compatible endpoint — plus Node 18+ (22.15+ for the session-record harvest) and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+
+# DeepSeek Harness Delegate
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the DeepSeek Harness CLI (`dsh --profile headless`) — then review what it produced
+and land it yourself. You write the brief and own the judgment; the harness does the typing inside
+its own sandbox posture; you verify and commit.
+
+> DeepSeek Harness is in **developer preview** and its README promises compatibility-breaking
+> changes. Treat any dsh behavior as provisional; the relay records the `dsh` version it ran.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so it works the same whether you are Claude Code, OpenCode with a selected
+model, or any comparable agent. (It is designed for and run on Claude Code; treat other orchestrators
+as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- `dsh` is not installed, or no provider is usable (no `DEEPSEEK_API_KEY` and no configured provider).
+- You want to write the code yourself, or you only need a diagnosis (then dispatch `--read-only`).
+
+## Prerequisites (check once)
+
+1. `dsh --version` succeeds. If not, install with `npm i -g @deepseek-ai/dsh`. There is no
+   `dsh auth` command: credentials resolve from the environment (`DEEPSEEK_API_KEY`, or the
+   `apiKeyEnv` a provider names in `$DSH_HOME/settings.yaml`) and the harness credential files.
+2. **Confirm which `dsh` is on PATH.** `command -v dsh` shows the active binary and `dsh --version`
+   its version; the relay records the version it ran into `result.json`, so a stale binary is
+   visible after the fact.
+3. You are in (or will point `--cd` at) the target git repository.
+
+## Choose the implementer model
+
+The headless surface has **no model flag**. The deployment default lives in the composed
+`agent-default-model` row (provider + model), which `$DSH_HOME/settings.yaml` can override. The
+relay's `--model <name>` (with optional `--provider <name>`) generates a `--patch` overlay that
+replaces that row's config — but a stored `settings.yaml` selection **outranks the overlay**
+(measured), so the flags are a request, not a guarantee. What makes this workable in practice:
+`result.json` reports both — `modelOverlay` is what was requested, and `actualModel` /
+`actualProvider` / `reasoningEffort` are what actually served the run, harvested from the session
+record dsh writes. Compare them instead of assuming.
+
+For a locally hosted model — or any OpenAI-compatible endpoint — see the local-model section of
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md): a persistent selection belongs in
+`$DSH_HOME/settings.yaml`, and a fully self-contained per-run wiring can ride a single `--patch`
+overlay (measured end-to-end against a local vLLM server).
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+`dsh` sees **only** the text you send plus what it can read from the working tree — no chat history,
+no shared context. Everything the task needs goes in the brief: the goal, the current state, what to
+change, what to leave untouched, the project's **actual** gate commands (discover them from the
+repo's AGENTS.md/CLAUDE.md/Makefile — do not assume), and a report contract. Tell `dsh` it will
+**not** commit (you will). Keep one task per brief. `dsh` auto-loads applicable `AGENTS.md` /
+`CLAUDE.md` context files from the workspace (measured), so don't restate what those already say —
+but keep the load-bearing constraints in the brief anyway. Full guidance and a template:
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to `dsh` with the bundled helper. `dsh --profile headless` takes the task **only** as
+a positional argv value — no stdin (measured) — so the relay writes the brief to
+`<out-dir>/brief.md` and passes a one-line pointer naming that absolute path; the sandbox confines
+mutations, not reads, so the implementer can read it. The relay captures the run and writes a
+structured `result.json` — your only job is "run a command, read a file." (`<skill-dir>` below is
+this skill's installed directory — the folder containing this `SKILL.md`. Claude Code prints it as
+"Base directory for this skill" when the skill loads; if unsure where it landed, run
+`find ~ -name relay.mjs -path '*dsh-delegate*'` and substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# request a model:                   add --model <name> [--provider <name>]  (a request — check actualModel)
+# fleet lane from delegate-setup:    add --lane <name>   (dials apply; explicit flags win)
+# read-only (review/diagnosis):      add --read-only     (DSH_PERMISSION_MODE=read-only + tripwire)
+# extra composition overlay:         add --patch ./overlay.yml   (repeatable; can wire a local endpoint)
+# hard time limit (watchdog):        add --timeout 2h    (default: off)
+# see all options:                   node .../relay.mjs --help
+```
+
+The helper writes its artifacts to a temp dir by default, so the repo under review stays clean. It
+**never commits** — see step 5. Mechanics, flags, the local-endpoint overlay, and the `result.json`
+shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until `dsh` finishes, so back it with whatever your orchestrator offers and resume
+when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent
+  (`Start-Job` in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a
+  `status`. (A pre-run usage error — bad args or an empty brief — instead exits with code 2 and
+  writes no result file, so check the exit code too. A missing `dsh` binary exits 127 but *does*
+  write a `result.json` with status `dsh_unavailable`.)
+- **There is no headless resume.** `--resume` is rejected by the app (measured). `result.json`
+  reports the run's `sessionId` harvested from the on-disk session record — an audit handle, not a
+  resume handle. Rework is a fresh, self-contained brief — see step 5.
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line. The implementer's full report is the
+`finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
+
+### 4. Review — do not trust the self-report
+
+`dsh`'s `result.json` includes its own final message and any gate claims. **Re-verify, don't
+accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did `dsh` do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Committing should be the act
+of the party that verified the work. Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a fresh, fully self-contained brief — the headless surface has no resume,
+  and `dsh` remembers nothing from the previous run. Fold the previous brief's constraints plus the
+  new corrections into one document, and review again.
+
+## Autonomy model
+
+`dsh`'s autonomy is the **`DSH_PERMISSION_MODE`** posture in the child's environment, mapped to the
+`sandbox-policy` row's `mode` with `workspaceRoot` bound to `process.cwd()`:
+
+| `DSH_PERMISSION_MODE` | sandbox `mode` | `approval` `policy` | Confinement |
+| --- | --- | --- | --- |
+| unset (default) | `workspace-write` | `ask` | Filesystem and shell **mutations** are confined to the workspace and the platform temp roots. Reads and network access are **not** confined. |
+| `read-only` | `read-only` | `ask` | Enforced by the sandbox: a briefed write is refused by the harness itself (measured), and the relay's tripwire measures the tree besides. |
+| `danger-full-access` | `danger-full-access` | `never` | Removes the workspace boundary **and** silences approval. Present it as what it is; never as the ordinary posture. |
+
+The **approval seam fails closed** in a headless run — no answerer is composed, so an escalation
+beyond the sandbox is rejected rather than left hanging on a prompt nobody can answer. This is why a
+headless `dsh` run needs no auto-approve flag and cannot hang on a permission prompt.
+
+Two relay-specific points, both measured:
+
+- **A refused write still exits 0.** A `read-only` run whose brief ordered a write completes with
+  the refusal in the final message and a clean tree — the exit code does not carry it. Read
+  `readOnlyViolation` and the final message, not just `status`.
+- **An already-exported `DSH_PERMISSION_MODE` is honored and reported** (`permissionModeSource:
+  "environment"`), never silently stripped — stripping it would loosen a user's standing read-only
+  posture. `--permission-mode` and lane dials override it; `--read-only` is sugar for
+  `--permission-mode read-only` and also arms the Git tripwire.
+
+The **invoking directory is the workspace root** — there is no workspace flag; the relay sets the
+child's cwd from `--cd` and that becomes the sandbox's `workspaceRoot`.
+
+Session telemetry stays local by default (`DSH_TELEMETRY_MODE` defaults to disabled). The relay does
+not set, change, or defeat any telemetry variable. After the run it reads the session record `dsh`
+itself wrote under `$DSH_HOME/sessions` — locally, reporting into `result.json` only — to recover
+the session id, the served model, token usage, and the recorded permission preset.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"),
+committing verified, gate-passing work is the agreed contract — that is the whole point. Two limits
+on that mandate: **surface, don't absorb** (report `dsh`'s design decisions,
+defensible-but-unasked turns, and non-blocking nitpicks rather than silently keeping them) and
+**stop for scope changes** (if correct completion needs going beyond the brief, ask — don't expand
+the mandate yourself). The full treatment is in
+[references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief `dsh`
+  can execute blind: structure, XML blocks, the report contract, the real gates, pointer-file
+  delivery, and sizing briefs for small-context local models.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract including the session-record harvest, wiring a local OpenAI-compatible
+  endpoint, the SIGTERM-exits-0 trap, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the rework cycle as a fresh self-contained brief.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward without resume, progress tracking, and the end-of-run coherence check.

--- a/skills/dsh-delegate/references/dispatch-and-poll.md
+++ b/skills/dsh-delegate/references/dispatch-and-poll.md
@@ -164,9 +164,10 @@ no file" as a usage error, not a lost run.
 
 - **`failed` with `MISSING_CREDENTIAL`** — the provider route has no key: export the credential the
   diagnostic names (or the `apiKeyEnv` your provider config names) and re-dispatch.
-- **`failed` at boot with a config validation error** — an invalid `DSH_PERMISSION_MODE` or a
-  malformed `--patch` overlay fails the plugin tree load with the offending row named; fix the
-  overlay and re-dispatch.
+- **`failed` at boot with a config validation error** — a malformed `--patch` overlay fails the
+  plugin tree load with the offending row named; fix the overlay and re-dispatch. (An invalid
+  `DSH_PERMISSION_MODE` never gets that far: the relay rejects it pre-run with exit 2 and no
+  result file, whether it came from `--permission-mode` or from the environment.)
 - **`timeout` / `aborted`** — inspect the working tree before anything else: the run may have
   partial edits. Keep or revert them deliberately (see
   [review-and-land.md](review-and-land.md)), then re-dispatch a fresh, self-contained brief.

--- a/skills/dsh-delegate/references/dispatch-and-poll.md
+++ b/skills/dsh-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,175 @@
+# Dispatch and poll
+
+The relay wraps one `dsh --profile headless` run: it validates arguments, writes the brief to a
+file, launches `dsh` with a one-line pointer task, captures the run, harvests the session record,
+and publishes `result.json` atomically. You run one command and read one file.
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+## Flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--brief <file>` | The brief; piped stdin is the alternative. Empty briefs exit 2. |
+| `--cd <dir>` | Child cwd and the sandbox's `workspaceRoot` (default: current directory). |
+| `--lane <name>` | Fleet lane from delegate-setup config; dials apply, explicit flags win. |
+| `--model <name>` | Request a model via a generated `agent-default-model` overlay. A stored `$DSH_HOME/settings.yaml` selection outranks it (measured) — compare `modelOverlay` with `actualModel`. |
+| `--provider <name>` | Provider for that overlay (default: `deepseek-official`). Requires `--model`. |
+| `--permission-mode <m>` | `DSH_PERMISSION_MODE` for the child: `read-only` \| `workspace-write` \| `danger-full-access`. |
+| `--read-only` | Sugar for `--permission-mode read-only`; also arms the Git tripwire. |
+| `--patch <file>` | Extra composition overlay, repeatable, passed straight to `dsh --patch`. |
+| `--timeout <dur>` | Relay-side watchdog (`30m`, `2h`; default off — `dsh` has no timeout flag of its own). |
+| `--out-dir <dir>` | Run artifacts directory (default: fresh dir under the system temp dir). |
+
+Permission-mode precedence, in order: `--permission-mode` / `--read-only` → a lane's
+`permissionMode` dial → a `DSH_PERMISSION_MODE` already exported in your environment (honored and
+reported as `permissionModeSource: "environment"`, never silently stripped) → unset, letting the
+harness's composed default (`workspace-write`) apply.
+
+## The pointer-file mechanic
+
+`dsh --profile headless` takes the task only as a positional argv value and reads no stdin
+(measured), so the relay writes the brief verbatim to `<out-dir>/brief.md` and passes:
+
+```
+Read the task brief at <out-dir>/brief.md and execute it fully.
+```
+
+The `workspace-write` sandbox confines mutations to the workspace and the platform temp roots and
+does not confine reads, which is what makes the pointer readable. On win32 the npm `dsh` is a
+`.cmd` shim that needs `shell:true`, so the relay quotes spaceable values and rejects paths carrying
+cmd metacharacters (`% ! & | ^ < > "`) with exit 2 — quoting alone is not a boundary in cmd.
+
+## result.json
+
+Alongside the shared `delegate-relay.result.v1` fields (`status`, `exitCode`, `signal`,
+`finalMessage`, `touchedFiles`, `stderrTail`, paths), the dsh relay reports:
+
+- `permissionMode` + `permissionModeSource` (`flag` / `lane` / `environment` / null) and `readOnly`.
+- `modelOverlay` — the requested `{provider, model}`, or null. A request, not a guarantee.
+- `readOnlyViolation` — the tripwire verdict on `--read-only` runs: `true` (the tree changed),
+  `false` (measured clean), or `null` (coverage incomplete — not a clean bill of health).
+- **Session-record harvest** (see below): `sessionId`, `sessionRecordPath`, `actualProvider`,
+  `actualModel`, `reasoningEffort`, `usage` (`inputTokens` / `outputTokens` /
+  `assistantMessages`), `turnEndReason`, `recordedPermissionMode`, `recordedSandboxMode`,
+  `recordedApprovalPolicy`, and `sessionHarvest` — `"ok"`, or the reason every harvested field is
+  null (`"unsupported-node (zlib zstd needs Node 22.15+)"`, `"no-dsh-home"`, `"not-found"`, an
+  `"error: …"` string, or `"skipped (dsh was not dispatched)"`).
+
+`finalMessage` is `dsh`'s own final stdout text — the headless app prints exactly the final
+assistant message (measured). The raw stream is kept at `outputPath`, the trimmed report at
+`finalPath`.
+
+## The session-record harvest
+
+The headless surface prints no session id, but `dsh`'s session-persistence-jsonl plugin appends
+every run to `$DSH_HOME/sessions/<escaped-workspace>/session-<uuid>/session.jsonl.zstd`. After the
+run the relay locates this run's record — matched by the record's own `cwd` header and creation
+time, never by predicting the directory-name escape — and reports from it:
+
+- **What actually served the run.** The record's request header carries the effective provider,
+  model, and reasoning effort. This is how a `--model` request that a stored settings selection
+  outranked becomes visible instead of silently ignored: `modelOverlay` says what you asked for,
+  `actualModel` says what ran (measured: an overlay naming a nonexistent model completed on the
+  stored selection, and the harvest reported the stored model).
+- **What it cost.** Token usage summed across assistant messages — the early warning for briefs
+  outgrowing a small-context local model.
+- **The recorded posture.** The harness's own `permission/preset`, `sandbox/mode`, and
+  `approval/policy` events — the run's autonomy as recorded, not as assumed.
+- **An audit handle.** `sessionId` names the on-disk record for later inspection. It is not a
+  resume handle: the headless surface has no resume.
+
+The record is a series of independent zstd frames (one per append); zlib gained zstd in Node
+22.15 / 23.8, so on an older Node the dispatch still works and `sessionHarvest` says
+`unsupported-node`. The harvest reads a file `dsh` itself just wrote, locally; nothing is sent
+anywhere, and it can never fail the run.
+
+## Wiring a local OpenAI-compatible endpoint
+
+`dsh` serves local models through its `llm-pi-ai` providers config — vLLM, llama.cpp, Ollama, or
+any OpenAI-compatible server. Two routes:
+
+**Persistent (recommended): `$DSH_HOME/settings.yaml`.** Define the provider and select it once;
+every dispatch uses it. Note that this stored selection outranks the relay's `--model` overlay —
+which is the desired behavior for a pinned local deployment.
+
+**Per-run: a `--patch` overlay.** On a home with no stored selection, one overlay can wire the
+endpoint end-to-end (measured against a local vLLM server: a fresh `$DSH_HOME` plus exactly this
+shape of overlay completed a run on the local model, confirmed by the harvest's `actualProvider`):
+
+```yaml
+- id: llm-pi-ai
+  config:
+    providers:
+      local-vllm:
+        api: openai-completions
+        baseURL: http://127.0.0.1:8000/v1
+        apiKeyEnv: LOCAL_API_KEY        # name of the env var holding the key; the file holds no secret
+        defaultContextWindow: 65536
+        defaultMaxTokens: 32768
+        models:
+          - id: my-local-model          # must match the id the server reports under /v1/models
+            contextWindow: 65536
+            maxTokens: 32768
+- id: agent-default-model
+  config:
+    provider: local-vllm
+    model: my-local-model
+```
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo --patch local-endpoint.yml
+```
+
+A `--patch` overlay replaces each targeted row's **whole** `config` (no deep-merge), so the file
+carries the complete provider definition. Reasoning-effort mapping and other compat switches are
+provider config too — set them where the provider is defined; the harvest's `reasoningEffort`
+reports the effective value when one is set.
+
+Two local-deployment realities to plan for:
+
+- **Wake latency.** A local inference server that sleeps or offloads VRAM when idle adds its wake
+  time to the first request. Budget `--timeout` for the task, not the first token, and treat a slow
+  start as normal.
+- **Throughput.** A local model is often slower per token than a hosted one. Implementation briefs
+  that need an hour on a hosted CLI need more here; start with `--timeout` off (the default) or
+  generous, and calibrate from `usage` and wall-clock on your own hardware.
+
+## Waiting, and the SIGTERM trap
+
+The relay blocks until `dsh` finishes. Back it with your orchestrator's background facility
+(Claude Code: `run_in_background: true`), or background it in the shell and poll for
+`result.json`. Completion means the process exited and `result.json` exists with a `status`.
+
+`dsh` catches SIGTERM, drains gracefully, and **exits 0** (measured on a live mid-run kill). The
+relay therefore classifies `timeout` (its watchdog fired) and `aborted` (the relay itself was
+killed and forwarded the kill) from its own state, never from the child's exit code — and any
+supervisor of yours that reads the child's exit code directly would misread a kill as success.
+Status semantics:
+
+| status | Meaning | Relay exit |
+| --- | --- | --- |
+| `completed` | `dsh` exited 0 on its own | 0 |
+| `failed` | `dsh` exited non-zero (e.g. the measured `MISSING_CREDENTIAL` diagnostic), or died on an external signal | dsh's exit / 128+signal |
+| `timeout` | The `--timeout` watchdog killed the run | mirrors the mapped exit |
+| `aborted` | The relay was killed and took `dsh` with it (whole process group) | 128+signal |
+| `dsh_unavailable` | No `dsh` on PATH | 127, result file written |
+
+A pre-run usage error exits 2 and writes **no** result file — a poller must treat "non-zero exit,
+no file" as a usage error, not a lost run.
+
+## Recovery when a run misbehaves
+
+- **`failed` with `MISSING_CREDENTIAL`** — the provider route has no key: export the credential the
+  diagnostic names (or the `apiKeyEnv` your provider config names) and re-dispatch.
+- **`failed` at boot with a config validation error** — an invalid `DSH_PERMISSION_MODE` or a
+  malformed `--patch` overlay fails the plugin tree load with the offending row named; fix the
+  overlay and re-dispatch.
+- **`timeout` / `aborted`** — inspect the working tree before anything else: the run may have
+  partial edits. Keep or revert them deliberately (see
+  [review-and-land.md](review-and-land.md)), then re-dispatch a fresh, self-contained brief.
+- **`completed` but the report says it could not act** — a `read-only` run whose brief ordered a
+  write completes with the refusal in the final message and exit 0 (measured). Read
+  `finalMessage` and `readOnlyViolation`, not just `status`.

--- a/skills/dsh-delegate/references/multi-task-queues.md
+++ b/skills/dsh-delegate/references/multi-task-queues.md
@@ -1,0 +1,66 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy — and with no session resume on this
+surface, the bookkeeping carries everything between tasks.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is
+the default because it preserves clean task boundaries.
+
+## Carry decided constraints forward — there is no other channel
+
+Every dispatch is a fresh session that remembers nothing, and there is no resume to lean on. If
+task 2 chooses a helper name, fixture location, or interface that task 5 needs, write that fact
+into task 5's brief. The same applies to rework: a rework brief is a fresh, self-contained
+document, not a delta (see [review-and-land.md](review-and-land.md)).
+
+On a small-context local deployment this cuts both ways: carry forward the *decisions*, not the
+transcripts. A queue whose briefs each restate everything ever decided will outgrow the context —
+`usage.inputTokens` in each `result.json` is the trend to watch; prune constraints that later
+tasks no longer need.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** — queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** — what landed, what you verified, and gate outcomes; include each
+  run's `sessionId` and `actualModel` from `result.json` so the audit trail names which record and
+  model produced each commit.
+- **Decided constraints** — the running list later briefs must restate.
+- **Needs your eyes** — design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** — the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/dsh-delegate/references/review-and-land.md
+++ b/skills/dsh-delegate/references/review-and-land.md
@@ -1,0 +1,102 @@
+# Review and land
+
+The implementer made the changes; you own the judgment. Verify against reality, never the
+self-report, and read the diff as generated code because a green gate cannot catch every failure
+mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries `dsh`'s claims, not evidence. Re-run the project's actual test, lint, and
+build commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** — changes the brief excluded.
+- **Scope shortfall** — missed behavior, edges, or cleanup.
+- **Quiet judgment calls** — defensible but unasked decisions that need review.
+
+Cross-check the run's metadata while you are here: `actualModel` confirms which model actually
+served the run (a `--model` request may have been outranked by a stored settings selection), and
+on a `--read-only` run, `readOnlyViolation` plus `recordedPermissionMode` confirm the posture the
+harness recorded — `false` is a measured verdict, `null` means coverage was incomplete and the
+tree deserves a direct look.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back as a fresh rework brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer.
+Write a clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`,
+`git diff --cached` for anything the implementer staged (plain `git diff` is blind to the index),
+and open any untracked files (`??` in `git status`) directly — they are the implementer's new
+files, and no diff shows their contents. The tree is evidence, not clutter. After that inspection
+the verdict can legitimately be to discard — work built on a premise you have since corrected,
+for example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Rework: a fresh, self-contained brief
+
+There is no headless resume — `--resume` is rejected by the app, and the `sessionId` in
+`result.json` is an audit handle for the on-disk record, not something a new run can continue. So
+rework is a **new brief that stands alone**: fold the original brief's constraints, the state the
+first run left behind, and the corrections into one document.
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief rework-01.txt --cd /path/to/repo
+```
+
+State in the rework brief what the tree already contains ("refund.py now checks the idempotency
+key; keep that") so the fresh session extends the work instead of redoing or reverting it. Rework
+gets the same gate rerun, test review, diff review, and implementer sweep.
+
+Keep rework briefs as narrow as the original, and keep the default `workspace-write` posture in
+mind: mutations are confined to the workspace and temp roots, reads are not, and the approval seam
+fails closed headlessly. Use `--read-only` for diagnosis-only follow-ups.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep
+them in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/dsh-delegate/references/writing-the-brief.md
+++ b/skills/dsh-delegate/references/writing-the-brief.md
@@ -1,0 +1,144 @@
+# Writing the brief
+
+A brief is the entire task as `dsh` will see it. It runs in a separate session with **no memory of
+your conversation, no access to prior notes, and no shared context** — only the text you send and
+whatever it can inspect in the workspace. If a constraint is not in the brief or discoverable in the
+repo, it does not exist for `dsh`.
+
+One shortcut: `dsh` auto-loads applicable `AGENTS.md` / `CLAUDE.md` context files from the workspace
+(measured: a rule stated only in the repo's `AGENTS.md` was followed by a headless run), so
+conventions written there reach `dsh` without inlining. Restate the load-bearing rules in the brief
+anyway — the brief is the contract.
+
+## How the brief travels
+
+`dsh --profile headless` takes the task **only as a positional argv value** — it reads no stdin
+(measured: a piped task with no positional exits 1, "a task is required") — and multiple positional
+words are space-joined, so a multi-line brief cannot ride argv. The relay therefore writes your
+brief verbatim to `<out-dir>/brief.md` and passes this fixed one-line pointer as the task
+(keep it in lockstep with `relay.mjs`):
+
+```
+Read the task brief at <out-dir>/brief.md and execute it fully.
+```
+
+The `workspace-write` sandbox confines mutations, not reads, and leaves the platform temp roots
+writable, so the implementer can read the pointer file. Consequences for you: the brief lands on
+disk under the run directory — keep secrets out of it and reference environment variables or
+workspace files instead — and there is no argv size cap to worry about.
+
+## Rework is a fresh brief, not a delta
+
+The headless surface has no resume (`--resume` is rejected; measured). Every dispatch starts a
+fresh session that remembers nothing. So a rework brief must be **fully self-contained**: fold the
+original brief's constraints plus the corrections into one document. Never send only "fix the test
+you just wrote" — there is no "you just" for a fresh session.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report `dsh` must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** — add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences, and
+  open questions), and dispatch with `--read-only` so the sandbox refuses writes.
+
+## Always ask for the report explicitly
+
+The relay's `finalMessage` is `dsh`'s final stdout text — the harness prints exactly the final
+assistant message. Without a closing summary, the edits may exist but the result is hard to review.
+The `<structured_output_contract>` block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy
+the actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Size the brief for the model that will serve it
+
+`dsh` deployments often serve a locally hosted model with a context window far smaller than hosted
+frontier models — `result.json`'s `actualModel` and `usage` show what served the run and what it
+cost. For a small-context deployment: keep briefs lean, point at workspace files instead of inlining
+them, keep the leave-untouched list tight, and split wide tasks into more, smaller queue items. The
+`usage.inputTokens` trend across a queue is the early warning that briefs are outgrowing the
+context.
+
+## One task per brief
+
+Keep each brief bounded. One brief → one `dsh` run → one reviewed commit keeps the diff and rollback
+clean. Split mixed implementation, review, documentation, and roadmap requests into separate
+dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/dsh-delegate/scripts/relay.mjs
+++ b/skills/dsh-delegate/scripts/relay.mjs
@@ -142,9 +142,13 @@ const STDERR_TRUNCATION_MARKER = "[truncated] ";
 // run, and decompressed bytes retained per record.
 const HARVEST_MAX_CANDIDATES = 512;
 const HARVEST_MAX_BYTES = 512 * 1024 * 1024;
-// Session directories created this many ms before the relay's own start
-// timestamp still count, absorbing coarse filesystem timestamps.
-const HARVEST_CLOCK_SLACK_MS = 2_000;
+// Filesystem-timestamp pruning slack: workspace and record mtimes older than
+// the relay's start minus this margin are skipped without decompression. This
+// slack applies ONLY to that mtime pruning (filesystem timestamps can be
+// coarse); the attribution itself compares the record's own createdAt — a
+// Date.now() from the same clock — strictly against the relay's start, so a
+// record born before this run can never be attributed to it.
+const HARVEST_MTIME_SLACK_MS = 2_000;
 
 const IMPLEMENTER_KEY = "dsh";
 
@@ -764,7 +768,7 @@ function harvestSessionRecord(cd, startedAtMs) {
     if (!root) return { ...empty, sessionHarvest: "no-dsh-home" };
     let cdReal;
     try { cdReal = realpathSync.native(cd); } catch { cdReal = resolve(cd); }
-    const cutoff = startedAtMs - HARVEST_CLOCK_SLACK_MS;
+    const cutoff = startedAtMs - HARVEST_MTIME_SLACK_MS;
     let best = null;
     let inspected = 0;
     for (const workspace of readdirSync(root)) {
@@ -784,7 +788,13 @@ function harvestSessionRecord(cd, startedAtMs) {
         let header;
         try { header = readSessionRecords(record, true)[0]; } catch { continue; }
         if (!header || header.type !== "session" || typeof header.id !== "string") continue;
-        if (typeof header.createdAt !== "number" || header.createdAt < cutoff) continue;
+        // Strict: createdAt is the child's own Date.now(), same clock as ours,
+        // so no slack — a record created before this run (a stale session on a
+        // reused $DSH_HOME) must never be attributed to this dispatch. A
+        // concurrent same-cwd session started during the run remains
+        // inherently ambiguous; the latest createdAt wins and the record path
+        // is reported so the reviewer can audit which record was read.
+        if (typeof header.createdAt !== "number" || header.createdAt < startedAtMs) continue;
         if (header.cwd !== cd && header.cwd !== cdReal) continue;
         if (!best || header.createdAt > best.createdAt) best = { record, id: header.id, createdAt: header.createdAt };
       }

--- a/skills/dsh-delegate/scripts/relay.mjs
+++ b/skills/dsh-delegate/scripts/relay.mjs
@@ -1,0 +1,1218 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · dsh-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the DeepSeek Harness CLI (`dsh --profile
+ * headless`), capture the run, and write a structured result the orchestrating
+ * agent can review. The orchestrator runs this one command and reads the result
+ * JSON — every dsh-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified on Claude Code; other shell-capable agents
+ * (OpenCode, Cursor, …) are designed-for but not yet verified.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `dsh` and `git`. After the run it reads back the
+ * session record dsh itself just wrote under `$DSH_HOME/sessions` — a local
+ * file, read locally, reported locally — to recover the session id, the
+ * provider/model that actually served the run, token usage, and the recorded
+ * permission preset. The `dsh` process it launches does authenticate — exactly
+ * as you do at the terminal. Read this file before you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's
+ * job — after it reviews the diff and re-runs the project gates.
+ *
+ * Brief delivery: `dsh --profile headless` takes the task ONLY as a positional
+ * argv value — no stdin (measured: a piped task with no positional exits 1,
+ * "a task is required"), no message-file flag. A multi-line brief cannot ride
+ * argv (`[task...]` is space-joined, and cmd.exe would mangle it besides), so
+ * the brief is written verbatim to <out-dir>/brief.md and the positional
+ * carries a short single-line pointer naming that absolute path. The
+ * workspace-write sandbox confines mutations, not reads, and leaves the
+ * platform temp roots writable, so the implementer can read the pointer file.
+ *
+ * Sessions: the headless surface prints no session id and offers no resume
+ * flag (`--resume` is rejected as an unknown option), so this relay ships no
+ * --resume-last and no --session — rework is a fresh, self-contained brief.
+ * But dsh's session-persistence-jsonl plugin persists every run to
+ * `$DSH_HOME/sessions/<workspace>/session-<uuid>/session.jsonl.zstd`, and the
+ * relay harvests that record after the run: sessionId, the request header's
+ * provider/model/reasoning effort (the configuration that actually served the
+ * run — not merely what was requested), summed token usage, the turn-end
+ * reason, and the recorded permission preset. Each field is null when the
+ * record cannot be read; `sessionHarvest` says why. The record is a series of
+ * independent zstd frames (one per append); zlib gained zstd in Node 22.15 /
+ * 23.8, so on an older runtime the harvest reports "unsupported-node".
+ *
+ * Autonomy, in dsh's own terms: DSH_PERMISSION_MODE (read-only /
+ * workspace-write / danger-full-access) in the child's environment, mapped to
+ * the sandbox-policy row's mode with workspaceRoot bound to process.cwd(). The
+ * approval seam fails closed when no answerer is composed — the headless case —
+ * so an escalation beyond the sandbox is rejected rather than left hanging on
+ * a prompt nobody can answer. A DSH_PERMISSION_MODE already exported in the
+ * relay's own environment is honored and reported (source "environment"), never
+ * silently stripped; --permission-mode and lane dials override it.
+ *
+ * Model selection has no flag on this surface. The deployment default lives in
+ * the composition row agent-default-model (provider + model); a per-run request
+ * is a generated --patch overlay replacing that row's whole config. A stored
+ * selection in $DSH_HOME/settings.yaml outranks the overlay (measured), so the
+ * overlay is a request, not a guarantee — and that is why the harvest reports
+ * actualProvider/actualModel from the session record instead of assuming.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for dsh; becomes the child cwd and the
+ *                           harness's workspace root (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Model for the generated agent-default-model patch overlay.
+ *                           A stored selection in $DSH_HOME/settings.yaml outranks it;
+ *                           compare result.json's modelOverlay (requested) with
+ *                           actualModel (served, from the session record).
+ *   --provider <name>       Provider for that overlay (default: deepseek-official, the
+ *                           harness's own default provider id). Requires --model.
+ *   --permission-mode <m>   DSH_PERMISSION_MODE for the child: read-only |
+ *                           workspace-write | danger-full-access. Default: an already
+ *                           exported DSH_PERMISSION_MODE is honored; otherwise the
+ *                           variable stays unset and the harness's composed default
+ *                           (workspace-write) applies.
+ *   --read-only             Sugar for --permission-mode read-only, and arms the tripwire.
+ *   --patch <file>          Extra --patch overlay, repeatable, passed straight through.
+ *                           An overlay can define a whole provider — including a local
+ *                           OpenAI-compatible endpoint — see dispatch-and-poll.md.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the dsh child is killed
+ *                           and result.json gets status "timeout". dsh has no timeout
+ *                           flag of its own, so the watchdog is relay-only.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, dshVersion, permissionMode (+ its source),
+ *   modelOverlay (the requested {provider, model} or null), sessionId,
+ *   actualProvider / actualModel / reasoningEffort (from the session record's
+ *   request header), usage (summed input/output tokens), turnEndReason,
+ *   recordedPermissionMode / recordedSandboxMode / recordedApprovalPolicy,
+ *   sessionHarvest (why any of those are null), finalMessage (dsh's own final
+ *   stdout text), touchedFiles (git porcelain, null if git can't report),
+ *   readOnlyViolation, and the paths to the brief, final.txt, and output.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief, a rejected
+ * --permission-mode) exits 2 before any run and writes no result file; a dsh
+ * CLI that cannot be found exits 127 and DOES write one; otherwise the exit
+ * code mirrors dsh's own (0 success, non-zero failure). dsh catches SIGTERM,
+ * drains gracefully, and exits 0 (measured), so timeout and aborted are
+ * classified from the relay's own state, never from the child's exit code. If
+ * the child dies on a signal, the exit code is 128 plus the signal number and
+ * result.json records the signal. Once the brief validates, result.json is
+ * written on every outcome — completed, failed, timeout, aborted, or
+ * dsh_unavailable. An orchestrator that polls for the file must therefore also
+ * treat a non-zero exit with no file as a usage error.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync, renameSync, readFileSync, readdirSync, existsSync, statSync, readlinkSync, lstatSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
+import {join, resolve, basename, dirname, sep, isAbsolute, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir, homedir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+import { createHash } from "node:crypto";
+// Namespace import, not a named one: a named zstdDecompressSync import would
+// crash at module load on a Node without it (zstd landed in zlib in 22.15 /
+// 23.8), and this relay must still run the dispatch there — only the
+// session-record harvest degrades.
+import * as zlib from "node:zlib";
+
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_BUFFERED_CHARS = 1_048_576;
+const MAX_TIMER_MS = 2_147_483_647;
+const SCHEMA = "delegate-relay.result.v1";
+const DEFAULT_PROVIDER = "deepseek-official";
+const PERMISSION_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
+// --model/--provider ride a generated overlay file, but their values also appear
+// in result.json and the overlay YAML, so keep them to safe token shapes.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+const STDERR_REMAINDER_LIMIT = 64 * 1024;
+const STDERR_TRUNCATION_MARKER = "[truncated] ";
+// Session-record harvest bounds: candidate session directories inspected per
+// run, and decompressed bytes retained per record.
+const HARVEST_MAX_CANDIDATES = 512;
+const HARVEST_MAX_BYTES = 512 * 1024 * 1024;
+// Session directories created this many ms before the relay's own start
+// timestamp still count, absorbing coarse filesystem timestamps.
+const HARVEST_CLOCK_SLACK_MS = 2_000;
+
+const IMPLEMENTER_KEY = "dsh";
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && (flagged.has("readOnly") || flagged.has("permissionMode"))) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+    if (field === "permissionMode") opts.permissionModeSource = "lane";
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+// Paths reach cmd.exe on win32, because a .cmd shim cannot be launched without a
+// shell and Node offers no shell-free path to one. Double quotes do NOT stop cmd
+// from expanding % or, under delayed expansion, !, and & | ^ < > still separate or
+// redirect. Quoting alone is therefore not a boundary: reject these outright rather
+// than pass a path cmd would rewrite. POSIX spawns argv directly and needs no check.
+const WIN32_SHELL_METACHARACTERS = /[%!&|^<>"]/;
+
+function assertShellSafePath(label, value) {
+  if (process.platform !== "win32") return;
+  const offending = WIN32_SHELL_METACHARACTERS.exec(value);
+  if (offending) {
+    fail(`${label} contains ${JSON.stringify(offending[0])}, which cmd.exe rewrites on win32: ${value}`);
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    provider: null,
+    permissionMode: null,
+    permissionModeSource: null,
+    readOnly: false,
+    patches: [],
+    timeout: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--provider": opts.provider = next(); flagged.add("provider"); break;
+      case "--permission-mode": opts.permissionMode = next(); opts.permissionModeSource = "flag"; flagged.add("permissionMode"); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--patch": { const patch = resolve(next()); assertShellSafePath("--patch", patch); opts.patches.push(patch); flagged.add("patch"); break; }
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); assertShellSafePath("--out-dir", opts.outDir); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  // An already exported DSH_PERMISSION_MODE is the user's own standing posture.
+  // Adopt it when no flag or lane chose one, so the run honors it AND
+  // result.json reports the mode that actually applied — stripping it silently
+  // would loosen a read-only environment to workspace-write.
+  const ambient = (process.env.DSH_PERMISSION_MODE || "").trim();
+  if (opts.permissionMode === null && ambient) {
+    opts.permissionMode = ambient;
+    opts.permissionModeSource = "environment";
+  }
+  if (opts.readOnly && opts.permissionMode !== null && opts.permissionMode !== "read-only" && opts.permissionModeSource !== "environment") {
+    fail(`--read-only conflicts with --permission-mode ${opts.permissionMode}; read-only runs use permission mode read-only`);
+  }
+  if (opts.readOnly) {
+    opts.permissionMode = "read-only";
+    opts.permissionModeSource = flagged.has("readOnly") ? "flag" : "lane";
+  }
+  if (opts.permissionMode !== null && !PERMISSION_MODES.has(opts.permissionMode)) {
+    fail(`invalid ${opts.permissionModeSource === "environment" ? "DSH_PERMISSION_MODE" : "--permission-mode"} "${opts.permissionMode}" (expected: ${[...PERMISSION_MODES].join(", ")})`);
+  }
+  opts.readOnly = opts.permissionMode === "read-only";
+  if (opts.model !== null && !SAFE_TOKEN.test(opts.model)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, . _ : / -)");
+  }
+  if (opts.provider !== null && !SAFE_TOKEN.test(opts.provider)) {
+    fail("--provider contains unsupported characters (allowed: letters, digits, . _ : / -)");
+  }
+  if (opts.provider !== null && opts.model === null) {
+    fail("--provider requires --model; pass both or neither for the agent-default-model overlay");
+  }
+  // The watchdog is relay-only (dsh has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  for (const patch of opts.patches) {
+    if (!existsSync(patch)) fail(`--patch file not found: ${patch}`);
+  }
+  if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to dsh --profile headless\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once dsh is running, so the preflight needs a bound of
+  // its own: a `dsh --version` that never returns would wedge the relay here, before
+  // any result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function dshVersion(probeTimeoutMs) {
+  try {
+    // On Windows, npm installs `dsh` as a .cmd shim; Node's CreateProcess only
+    // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
+    // ENOENTs on a working install. POSIX is unaffected.
+    const version = execFileSync("dsh", ["--version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+      env: process.env,
+    }).trim();
+    return { version: version || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+    // exit rather than ENOENT; that is still "not installed", not a broken install.
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    // Anything else — a hung probe we killed, or a real non-zero exit — means dsh is
+    // installed but not usable. Reporting that as "unavailable" would send the caller
+    // off to reinstall a CLI that is already there.
+    return { version: null, error };
+  }
+}
+
+const FINGERPRINT_UNREADABLE = "<unreadable>";
+const FINGERPRINT_DIRECTORY = "<directory>";
+
+function gitRepoRoot(cwd) {
+  // Porcelain paths are relative to the repository ROOT, not to the directory git ran in
+  // (--porcelain forces status.relativePaths off). Joining them against a --cd that is a
+  // subdirectory would look for <repo>/src/src/file and find nothing at either end.
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).replace(/\n$/, "") || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitStatusEntries(cwd) {
+  // -z so a path containing a space, a quote, or a newline stays one field rather than being
+  // quoted and escaped; -uall so an untracked directory is expanded into its files, because a
+  // collapsed "?? dir/" line never changes when a file inside it does.
+  try {
+    const output = execFileSync("git", ["status", "--porcelain", "-z", "-uall"], {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const fields = new TextDecoder("utf-8", { fatal: true }).decode(output)
+      .split("\0").filter((field) => field.length > 0);
+    const entries = [];
+    for (let i = 0; i < fields.length; i += 1) {
+      const entry = fields[i];
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      // R and C can sit in EITHER status column, and under -z such an entry is followed by its
+      // origin path as its own unprefixed field. Consume that field in both cases. A rename
+      // origin belongs in the dirty set (the file moved away from it); a copy origin does not,
+      // since a copy source can be a perfectly clean file.
+      const renamed = status.includes("R");
+      const copied = status.includes("C");
+      let origin = null;
+      if (renamed || copied) {
+        i += 1;
+        origin = fields[i] ?? null;
+      }
+      entries.push({ status, path, origin });
+    }
+    return entries;
+  } catch {
+    return null;
+  }
+}
+
+function dirtyPaths(cwd) {
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const paths = [];
+  for (const entry of entries) {
+    paths.push(entry.path);
+    if (entry.status.includes("R") && entry.origin !== null) paths.push(entry.origin);
+  }
+  return paths;
+}
+
+function asciiFold(value) {
+  return value.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+}
+
+function canonicalFilePath(path) {
+  const absolute = resolve(path);
+  let parent;
+  try { parent = realpathSync.native(dirname(absolute)); } catch { return absolute; }
+  const leaf = basename(absolute);
+  const canonical = join(parent, leaf);
+  try { lstatSync(canonical); } catch { return canonical; }
+  try {
+    const entries = readdirSync(parent);
+    if (entries.includes(leaf)) return canonical;
+    const matches = entries.filter((entry) => asciiFold(entry) === asciiFold(leaf));
+    return join(parent, matches.length === 1 ? matches[0] : leaf);
+  } catch {
+    return canonical;
+  }
+}
+
+function gitPathKey(root, path) {
+  let canonicalRoot;
+  try { canonicalRoot = realpathSync.native(root); } catch { canonicalRoot = resolve(root); }
+  const key = relative(canonicalRoot, canonicalFilePath(path));
+  return process.platform === "win32" ? key.replaceAll("\\", "/") : key;
+}
+
+function gitPathIsExcluded(root, path, excluded, foldedExcluded) {
+  return excluded.has(path) ||
+    (foldedExcluded.has(asciiFold(path)) && excluded.has(gitPathKey(root, join(root, path))));
+}
+
+function gitTripwireState(cwd, excludedPaths) {
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return entries.flatMap((entry) => [
+    [entry.status, "path", entry.path],
+    ...(entry.origin === null ? [] : [[entry.status.replace(/[^RC]/g, " "), "origin", entry.origin]]),
+  ]
+    .filter(([, , path]) => !gitPathIsExcluded(root, path, excluded, foldedExcluded)));
+}
+
+function pathFingerprint(absolutePath) {
+  // Identity, not just bytes: a retargeted symlink, a flipped mode bit, or a file replaced by a
+  // directory are all writes, and none of them change file contents.
+  let stats;
+  try {
+    stats = lstatSync(absolutePath);
+  } catch (error) {
+    // Absence is a state, not a failure - it differs from every real fingerprint, so a deletion
+    // or a re-creation still registers. Any other errno means we genuinely cannot tell.
+    return error && error.code === "ENOENT" ? "absent" : FINGERPRINT_UNREADABLE;
+  }
+  if (stats.isSymbolicLink()) {
+    try {
+      return `symlink:${readlinkSync(absolutePath, { encoding: "buffer" }).toString("hex")}`;
+    } catch {
+      return FINGERPRINT_UNREADABLE;
+    }
+  }
+  // A directory in the dirty set is a submodule, whose contents belong to another repository.
+  // Reported as unknown coverage rather than silently passed off as unchanged.
+  if (stats.isDirectory()) return FINGERPRINT_DIRECTORY;
+  if (!stats.isFile()) return FINGERPRINT_UNREADABLE;
+  let fd;
+  try {
+    // Streamed rather than read whole: an unignored multi-gigabyte artifact must not be pulled
+    // into memory just to answer whether it changed.
+    const hash = createHash("sha256");
+    fd = openSync(absolutePath, "r");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      const read = readSync(fd, buffer, 0, buffer.length, null);
+      if (read <= 0) break;
+      hash.update(buffer.subarray(0, read));
+    }
+    return `file:${(stats.mode & 0o7777).toString(8)}:${hash.digest("hex")}`;
+  } catch {
+    return FINGERPRINT_UNREADABLE;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+  }
+}
+
+function gitIndexFingerprints(root, paths) {
+  if (paths.length === 0) return new Map();
+  try {
+    const output = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const wanted = new Set(paths);
+    const prints = new Map(paths.map((path) => [path, []]));
+    for (const field of new TextDecoder("utf-8", { fatal: true }).decode(output).split("\0")) {
+      if (!field) continue;
+      const separator = field.indexOf("\t");
+      if (separator === -1) return null;
+      const path = field.slice(separator + 1);
+      if (wanted.has(path)) prints.get(path).push(field.slice(0, separator));
+    }
+    return prints;
+  } catch {
+    return null;
+  }
+}
+
+function fingerprintPaths(root, paths) {
+  // `complete` goes false the moment one path cannot be fingerprinted, so the caller reports
+  // "unknown" instead of an unearned clean bill of health.
+  const indexPrints = gitIndexFingerprints(root, paths);
+  const prints = new Map();
+  let complete = indexPrints !== null;
+  for (const path of paths) {
+    const file = pathFingerprint(join(root, path));
+    if (file === FINGERPRINT_UNREADABLE || file === FINGERPRINT_DIRECTORY) complete = false;
+    prints.set(path, { file, index: indexPrints?.get(path) ?? null });
+  }
+  return { prints, complete };
+}
+
+function fingerprintDirtyPaths(cwd, excludedPaths) {
+  // Only the already-dirty set is covered. A path that is clean at dispatch and gets written
+  // surfaces as a brand-new porcelain line anyway, and fingerprinting a whole repository per run
+  // would cost far more than the case it covers.
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const paths = dirtyPaths(cwd);
+  if (paths === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return {
+    root,
+    ...fingerprintPaths(root, paths.filter((path) => !gitPathIsExcluded(root, path, excluded, foldedExcluded))),
+  };
+}
+
+function changedDirtyPaths(before) {
+  // Re-fingerprint exactly the baseline paths, not whatever happens to be dirty now: a path the
+  // run newly dirtied is already reported by the porcelain comparison, and letting an unreadable
+  // one of those blind this signal would be a regression, not caution.
+  if (!before) return { changed: [], complete: false };
+  const now = fingerprintPaths(before.root, [...before.prints.keys()]);
+  const changed = [];
+  for (const [path, print] of before.prints) {
+    const current = now.prints.get(path);
+    const fileKnown = print.file !== FINGERPRINT_UNREADABLE && current.file !== FINGERPRINT_UNREADABLE;
+    const fileChanged = fileKnown &&
+      !(print.file === FINGERPRINT_DIRECTORY && current.file === FINGERPRINT_DIRECTORY) &&
+      current.file !== print.file;
+    const indexChanged = print.index !== null && current.index !== null &&
+      JSON.stringify(current.index) !== JSON.stringify(print.index);
+    if (fileChanged || indexChanged) changed.push(path);
+  }
+  return { changed: changed.sort(), complete: before.complete && now.complete };
+}
+
+function readOnlyVerdict(beforeTree, afterTree, beforeFingerprints) {
+  // Three-valued on purpose. Proof of a write settles it even when the other signal is unknown;
+  // only when nothing is proven AND coverage is incomplete is the answer genuinely unknown.
+  // Collapsing that last case to false is the false assurance a tripwire must never give.
+  const changed = changedDirtyPaths(beforeFingerprints);
+  const porcelainMoved =
+    beforeTree !== null && afterTree !== null && JSON.stringify(beforeTree) !== JSON.stringify(afterTree);
+  if (porcelainMoved || changed.changed.length > 0) return true;
+  if (beforeTree === null || afterTree === null || !changed.complete) return null;
+  return false;
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+// ---------------------------------------------------------------------------
+// Session-record harvest
+//
+// dsh's session-persistence-jsonl plugin appends every run to
+// $DSH_HOME/sessions/<escaped-workspace>/session-<uuid>/session.jsonl.zstd.
+// The headless surface prints no session id, but the record on disk carries
+// it — with the request header naming the provider, model, and reasoning
+// effort that actually served the run, per-message token usage, the turn-end
+// reason, and the recorded permission preset. The workspace escaping is not
+// reversible (a directory name may itself begin with a dash), so candidates
+// are matched by the header record's own `cwd` field and creation time, never
+// by predicting the escape. Each append is an independent zstd frame; zlib's
+// one-shot API stops after the first frame, so frames are walked by parsing
+// each frame's block headers to find its end. zlib gained zstd in Node 22.15 /
+// 23.8 — on an older runtime the harvest reports "unsupported-node" and only
+// then; nothing here can fail the run itself.
+// ---------------------------------------------------------------------------
+
+function zstdFrameEnd(buf, off) {
+  if (off + 8 > buf.length) return -1;
+  const magic = buf.readUInt32LE(off);
+  // Skippable frame: magic 0x184D2A50–0x184D2A5F, then a 4-byte little-endian size.
+  if (magic >= 0x184D2A50 && magic <= 0x184D2A5F) {
+    const end = off + 8 + buf.readUInt32LE(off + 4);
+    return end > buf.length ? -1 : end;
+  }
+  if (magic !== 0xFD2FB528) return -1;
+  let p = off + 4;
+  const descriptor = buf[p]; p += 1;
+  const contentSizeFlag = descriptor >> 6;
+  const singleSegment = (descriptor >> 5) & 1;
+  const checksumFlag = (descriptor >> 2) & 1;
+  const dictionaryIdFlag = descriptor & 3;
+  if (!singleSegment) p += 1; // window descriptor
+  p += [0, 1, 2, 4][dictionaryIdFlag];
+  p += contentSizeFlag === 0 ? (singleSegment ? 1 : 0) : [1, 2, 4, 8][contentSizeFlag];
+  for (;;) {
+    if (p + 3 > buf.length) return -1;
+    const blockHeader = buf.readUIntLE(p, 3); p += 3;
+    const blockType = (blockHeader >> 1) & 3;
+    p += blockType === 1 ? 1 : blockHeader >> 3; // an RLE block stores one byte
+    if (blockHeader & 1) break; // last block
+  }
+  if (checksumFlag) p += 4;
+  return p > buf.length ? -1 : p;
+}
+
+function readSessionRecords(file, firstFrameOnly) {
+  const buf = readFileSync(file);
+  const parts = [];
+  let off = 0;
+  let bytes = 0;
+  while (off < buf.length) {
+    const end = zstdFrameEnd(buf, off);
+    if (end < 0 || end <= off) break;
+    const part = zlib.zstdDecompressSync(buf.subarray(off, end));
+    bytes += part.length;
+    if (bytes > HARVEST_MAX_BYTES) break;
+    parts.push(part);
+    off = end;
+    if (firstFrameOnly) break;
+  }
+  const lines = [];
+  for (const line of Buffer.concat(parts).toString("utf8").split("\n")) {
+    if (!line.trim()) continue;
+    try { lines.push(JSON.parse(line)); } catch { /* a frame cut mid-line stays unparsed */ }
+  }
+  return lines;
+}
+
+function dshSessionsRoot() {
+  const fromEnv = (process.env.DSH_HOME || "").trim();
+  if (fromEnv) {
+    const root = join(fromEnv, "sessions");
+    return existsSync(root) ? root : null;
+  }
+  const fallback = join(homedir(), ".dsh", "sessions");
+  return existsSync(fallback) ? fallback : null;
+}
+
+function harvestSessionRecord(cd, startedAtMs) {
+  const empty = {
+    sessionId: null,
+    sessionRecordPath: null,
+    actualProvider: null,
+    actualModel: null,
+    reasoningEffort: null,
+    usage: null,
+    turnEndReason: null,
+    recordedPermissionMode: null,
+    recordedSandboxMode: null,
+    recordedApprovalPolicy: null,
+  };
+  if (typeof zlib.zstdDecompressSync !== "function") {
+    return { ...empty, sessionHarvest: "unsupported-node (zlib zstd needs Node 22.15+)" };
+  }
+  try {
+    const root = dshSessionsRoot();
+    if (!root) return { ...empty, sessionHarvest: "no-dsh-home" };
+    let cdReal;
+    try { cdReal = realpathSync.native(cd); } catch { cdReal = resolve(cd); }
+    const cutoff = startedAtMs - HARVEST_CLOCK_SLACK_MS;
+    let best = null;
+    let inspected = 0;
+    for (const workspace of readdirSync(root)) {
+      const workspaceDir = join(root, workspace);
+      let workspaceStat;
+      try { workspaceStat = statSync(workspaceDir); } catch { continue; }
+      // A new session directory bumps its workspace directory's mtime, so an
+      // untouched workspace cannot hold this run's record and is skipped whole.
+      if (!workspaceStat.isDirectory() || workspaceStat.mtimeMs < cutoff) continue;
+      for (const session of readdirSync(workspaceDir)) {
+        if (inspected >= HARVEST_MAX_CANDIDATES) break;
+        const record = join(workspaceDir, session, "session.jsonl.zstd");
+        let recordStat;
+        try { recordStat = statSync(record); } catch { continue; }
+        if (recordStat.mtimeMs < cutoff) continue;
+        inspected += 1;
+        let header;
+        try { header = readSessionRecords(record, true)[0]; } catch { continue; }
+        if (!header || header.type !== "session" || typeof header.id !== "string") continue;
+        if (typeof header.createdAt !== "number" || header.createdAt < cutoff) continue;
+        if (header.cwd !== cd && header.cwd !== cdReal) continue;
+        if (!best || header.createdAt > best.createdAt) best = { record, id: header.id, createdAt: header.createdAt };
+      }
+    }
+    if (!best) return { ...empty, sessionHarvest: "not-found" };
+    const lines = readSessionRecords(best.record, false);
+    const last = (type) => lines.filter((event) => event.type === type).pop();
+    const requestHeader = last("request/header")?.data?.header?.config ?? null;
+    const usage = { inputTokens: 0, outputTokens: 0, assistantMessages: 0 };
+    for (const event of lines) {
+      if (event.type !== "assistant/message" || !event.data?.usage) continue;
+      usage.inputTokens += event.data.usage.inputTokens || 0;
+      usage.outputTokens += event.data.usage.outputTokens || 0;
+      usage.assistantMessages += 1;
+    }
+    return {
+      sessionId: best.id,
+      sessionRecordPath: best.record,
+      actualProvider: typeof requestHeader?.provider === "string" ? requestHeader.provider : null,
+      actualModel: typeof requestHeader?.model === "string" ? requestHeader.model : null,
+      reasoningEffort: typeof requestHeader?.reasoningEffort === "string" ? requestHeader.reasoningEffort : null,
+      usage: usage.assistantMessages > 0 ? usage : null,
+      turnEndReason: last("turn/end")?.data?.reason?.kind ?? null,
+      recordedPermissionMode: last("permission/preset")?.data?.preset ?? null,
+      recordedSandboxMode: last("sandbox/mode")?.data?.mode ?? null,
+      recordedApprovalPolicy: last("approval/policy")?.data?.policy ?? null,
+      sessionHarvest: "ok",
+    };
+  } catch (error) {
+    return { ...empty, sessionHarvest: `error: ${String(error?.message || error)}` };
+  }
+}
+
+function buildArgv(opts, pointerTask, patchOverlayPath) {
+  // Spaceable values reach cmd.exe unquoted when the .cmd shim forces shell:true
+  // (a temp path under C:\Users\First Last\... would otherwise split — issue #3),
+  // so quote exactly those there. The pointer task is a single positional argv
+  // value; quoting keeps it intact on win32. POSIX passes argv directly.
+  const shellQuoted = process.platform === "win32";
+  const quote = (value) => (shellQuoted ? `"${value}"` : value);
+  const argv = ["--profile", "headless"];
+  if (patchOverlayPath) argv.push("--patch", quote(patchOverlayPath));
+  for (const patch of opts.patches) argv.push("--patch", quote(patch));
+  argv.push(quote(pointerTask));
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only dsh's edits, not relay's artifacts.
+  // The workspace-write sandbox leaves the platform temp roots writable and
+  // reads unconfined, which is what makes the pointer-file mechanic workable.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  // The default out-dir borrows basename(--cd), so a repo directory carrying a
+  // cmd metacharacter would reach cmd.exe through the generated brief path.
+  assertShellSafePath("the run directory", outDir);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    startedAtMs: Date.now(),
+    outDir,
+    briefPath: join(outDir, "brief.md"),
+    finalPath: join(outDir, "final.txt"),
+    outputPath: join(outDir, "output.txt"),
+    resultPath: join(outDir, "result.json"),
+    patchOverlayPath: null,
+  };
+  // A reused --out-dir must not publish a previous run's artifacts as this one's:
+  // makeResultWriter derives finalPath/outputPath from existsSync, and a polling
+  // orchestrator reads resultPath (same guard as aider-delegate).
+  for (const stale of [run.finalPath, run.outputPath, run.resultPath, join(outDir, "model-overlay.yml")]) {
+    rmSync(stale, { force: true });
+  }
+  writeFileSync(run.briefPath, brief, "utf8");
+  // A requested model rides a generated patch overlay replacing the
+  // agent-default-model row's whole config (a patch replaces the targeted row's
+  // complete config rather than deep-merging keys, so provider and model both
+  // belong in the file). A stored selection in $DSH_HOME/settings.yaml layers
+  // over the composition and wins — measured — so this is a request; the
+  // harvest's actualModel reports what actually served the run.
+  if (opts.model !== null) {
+    const provider = opts.provider || DEFAULT_PROVIDER;
+    const overlay = `- id: agent-default-model\n  config:\n    provider: ${provider}\n    model: ${opts.model}\n`;
+    run.patchOverlayPath = join(outDir, "model-overlay.yml");
+    writeFileSync(run.patchOverlayPath, overlay, "utf8");
+  }
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  const modelOverlay = opts.model !== null
+    ? { provider: opts.provider || DEFAULT_PROVIDER, model: opts.model }
+    : null;
+  return (extra) => {
+    const result = {
+      schema: SCHEMA,
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      workdir: opts.cd,
+      permissionMode: opts.permissionMode,
+      permissionModeSource: opts.permissionModeSource,
+      readOnly: opts.readOnly,
+      patches: opts.patches,
+      modelOverlay,
+      dshVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      outputPath: existsSync(run.outputPath) ? run.outputPath : null,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+const HARVEST_SKIPPED = {
+  sessionId: null,
+  sessionRecordPath: null,
+  actualProvider: null,
+  actualModel: null,
+  reasoningEffort: null,
+  usage: null,
+  turnEndReason: null,
+  recordedPermissionMode: null,
+  recordedSandboxMode: null,
+  recordedApprovalPolicy: null,
+  sessionHarvest: "skipped (dsh was not dispatched)",
+};
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "dsh_unavailable", exitCode: 127, signal: null, finalMessage: "", touchedFiles: null, readOnlyViolation: null, ...HARVEST_SKIPPED });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `dsh` not found on PATH. Install it with `npm i -g @deepseek-ai/dsh` (or `npx @deepseek-ai/dsh`) and provide a provider credential (DEEPSEEK_API_KEY, or the provider configured in $DSH_HOME/settings.yaml).\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `dsh --version preflight timed out after ${probeTimeoutMs}ms; dsh was not dispatched`
+    : `dsh --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; dsh was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    readOnlyViolation: null,
+    ...HARVEST_SKIPPED,
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, relayArtifacts) {
+  // The pointer task is a single-line, ASCII-only instruction naming the
+  // absolute brief path; the brief itself travels as a file because the
+  // headless surface reads no stdin. Keep the sentence in lockstep with
+  // writing-the-brief.md.
+  const pointerTask = `Read the task brief at ${run.briefPath} and execute it fully.`;
+  const argv = buildArgv(opts, pointerTask, run.patchOverlayPath);
+  // DSH_PERMISSION_MODE is the harness's own autonomy term. The effective mode
+  // (flag > lane > already-exported environment) is set explicitly; when none
+  // was chosen anywhere the variable is simply absent and the harness's
+  // composed default (workspace-write) applies.
+  const childEnv = { ...process.env };
+  if (opts.permissionMode !== null) childEnv.DSH_PERMISSION_MODE = opts.permissionMode;
+  // shell:true only for the .cmd shim on win32 (see dshVersion). Safe either
+  // way: the brief travels as a file, and argv holds only launcher flags,
+  // metacharacter-checked patch paths, and the single-line pointer task.
+  // detached on POSIX: the child leads a new process group so killChild can fell the whole tree
+  const child = spawn("dsh", argv, {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32",
+    env: childEnv,
+  });
+
+  let stdoutBuf = "";
+  let stdoutTruncated = false;
+  const stderrTail = [];
+  // A stderr line can span data chunks; the held fragment keeps the tail one
+  // entry per logical line. The fragment itself is bounded, so one enormous
+  // unterminated line cannot grow it without limit — a bounded suffix survives,
+  // marked as truncated.
+  let stderrRemainder = "";
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  // dsh prints exactly the final assistant message on stdout (measured), so
+  // stdout is buffered whole. The bound keeps a runaway process from exhausting
+  // memory; past it the HEAD is kept and the truncation reported.
+  child.stdout.on("data", (chunk) => {
+    if (stdoutTruncated) return;
+    stdoutBuf += stdoutDecoder.write(chunk);
+    if (stdoutBuf.length > MAX_BUFFERED_CHARS) {
+      stdoutBuf = stdoutBuf.slice(0, MAX_BUFFERED_CHARS);
+      stdoutTruncated = true;
+    }
+  });
+
+  const pushStderr = (text, flush = false) => {
+    const lines = `${stderrRemainder}${text}`.split("\n");
+    // On flush the decoder is done, so the trailing fragment is a complete line.
+    const remainder = flush ? "" : (lines.pop() ?? "");
+    stderrRemainder = remainder.length > STDERR_REMAINDER_LIMIT
+      ? `${STDERR_TRUNCATION_MARKER}${remainder.slice(-(STDERR_REMAINDER_LIMIT - STDERR_TRUNCATION_MARKER.length))}`
+      : remainder;
+    for (const line of lines) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  };
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk); // surface dsh progress live for the orchestrator
+    pushStderr(stderrDecoder.write(chunk));
+  });
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  const flushCapture = () => {
+    stdoutBuf += stdoutDecoder.end();
+    pushStderr(stderrDecoder.end(), true);
+    if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
+    const finalMessage = stdoutBuf.trim();
+    if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
+    return finalMessage;
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the dsh child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const finalMessage = flushCapture();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        finalMessage,
+        touchedFiles: gitTouchedFiles(opts.cd),
+        readOnlyViolation: null,
+        ...harvestSessionRecord(opts.cd, run.startedAtMs),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; dsh was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd), ...harvestSessionRecord(opts.cd, run.startedAtMs) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const finalMessage = flushCapture();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      readOnlyViolation: null,
+      ...harvestSessionRecord(opts.cd, run.startedAtMs),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    const finalMessage = flushCapture();
+    // dsh catches SIGTERM, drains gracefully, and exits 0 (measured), so a
+    // timed-out or aborted run is classified from the relay's own state —
+    // never from the child's exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    // Only a read-only run makes a read-only claim worth measuring.
+    const readOnlyViolation = opts.readOnly
+      ? readOnlyVerdict(beforeTree, gitTripwireState(opts.cd, relayArtifacts), beforeFingerprints)
+      : null;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      readOnlyViolation,
+      ...harvestSessionRecord(opts.cd, run.startedAtMs),
+      ...(stdoutTruncated ? { outputTruncated: `dsh's stdout exceeded ${MAX_BUFFERED_CHARS} characters; finalMessage is the retained head — read outputPath.` } : {}),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `dsh did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = dshVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+
+  // Fingerprint before dispatch so a read-only run has something to compare
+  // against. The relay's own artifacts are excluded: --out-dir can point into
+  // the repo under review, and the relay must not trip its own tripwire.
+  const relayArtifacts = [run.briefPath, run.outputPath, run.finalPath, run.resultPath, run.patchOverlayPath].filter(Boolean);
+  const beforeTree = opts.readOnly ? gitTripwireState(opts.cd, relayArtifacts) : null;
+  const beforeFingerprints = opts.readOnly ? fingerprintDirtyPaths(opts.cd, relayArtifacts) : null;
+
+  dispatchToDsh(opts, run, writeResult, beforeTree, beforeFingerprints, relayArtifacts);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  dsh ${result.dshVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a dsh error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated dsh (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.permissionMode) {
+    lines.push(`permission mode: ${result.permissionMode} (DSH_PERMISSION_MODE, from ${result.permissionModeSource ?? "flag"})`);
+  }
+  if (result.readOnlyViolation === true) lines.push("READ-ONLY VIOLATION: the tree changed during a read-only run — inspect it before trusting this result.");
+  if (result.modelOverlay) lines.push(`model requested: ${result.modelOverlay.provider}/${result.modelOverlay.model} (an overlay request; a stored settings.yaml selection outranks it)`);
+  if (result.actualModel) lines.push(`model served: ${result.actualProvider ? `${result.actualProvider}/` : ""}${result.actualModel}${result.reasoningEffort ? ` (reasoning effort ${result.reasoningEffort})` : ""}`);
+  if (result.sessionId) lines.push(`session record: ${result.sessionId} (no headless resume; the id names the record under $DSH_HOME/sessions for audit)`);
+  if (result.usage) lines.push(`usage: ${result.usage.inputTokens} in / ${result.usage.outputTokens} out across ${result.usage.assistantMessages} assistant message(s)`);
+  if (result.recordedPermissionMode) lines.push(`recorded posture: preset ${result.recordedPermissionMode}, sandbox ${result.recordedSandboxMode ?? "?"}, approval ${result.recordedApprovalPolicy ?? "?"}`);
+  if (result.sessionHarvest && result.sessionHarvest !== "ok" && !result.sessionHarvest.startsWith("skipped")) {
+    lines.push(`session harvest: ${result.sessionHarvest} — sessionId/actualModel/usage are null, not zero`);
+  }
+  if (result.outputTruncated) lines.push(`warning: ${result.outputTruncated}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- dsh final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -100,6 +100,32 @@ if (process.env.SMOKE_MODE === "dsh-success") {
       permissionMode: process.env.DSH_PERMISSION_MODE ?? null,
     }));
   }
+  // When asked, persist a two-frame session record the way dsh's
+  // session-persistence-jsonl does (each append its own zstd frame) — created
+  // DURING the dispatch, because the relay's harvest attributes only records
+  // born in the run's own window; a fixture pre-seeded by the test would (and
+  // must) be rejected as stale. Skipped silently on a Node without zlib zstd;
+  // the test gates its harvest cases on the same feature.
+  if (process.env.SMOKE_DSH_RECORD_DIR) {
+    const zlib = require("node:zlib");
+    if (typeof zlib.zstdCompressSync === "function") {
+      const frame = (lines) => zlib.zstdCompressSync(Buffer.from(`${lines.map((l) => JSON.stringify(l)).join("\n")}\n`, "utf8"));
+      const id = process.env.SMOKE_DSH_SESSION_ID || "session-33333333-cccc-4ccc-8ccc-333333333333";
+      fs.mkdirSync(process.env.SMOKE_DSH_RECORD_DIR, { recursive: true });
+      fs.writeFileSync(require("node:path").join(process.env.SMOKE_DSH_RECORD_DIR, "session.jsonl.zstd"), Buffer.concat([
+        frame([{ type: "session", version: 3, id, createdAt: Date.now(), cwd: process.cwd(), delegationDepth: 0 }]),
+        frame([
+          { type: "permission/preset", seq: 1, time: 1, data: { preset: "workspace-write" } },
+          { type: "sandbox/mode", seq: 2, time: 1, data: { mode: "workspace-write" } },
+          { type: "approval/policy", seq: 3, time: 1, data: { policy: "ask" } },
+          { type: "request/header", seq: 4, time: 1, data: { header: { config: { provider: "fake-provider", model: "fake-model", maxTokens: 1024, reasoningEffort: "low" } } } },
+          { type: "assistant/message", seq: 5, time: 1, data: { turn: 1, step: 1, message: { role: "assistant", content: [{ type: "text", text: "working" }] }, usage: { inputTokens: 20, outputTokens: 5 } } },
+          { type: "assistant/message", seq: 6, time: 1, data: { turn: 1, step: 2, message: { role: "assistant", content: [{ type: "text", text: "done" }] }, usage: { inputTokens: 10, outputTokens: 2 } } },
+          { type: "turn/end", seq: 7, time: 1, data: { turn: 1, reason: { kind: "completed" } } },
+        ]),
+      ]));
+    }
+  }
   console.log("");
   console.log("fake dsh completed");
   process.exit(0);

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -89,6 +89,35 @@ if (process.env.SMOKE_MODE === "aider-exit-nonzero") {
   console.error("fake aider nonzero exit");
   process.exit(7);
 }
+// dsh prints exactly the final assistant message on stdout (with leading blank
+// lines, as the real CLI does), reads no stdin, and exits 0. The task rides argv
+// only, so the capture includes it for the pointer-task assertions.
+if (process.env.SMOKE_MODE === "dsh-success") {
+  if (process.env.SMOKE_ARGS_FILE) {
+    fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify({
+      args,
+      cwd: process.cwd(),
+      permissionMode: process.env.DSH_PERMISSION_MODE ?? null,
+    }));
+  }
+  console.log("");
+  console.log("fake dsh completed");
+  process.exit(0);
+}
+// The measured live failure shape: a one-line diagnostic on stderr, nothing on
+// stdout, exit 1.
+if (process.env.SMOKE_MODE === "dsh-error") {
+  console.error('dsh: MISSING_CREDENTIAL: llm-deepseek: no API key for provider route "deepseek-official"');
+  process.exit(1);
+}
+// One very long stderr line with no newline at all, so the relay's bounded held
+// fragment is exercised rather than its whole-line tail. Exit nonzero: the relay
+// reports stderrTail only for a run it did not call completed.
+if (process.env.SMOKE_MODE === "dsh-unterminated-stderr") {
+  for (let i = 0; i < 200; i += 1) process.stderr.write("x".repeat(10000));
+  process.stdout.write("fake dsh done\n");
+  process.exit(1);
+}
 if (process.env.SMOKE_MODE === "agy-permission-denied") {
   console.error('jetski: no output produced — a tool required the "write_file" permission that headless\nmode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow\nin settings.json (e.g. write_file(<target>)). Alternatively, re-run with\n--dangerously-skip-permissions to auto-approve all tools.');
   process.exit(0);

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode"];
+export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode", "dsh"];
 
 export const EXTRA_ARGS = {
   claude: [],
@@ -20,6 +20,7 @@ export const EXTRA_ARGS = {
   warp: [],
   zcode: [],
   commandcode: [],
+  dsh: [],
 };
 
 export const WIN = process.platform === "win32";

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -14,7 +14,7 @@ export function installShim(h) {
   copyFileSync(join(fixturesDir, "fake-cli.cjs"), join(shimDir, "fake-cli.cjs"));
 
   if (WIN) {
-    for (const skill of ["claude", "cline", "codex", "opencode", "grok", "cursor", "pi", "copilot", "zcode"]) {
+    for (const skill of ["claude", "cline", "codex", "opencode", "grok", "cursor", "pi", "copilot", "zcode", "dsh"]) {
       writeFileSync(join(shimDir, `${binaryName(skill)}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
     }
     const windir = process.env.WINDIR || "C:\\Windows";

--- a/test/relay-isolated.mjs
+++ b/test/relay-isolated.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode", "dsh"];
 let failed = 0;
 const check = (name, condition) => {
   console.log(`${condition ? "  ok " : "  FAIL"}  ${name}`);

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -4,8 +4,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode"];
-const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok", "zcode", "commandcode"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode", "dsh"];
+const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok", "zcode", "commandcode", "dsh"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],
   ["parseDuration", "function", RELAYS],
@@ -27,7 +27,7 @@ const SYMBOLS = [
   ["fingerprintDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["changedDirtyPaths", "function", READ_ONLY_TRIPWIRE_RELAYS],
   ["readOnlyVerdict", "function", READ_ONLY_TRIPWIRE_RELAYS],
-  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "copilot", "cursor", "grok", "kimi", "opencode", "pi", "omp", "qoder", "vibe", "warp", "zcode", "commandcode"]],
+  ["MAX_BUFFERED_CHARS", "const", ["claude", "cline", "copilot", "cursor", "grok", "kimi", "opencode", "pi", "omp", "qoder", "vibe", "warp", "zcode", "commandcode", "dsh"]],
   ["makeLineScanner", "function", ["vibe", "copilot"]],
   ["makeEventScanner", "function", ["claude", "cline", "cursor", "grok", "kimi", "opencode", "pi", "omp", "qoder", "warp"]],
 ];

--- a/test/relay/dsh.mjs
+++ b/test/relay/dsh.mjs
@@ -28,7 +28,7 @@ export function runDsh(h) {
       "--cd", workDir,
       "--out-dir", outDir,
       ...extraArgs,
-    ], { env: { SMOKE_MODE: "dsh-success", ...h.baseEnv, SMOKE_ARGS_FILE: argsFile, ...extraEnv }, encoding: "utf8" });
+    ], { env: { ...h.baseEnv, SMOKE_MODE: "dsh-success", SMOKE_ARGS_FILE: argsFile, ...extraEnv }, encoding: "utf8" });
     const capture = existsSync(argsFile) ? JSON.parse(readFileSync(argsFile, "utf8")) : {};
     return { run, outDir, capture };
   };
@@ -114,32 +114,29 @@ export function runDsh(h) {
     const home = join(h.scratch, "dsh-home");
     const sessionId = "session-11111111-aaaa-4aaa-8aaa-111111111111";
     const sessionDir = join(home, "sessions", "workspace-a", sessionId);
-    mkdirSync(sessionDir, { recursive: true });
-    // Two frames on purpose: the header append and a later append are separate
-    // zstd frames in the real record, and a one-shot decompress sees only the
-    // first — the frame walk is the thing under test.
-    writeFileSync(join(sessionDir, "session.jsonl.zstd"), seedFrames([
-      [{ type: "session", version: 3, id: sessionId, createdAt: Date.now(), cwd: workDir, delegationDepth: 0 }],
-      [
-        { type: "permission/preset", seq: 1, time: 1, data: { preset: "workspace-write" } },
-        { type: "sandbox/mode", seq: 2, time: 1, data: { mode: "workspace-write" } },
-        { type: "approval/policy", seq: 3, time: 1, data: { policy: "ask" } },
-        { type: "request/header", seq: 4, time: 1, data: { header: { config: { provider: "fake-provider", model: "fake-model", maxTokens: 1024, reasoningEffort: "low" } } } },
-        { type: "assistant/message", seq: 5, time: 1, data: { turn: 1, step: 1, message: { role: "assistant", content: [{ type: "text", text: "working" }] }, usage: { inputTokens: 20, outputTokens: 5 } } },
-        { type: "assistant/message", seq: 6, time: 1, data: { turn: 1, step: 2, message: { role: "assistant", content: [{ type: "text", text: "done" }] }, usage: { inputTokens: 10, outputTokens: 2 } } },
-        { type: "turn/end", seq: 7, time: 1, data: { turn: 1, reason: { kind: "completed" } } },
-      ],
+    // The matching record is written by the fake DURING the dispatch (two zstd
+    // frames, like the real session-persistence-jsonl appends — a one-shot
+    // decompress sees only the first, so the frame walk is under test). It
+    // cannot be pre-seeded here: the harvest attributes only records whose own
+    // createdAt falls inside the run's window, and a pre-seeded one is stale.
+    // A stale record for the SAME workspace, created well before the relay
+    // starts, pins exactly that: it must not be attributed to this dispatch.
+    const staleId = "session-44444444-dddd-4ddd-8ddd-444444444444";
+    const staleDir = join(home, "sessions", "workspace-a", staleId);
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, "session.jsonl.zstd"), seedFrames([
+      [{ type: "session", version: 3, id: staleId, createdAt: Date.now() - 10_000, cwd: workDir, delegationDepth: 0 }],
     ]));
-    // A record for another workspace must not match — candidates are matched by
-    // the header's own cwd, never by predicting the directory-name escape.
+    // A record for another workspace must not match either — candidates are
+    // matched by the header's own cwd, never by predicting the name escape.
     const otherDir = join(home, "sessions", "workspace-b", "session-22222222-bbbb-4bbb-8bbb-222222222222");
     mkdirSync(otherDir, { recursive: true });
     writeFileSync(join(otherDir, "session.jsonl.zstd"), seedFrames([
       [{ type: "session", version: 3, id: "session-22222222-bbbb-4bbb-8bbb-222222222222", createdAt: Date.now(), cwd: join(h.scratch, "elsewhere"), delegationDepth: 0 }],
     ]));
-    const harvested = runRelay("harvest", [], { DSH_HOME: home });
+    const harvested = runRelay("harvest", [], { DSH_HOME: home, SMOKE_DSH_RECORD_DIR: sessionDir, SMOKE_DSH_SESSION_ID: sessionId });
     const value = existsSync(join(harvested.outDir, "result.json")) ? h.result(harvested.outDir) : {};
-    h.check("dsh harvest: the multi-frame session record is walked and matched by cwd",
+    h.check("dsh harvest: the multi-frame record written during the run is walked and matched by cwd",
       harvested.run.status === 0 &&
       value.sessionHarvest === "ok" &&
       value.sessionId === sessionId &&
@@ -157,6 +154,19 @@ export function runDsh(h) {
       value.recordedPermissionMode === "workspace-write" &&
       value.recordedSandboxMode === "workspace-write" &&
       value.recordedApprovalPolicy === "ask");
+    // Re-dispatch against the same reused DSH_HOME with no new record written:
+    // the previous run's record (and the stale seed) match on cwd but predate
+    // this run, so neither may be attributed — a reused home must never report
+    // a prior run's provider, model, usage, or posture.
+    const reused = runRelay("harvest-stale", [], { DSH_HOME: home });
+    const reusedValue = existsSync(join(reused.outDir, "result.json")) ? h.result(reused.outDir) : {};
+    h.check("dsh harvest: records predating the run are never attributed to it",
+      reused.run.status === 0 &&
+      reusedValue.sessionHarvest === "not-found" &&
+      reusedValue.sessionId === null &&
+      reusedValue.actualModel === null &&
+      reusedValue.usage === null &&
+      reusedValue.recordedPermissionMode === null);
     const unmatched = runRelay("harvest-miss", ["--cd", h.freshRepo("work-dsh-miss")], { DSH_HOME: home });
     const missValue = existsSync(join(unmatched.outDir, "result.json")) ? h.result(unmatched.outDir) : {};
     h.check("dsh harvest: no matching record reports not-found with null fields",

--- a/test/relay/dsh.mjs
+++ b/test/relay/dsh.mjs
@@ -1,0 +1,256 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as zlib from "node:zlib";
+
+/**
+ * dsh-delegate contract cases. Beyond the shared timeout/abort matrix these pin:
+ * the exact `--profile headless` argv with pointer-task brief delivery, the
+ * generated agent-default-model overlay, DSH_PERMISSION_MODE handling — flag
+ * wins, an already-exported environment value is honored and reported rather
+ * than silently stripped — the session-record harvest (multi-frame zstd, matched
+ * by the header's own cwd), the measured MISSING_CREDENTIAL failure shape, the
+ * bounded unterminated-stderr fragment, and the win32 cmd metacharacter guard.
+ */
+const METACHARACTERS = ["%", "!", "&", "|", "^", "<", ">", '"'];
+
+const seedFrames = (lines) =>
+  Buffer.concat(lines.map((group) => zlib.zstdCompressSync(Buffer.from(`${group.map((l) => JSON.stringify(l)).join("\n")}\n`, "utf8"))));
+
+export function runDsh(h) {
+  const workDir = h.freshRepo("work-dsh");
+  const runRelay = (name, extraArgs, extraEnv) => {
+    const outDir = join(h.scratch, `out-${name}-dsh`);
+    const argsFile = join(h.scratch, `args-${name}-dsh`);
+    const run = spawnSync(process.execPath, [
+      h.relayPath("dsh"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", outDir,
+      ...extraArgs,
+    ], { env: { SMOKE_MODE: "dsh-success", ...h.baseEnv, SMOKE_ARGS_FILE: argsFile, ...extraEnv }, encoding: "utf8" });
+    const capture = existsSync(argsFile) ? JSON.parse(readFileSync(argsFile, "utf8")) : {};
+    return { run, outDir, capture };
+  };
+
+  // --- documented argv, pointer-task delivery, and the generated overlay -----
+  const success = runRelay("success", ["--model", "fake-model", "--provider", "fake-provider", "--permission-mode", "read-only"], {});
+  const overlayPath = join(success.outDir, "model-overlay.yml");
+  const briefCopy = join(success.outDir, "brief.md");
+  h.check("dsh success: relay exits zero", success.run.status === 0);
+  // On win32 the .cmd shim launch pre-quotes spaceable values; strip surrounding
+  // quotes before comparing so the assertion holds however cmd re-tokenized them.
+  const unquote = (value) => String(value).replace(/^"|"$/g, "");
+  h.check("dsh success: documented argv is exact",
+    JSON.stringify((success.capture.args ?? []).map(unquote)) === JSON.stringify([
+      "--profile", "headless",
+      "--patch", overlayPath,
+      `Read the task brief at ${briefCopy} and execute it fully.`,
+    ]));
+  h.check("dsh success: the brief travels as a file, verbatim",
+    existsSync(briefCopy) && readFileSync(briefCopy, "utf8") === readFileSync(h.briefPath, "utf8"));
+  h.check("dsh success: the overlay replaces the whole agent-default-model config",
+    existsSync(overlayPath) &&
+    readFileSync(overlayPath, "utf8") === "- id: agent-default-model\n  config:\n    provider: fake-provider\n    model: fake-model\n");
+  h.check("dsh success: DSH_PERMISSION_MODE reaches the child",
+    success.capture.permissionMode === "read-only");
+  // Skipped on win32: tmpdir() can hand out an 8.3 short path while process.cwd()
+  // reports the long form, and this check is about the relay's cwd wiring, not
+  // Windows path aliasing.
+  if (!h.WIN) h.check("dsh success: the child cwd is the workspace root", success.capture.cwd === workDir);
+  if (existsSync(join(success.outDir, "result.json"))) {
+    const value = h.result(success.outDir);
+    h.check("dsh success: result fields",
+      value.status === "completed" &&
+      value.exitCode === 0 &&
+      value.finalMessage === "fake dsh completed" &&
+      value.permissionMode === "read-only" &&
+      value.permissionModeSource === "flag" &&
+      value.readOnly === true &&
+      value.readOnlyViolation === false &&
+      value.modelOverlay?.provider === "fake-provider" &&
+      value.modelOverlay?.model === "fake-model" &&
+      typeof value.sessionHarvest === "string");
+  } else {
+    h.check("dsh success: result.json exists", false);
+  }
+
+  // --- an exported DSH_PERMISSION_MODE is honored and reported, never stripped
+  const ambient = runRelay("ambient", [], { DSH_PERMISSION_MODE: "read-only" });
+  h.check("dsh ambient posture: environment read-only is honored, not stripped",
+    ambient.run.status === 0 &&
+    ambient.capture.permissionMode === "read-only" &&
+    h.result(ambient.outDir).permissionMode === "read-only" &&
+    h.result(ambient.outDir).permissionModeSource === "environment" &&
+    h.result(ambient.outDir).readOnly === true);
+  const override = runRelay("override", ["--permission-mode", "workspace-write"], { DSH_PERMISSION_MODE: "read-only" });
+  h.check("dsh ambient posture: an explicit flag overrides the environment",
+    override.run.status === 0 &&
+    override.capture.permissionMode === "workspace-write" &&
+    h.result(override.outDir).permissionModeSource === "flag");
+
+  // --- usage errors: exit 2 before any run, no result file --------------------
+  const usageCases = [
+    ["provider without model", ["--provider", "fake-provider"]],
+    ["invalid --permission-mode", ["--permission-mode", "bogus"]],
+    ["--read-only conflicting with a write mode", ["--read-only", "--permission-mode", "workspace-write"]],
+    ["missing --patch file", ["--patch", join(h.scratch, "no-such-overlay.yml")]],
+    ["unknown option", ["--resume-last"]],
+  ];
+  for (const [name, extraArgs] of usageCases) {
+    const outDir = join(h.scratch, `out-usage-${usageCases.findIndex(([n]) => n === name)}-dsh`);
+    const run = spawnSync(process.execPath, [
+      h.relayPath("dsh"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir, ...extraArgs,
+    ], { env: h.baseEnv, encoding: "utf8" });
+    h.check(`dsh usage error (${name}): exits 2 with no result file`,
+      run.status === 2 && !existsSync(join(outDir, "result.json")));
+  }
+  const badAmbient = runRelay("bad-ambient", [], { DSH_PERMISSION_MODE: "bogus" });
+  h.check("dsh usage error (invalid exported DSH_PERMISSION_MODE): exits 2, names the variable",
+    badAmbient.run.status === 2 && String(badAmbient.run.stderr).includes("DSH_PERMISSION_MODE"));
+
+  // --- session-record harvest (zlib zstd needs Node 22.15+; skipped below it) -
+  if (typeof zlib.zstdCompressSync === "function") {
+    const home = join(h.scratch, "dsh-home");
+    const sessionId = "session-11111111-aaaa-4aaa-8aaa-111111111111";
+    const sessionDir = join(home, "sessions", "workspace-a", sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+    // Two frames on purpose: the header append and a later append are separate
+    // zstd frames in the real record, and a one-shot decompress sees only the
+    // first — the frame walk is the thing under test.
+    writeFileSync(join(sessionDir, "session.jsonl.zstd"), seedFrames([
+      [{ type: "session", version: 3, id: sessionId, createdAt: Date.now(), cwd: workDir, delegationDepth: 0 }],
+      [
+        { type: "permission/preset", seq: 1, time: 1, data: { preset: "workspace-write" } },
+        { type: "sandbox/mode", seq: 2, time: 1, data: { mode: "workspace-write" } },
+        { type: "approval/policy", seq: 3, time: 1, data: { policy: "ask" } },
+        { type: "request/header", seq: 4, time: 1, data: { header: { config: { provider: "fake-provider", model: "fake-model", maxTokens: 1024, reasoningEffort: "low" } } } },
+        { type: "assistant/message", seq: 5, time: 1, data: { turn: 1, step: 1, message: { role: "assistant", content: [{ type: "text", text: "working" }] }, usage: { inputTokens: 20, outputTokens: 5 } } },
+        { type: "assistant/message", seq: 6, time: 1, data: { turn: 1, step: 2, message: { role: "assistant", content: [{ type: "text", text: "done" }] }, usage: { inputTokens: 10, outputTokens: 2 } } },
+        { type: "turn/end", seq: 7, time: 1, data: { turn: 1, reason: { kind: "completed" } } },
+      ],
+    ]));
+    // A record for another workspace must not match — candidates are matched by
+    // the header's own cwd, never by predicting the directory-name escape.
+    const otherDir = join(home, "sessions", "workspace-b", "session-22222222-bbbb-4bbb-8bbb-222222222222");
+    mkdirSync(otherDir, { recursive: true });
+    writeFileSync(join(otherDir, "session.jsonl.zstd"), seedFrames([
+      [{ type: "session", version: 3, id: "session-22222222-bbbb-4bbb-8bbb-222222222222", createdAt: Date.now(), cwd: join(h.scratch, "elsewhere"), delegationDepth: 0 }],
+    ]));
+    const harvested = runRelay("harvest", [], { DSH_HOME: home });
+    const value = existsSync(join(harvested.outDir, "result.json")) ? h.result(harvested.outDir) : {};
+    h.check("dsh harvest: the multi-frame session record is walked and matched by cwd",
+      harvested.run.status === 0 &&
+      value.sessionHarvest === "ok" &&
+      value.sessionId === sessionId &&
+      value.sessionRecordPath === join(sessionDir, "session.jsonl.zstd"));
+    h.check("dsh harvest: the request header names what actually served the run",
+      value.actualProvider === "fake-provider" &&
+      value.actualModel === "fake-model" &&
+      value.reasoningEffort === "low");
+    h.check("dsh harvest: usage is summed across assistant messages",
+      value.usage?.inputTokens === 30 &&
+      value.usage?.outputTokens === 7 &&
+      value.usage?.assistantMessages === 2);
+    h.check("dsh harvest: turn-end reason and recorded posture are reported",
+      value.turnEndReason === "completed" &&
+      value.recordedPermissionMode === "workspace-write" &&
+      value.recordedSandboxMode === "workspace-write" &&
+      value.recordedApprovalPolicy === "ask");
+    const unmatched = runRelay("harvest-miss", ["--cd", h.freshRepo("work-dsh-miss")], { DSH_HOME: home });
+    const missValue = existsSync(join(unmatched.outDir, "result.json")) ? h.result(unmatched.outDir) : {};
+    h.check("dsh harvest: no matching record reports not-found with null fields",
+      unmatched.run.status === 0 &&
+      missValue.sessionHarvest === "not-found" &&
+      missValue.sessionId === null &&
+      missValue.actualModel === null &&
+      missValue.usage === null);
+  } else {
+    console.log("  (dsh harvest cases skipped: this Node has no zlib zstd)");
+  }
+
+  // --- the measured failure shape --------------------------------------------
+  const failed = runRelay("error", [], { SMOKE_MODE: "dsh-error" });
+  const failedValue = existsSync(join(failed.outDir, "result.json")) ? h.result(failed.outDir) : {};
+  h.check("dsh failed path: exit 1 with the diagnostic in stderrTail",
+    failed.run.status === 1 &&
+    failedValue.status === "failed" &&
+    failedValue.exitCode === 1 &&
+    (failedValue.stderrTail ?? []).some((line) => line.includes("MISSING_CREDENTIAL")));
+
+  // --- missing binary: 127 WITH a result file ---------------------------------
+  const missingOutDir = join(h.scratch, "out-unavailable-dsh");
+  const missing = spawnSync(process.execPath, [
+    h.relayPath("dsh"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", missingOutDir,
+  ], { env: { ...process.env, PATH: "" }, encoding: "utf8" });
+  h.check("dsh unavailable: missing binary writes the structured result",
+    missing.status === 127 &&
+    existsSync(join(missingOutDir, "result.json")) &&
+    h.result(missingOutDir).status === "dsh_unavailable");
+
+  // --- bounded preflight -------------------------------------------------------
+  for (const [mode, expectedStatus, expectedExit] of [
+    ["dsh-version-fail", "failed", 7],
+    ["dsh-version-hang", "timeout", 124],
+  ]) {
+    const outDir = join(h.scratch, `out-${mode}`);
+    const preflight = spawnSync(process.execPath, [
+      h.relayPath("dsh"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir, "--timeout", "1s",
+    ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 15_000 });
+    const value = existsSync(join(outDir, "result.json")) ? h.result(outDir) : {};
+    h.check(`dsh preflight: ${mode} is explicit and prevents dispatch`,
+      preflight.status === expectedExit &&
+      value.status === expectedStatus &&
+      value.error?.includes("version preflight") &&
+      value.error?.includes("was not dispatched"));
+  }
+
+  // --- 2 MB of stderr with no newline: the held fragment stays bounded --------
+  const floodOut = join(h.scratch, "out-stderr-flood-dsh");
+  const flood = spawnSync(process.execPath, [
+    h.relayPath("dsh"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", floodOut,
+    // The relay echoes the child's stderr to its own, so this spawnSync needs room
+    // for all 2 MB; the default 1 MB maxBuffer would kill the relay mid-run.
+  ], { env: { ...h.baseEnv, SMOKE_MODE: "dsh-unterminated-stderr" }, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 });
+  h.check("dsh stderr flood: relay survives an unterminated 2 MB line", flood.status === 1);
+  if (existsSync(join(floodOut, "result.json"))) {
+    const tail = h.result(floodOut).stderrTail ?? [];
+    h.check("dsh stderr flood: the fragment is one bounded, marked entry",
+      tail.length === 1 && tail[0].length <= 65_536 && tail[0].startsWith("[truncated] "));
+  } else {
+    h.check("dsh stderr flood: result.json exists", false);
+  }
+
+  // --- win32 cmd metacharacter guard ------------------------------------------
+  // Paths reach cmd.exe there because the .cmd shim needs shell:true, and quoting
+  // is not a boundary in cmd; the relay rejects such paths with exit 2 and no
+  // result file. POSIX spawns argv directly, so the guard must not fire at all.
+  for (const character of METACHARACTERS) {
+    const index = METACHARACTERS.indexOf(character);
+    const patch = join(h.scratch, `overlay${character}.yml`);
+    if (!h.WIN) writeFileSync(patch, "- id: agent-default-model\n", "utf8");
+    const outDir = join(h.scratch, `out-patch-metachar-${index}-dsh`);
+    const run = spawnSync(process.execPath, [
+      h.relayPath("dsh"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", outDir, "--patch", patch,
+    ], { env: { SMOKE_MODE: "dsh-success", ...h.baseEnv }, encoding: "utf8" });
+    if (h.WIN) {
+      h.check(`dsh win32 --patch ${JSON.stringify(character)}: exits 2, no result file`,
+        run.status === 2 &&
+        run.stderr.includes("--patch") &&
+        run.stderr.includes(JSON.stringify(character)) &&
+        !existsSync(join(outDir, "result.json")));
+    } else {
+      h.check(`dsh posix --patch ${JSON.stringify(character)}: no usage exit`, run.status !== 2);
+    }
+    const dirOut = join(h.scratch, `out-dir-metachar${character}-dsh`);
+    const dirRun = spawnSync(process.execPath, [
+      h.relayPath("dsh"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", dirOut,
+    ], { env: { SMOKE_MODE: "dsh-success", ...h.baseEnv }, encoding: "utf8" });
+    if (h.WIN) {
+      h.check(`dsh win32 --out-dir ${JSON.stringify(character)}: exits 2, no result file`,
+        dirRun.status === 2 && !existsSync(join(dirOut, "result.json")));
+    } else {
+      h.check(`dsh posix --out-dir ${JSON.stringify(character)}: no usage exit`, dirRun.status !== 2);
+    }
+  }
+}

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -20,6 +20,7 @@ import { runAider } from "./aider.mjs";
 import { runCopilot } from "./copilot.mjs";
 import { runCommandcode } from "./commandcode.mjs";
 import { runZcode } from "./zcode.mjs";
+import { runDsh } from "./dsh.mjs";
 
 export const runners = [
   ["package-shape", runPackageShape],
@@ -43,5 +44,6 @@ export const runners = [
   ["timeout-tree", runTimeoutTree],
   ["abort", runAbort],
   ["zcode", runZcode],
+  ["dsh", runDsh],
   ["delegate-setup", runDelegateSetup],
 ];


### PR DESCRIPTION
**Claim:** #93 — claimed by @AbdullahElTiby, whose #94 covers the same implementer. This is an
independent implementation, submitted under CONTRIBUTING's rule for two pull requests covering the
same implementer ("this checklist decides — the one that satisfies more of it merges… the other
pull request's distinct improvements get pulled in and credited"). Three of #94's distinct findings
are confirmed here on a second platform and a newer rc, credited inline below, so whichever PR
lands can pull from the other with the measurements already cross-checked.

## What ran

Linux (x86_64), `dsh` 0.1.1-rc.1 (npm install), driven from bash by Claude Code, against a **live
local inference server** — vLLM on loopback serving an FP8 27B Qwen model through an
OpenAI-compatible endpoint (a real inference server, not a stub). Seven live dispatches through the
relay:

- **Write run (default posture)** — created exactly the briefed file, left it uncommitted,
  `touchedFiles` reported it, and the session-record harvest returned `sessionId`,
  `actualProvider`/`actualModel`, reasoning effort, summed usage, and the recorded
  `workspace-write` posture.
- **`--read-only` run whose brief ordered an immediate write** — the sandbox refused it; the final
  message stated the approval escalation failed closed; `touchedFiles` empty,
  `readOnlyViolation: false`, and the record's own `permission/preset` read `read-only`. The
  refusal exits 0 — documented, since the exit code does not carry it.
- **`--model nonexistent-model-xyz`** — completed on the stored `settings.yaml` selection, with
  `modelOverlay` reporting the request and `actualModel` the served model (see harvest, below).
- **`--timeout 25s` firing against live `dsh`** — dsh caught the SIGTERM, drained, and **exited 0**
  (`signal: null`); the relay reported `status: "timeout"`, exit 1. No orphaned processes; the
  interrupted session was still harvested.
- **Relay-level SIGTERM abort mid-run** — `status: "aborted"`, exit 143, `result.json` written, no
  orphans.
- **`failed` path** — a fresh `$DSH_HOME` with no credentials failed live with
  `MISSING_CREDENTIAL` in `stderrTail`, exit 1.
- **Local endpoint via one `--patch` overlay** — on a fresh `$DSH_HOME`, a single overlay defining
  the provider (`llm-pi-ai` row + `agent-default-model` row) completed a run on the local endpoint,
  confirmed by the harvest's `actualProvider`.

Direct CLI probes measured the surface the docs claim: no stdin task ("a task is required",
exit 1), `--resume` rejected as an unknown option, workspace `AGENTS.md` auto-loaded by a headless
run, and an invalid `DSH_PERMISSION_MODE` failing the plugin tree load with the valid enum named.

Gates: full `relay-smoke` (including the new dsh cases and the shared timeout/abort matrix),
`relay-parity`, `relay-isolated`, and `npx skills add . --list` — all green.

## What this adds beyond the headless surface's limits

The headless app prints no session id, has no resume, and has no model flag — #94 documents those
limits accurately. This implementation closes the *observability* half without inventing CLI
surface:

**Session-record harvest.** dsh persists every run to
`$DSH_HOME/sessions/<escaped-workspace>/session-<uuid>/session.jsonl.zstd`. After the run the relay
locates this run's record — matched by the record's own `cwd` header field and creation time, never
by predicting the directory-name escape (ambiguous: a path segment may itself begin with a dash) —
and reports into `result.json`: `sessionId` (an audit handle, explicitly not a resume handle),
`actualProvider` / `actualModel` / `reasoningEffort` from the request header (what actually served
the run), summed token `usage`, `turnEndReason`, and the recorded `permission/preset` /
`sandbox/mode` / `approval/policy`. The record is a sequence of independent zstd frames (one per
append), so the relay walks frame boundaries by parsing block headers — zlib's one-shot API stops
at the first frame. Feature-detected: zlib gained zstd in Node 22.15/23.8; below that the dispatch
still works and `sessionHarvest` states why the fields are null. The harvest reads a file dsh
itself just wrote, locally, and can never fail the run; a seeded multi-frame record pins the
contract in the smoke suite.

Measured consequence: the nonexistent-model run above reports both the request and what served it,
so the overlay-precedence caveat becomes a per-run observable instead of something the user has to
remember.

**Ambient `DSH_PERMISSION_MODE` honored.** A `DSH_PERMISSION_MODE` already exported in the user's
environment is adopted and reported (`permissionModeSource: "environment"`) rather than removed
from the child environment — removing it would silently loosen a standing `read-only` posture to
`workspace-write`. Explicit `--permission-mode` / `--read-only` and lane dials override it.
Contract-tested in both directions.

**Local models as a first-class path.** The docs carry the measured worked example above (fresh
home + one overlay → local endpoint end-to-end), plus wake-latency guidance for servers that sleep
or offload VRAM, and brief-sizing guidance for small-context local models with `usage` as the
context-budget early warning.

## Confirmations of #94's distinct findings (credited)

- **SIGTERM → graceful drain → exit 0**, so timeout/abort must be classified from relay state:
  first measured in #94 on Windows; confirmed here against live `dsh` on Linux, 0.1.1-rc.1.
- **Stored-selection precedence over the model overlay**: first measured in #94 on 0.1.0-rc.7;
  confirmed here on 0.1.1-rc.1.
- The **win32 cmd-metacharacter rejection** and the pointer-file delivery rationale follow #94's
  approach; the smoke cases pin the same contract.

## Registration

`skills.sh.json`; the smoke matrix (`test/harness/constants.mjs` + the win32 `.cmd` shim list);
both `relay-parity` lists — dsh joins the read-only tripwire set with helpers byte-identical to
claude/grok/zcode/commandcode, and the `MAX_BUFFERED_CHARS` set; `relay-isolated`;
`test/relay/dsh.mjs` (42 checks, including the seeded multi-frame harvest contract and the ambient
posture rules); README table row, footnote, and Verification status entry; AGENTS.md vocabulary row
and the win32 `shell:true` note; and the delegate-setup implementers entry plus lane validation
(`DSH_PERMISSION` enum, dsh provider-needs-model, readOnly/permissionMode consistency).

**Untested:** native Windows and macOS (the win32 launch path and guards are contract-tested via
the smoke matrix's compiled fake only); `cmd.exe` as the launching shell; and upstream had already
tagged `0.1.1-rc.2` — every run here is against `0.1.1-rc.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for delegating bounded coding tasks to the DeepSeek Harness CLI.
  - Supports provider and model selection, permission modes, read-only execution, timeouts, background runs, and Windows environments.
  - Provides structured results, session metadata, failure handling, and safe change verification.
  - Added guidance for task briefs, multi-task queues, reviews, rework, and landing changes.

- **Documentation**
  - Updated supported skills, CLI usage, configuration, prerequisites, and verification guidance.

- **Tests**
  - Added coverage for successful runs, errors, permissions, portability, output limits, and read-only protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->