### PR TITLE
fix: restore the empty-PATH-component discovery fix lost with #41

### DIFF
--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -48,8 +48,12 @@ It counts session entries and reads their mtimes; it never opens a session file.
 `;
 
 function resolveBinary(binary) {
-  const pathValue = process.env.PATH || process.env.Path || "";
-  if (!pathValue) return null;
+  const pathValue = process.env.PATH ?? process.env.Path;
+  // A set-but-empty PATH is one empty component — the current directory — in
+  // POSIX lookup, so spawn still resolves there and discovery must agree. Only
+  // an absent PATH (spawn falls back to the system default path, never the
+  // current directory) or an empty one on Windows reports nothing.
+  if (pathValue === undefined || (pathValue === "" && process.platform === "win32")) return null;
   const pathEntries = pathValue
     .split(delimiter)
     .map((entry) => entry.replace(/^"(.*)"$/, "$1"))

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -53,6 +53,10 @@ function resolveBinary(binary) {
   const pathEntries = pathValue
     .split(delimiter)
     .map((entry) => entry.replace(/^"(.*)"$/, "$1"))
+    // An empty component means the current directory in POSIX lookup, which is
+    // where a relay's own spawn would find the binary. Dropping it made
+    // discovery report a CLI as missing that dispatch can actually run.
+    .map((entry) => (entry.length === 0 && process.platform !== "win32" ? "." : entry))
     .filter((entry) => entry.length > 0);
 
   if (process.platform === "win32") {

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -59,16 +59,21 @@ export function runDelegateSetup(h) {
       '#!/bin/sh\ncase "$1" in --version) echo "9.9.9"; exit 0;; esac\nexit 0\n',
     );
     chmodSync(join(cwdProbe, "codex"), 0o755);
-    const cwdDiscover = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
-      encoding: "utf8",
-      cwd: cwdProbe,
-      env: { ...process.env, PATH: delimiter },
-    });
-    const cwdReport = cwdDiscover.status === 0 ? JSON.parse(cwdDiscover.stdout) : null;
-    h.check(
-      "discover honours an empty PATH component as the current directory",
-      cwdReport?.discovered.find((d) => d.key === "codex")?.version === "9.9.9",
-    );
+    for (const [label, pathValue] of [
+      ["an empty PATH component", delimiter],
+      ["a set-but-empty PATH", ""],
+    ]) {
+      const cwdDiscover = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+        encoding: "utf8",
+        cwd: cwdProbe,
+        env: { ...process.env, PATH: pathValue },
+      });
+      const cwdReport = cwdDiscover.status === 0 ? JSON.parse(cwdDiscover.stdout) : null;
+      h.check(
+        `discover honours ${label} as the current directory`,
+        cwdReport?.discovered.find((d) => d.key === "codex")?.version === "9.9.9",
+      );
+    }
   }
 
   if (h.WIN) {

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 
 // ---- delegate-setup: discover + fleet (fleet lanes) ----
 export function runDelegateSetup(h) {
@@ -47,6 +47,27 @@ export function runDelegateSetup(h) {
       "discover honors COMMANDCODE_BIN outside Windows",
       overrideReport.discovered.some(({ key, path, version }) =>
         key === "commandcode" && path === commandCodeOverride && version === "override-commandcode"),
+    );
+
+    // An empty PATH component is the current directory in POSIX lookup, so a
+    // relay's spawn would find a binary there. Discovery must agree, or it
+    // reports a CLI as missing that dispatch can actually run.
+    const cwdProbe = join(h.scratch, "discover-cwd");
+    mkdirSync(cwdProbe);
+    writeFileSync(
+      join(cwdProbe, "codex"),
+      '#!/bin/sh\ncase "$1" in --version) echo "9.9.9"; exit 0;; esac\nexit 0\n',
+    );
+    chmodSync(join(cwdProbe, "codex"), 0o755);
+    const cwdDiscover = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+      encoding: "utf8",
+      cwd: cwdProbe,
+      env: { ...process.env, PATH: delimiter },
+    });
+    const cwdReport = cwdDiscover.status === 0 ? JSON.parse(cwdDiscover.stdout) : null;
+    h.check(
+      "discover honours an empty PATH component as the current directory",
+      cwdReport?.discovered.find((d) => d.key === "codex")?.version === "9.9.9",
     );
   }
 


### PR DESCRIPTION
Restores a discovery fix that was merged in #41 but never reached `master`.

## What happened

#41 ("Harden delegate-setup discovery, validation, and lane lookup") was stacked on #37 and merged into `feature/delegate-setup-lanes` on Aug 4 (merge commit `dd4c946`). #37 was then closed unmerged about two hours later — `delegate-setup` had already landed on `master` separately (`fdca81f`, Jul 31). Net effect: everything #41 added exists only on the closed feature branch, and `master` never received it.

This PR restores one piece of it: `resolveBinary` drops empty `PATH` components, but on POSIX an empty component means the current directory — exactly where a relay's own spawn would find the binary. Discovery therefore reported a CLI as missing that dispatch could run.

## What this PR contains

- `b399a78` cherry-picked from `fix/delegate-setup-robustness`, authorship preserved (it is your commit). The `discover.mjs` change applied cleanly.
- The accompanying check moved from `test/relay-smoke.mjs` to `test/relay/delegate-setup.mjs`, adapted to the harness style introduced by the #43 suite split. It is POSIX-only, matching the fix's `process.platform !== "win32"` guard.

## The rest of #41 is also missing

Spot checks against today's `master`: no `killSignal`/`maxBuffer` on the discovery probes, no NUL-byte rejection in `config.mjs`, the `lane.mjs` prototype-chain lookup is back, and `mergeDials` still exists. I kept this PR to the one self-contained fix; happy to follow up on the remainder if you want it restored the same way.

## What was run

- Windows: `node test/relay-parity.mjs`, `node test/relay-isolated.mjs`, `node test/event-scanner.mjs`, `node test/relay-smoke.mjs --only delegate-setup`, `npx skills add . --list` — all green.
- Linux (node:22 container): `node test/relay-smoke.mjs --only delegate-setup` — all green, including the new check.
- Mutation check: reverting the `discover.mjs` hunk in place turns the new check red; restoring it turns it green.

Full smoke was not run locally; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHQPvAe9kwh8e3AKhQo8EU
