### PR TITLE
fix(commandcode): launch cmdc shim on Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,9 +90,10 @@ CLI flag, field, and command in the docs must match the installed implementer CL
 - Smoke-test any changed script directly (e.g. `node skills/<skill>/scripts/relay.mjs --help`, and a
   no-write or read-only run against a throwaway repo) before relying on it.
 - If you touch how a `relay.mjs` launches its implementer CLI, smoke-test on Windows too (native
-  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, `grok`, `pi`, `cline`, and `copilot` launches
+  PowerShell/cmd, not just Git Bash/WSL): the `codex`, `opencode`, `grok`, `pi`, `cline`, `copilot`, and `commandcode` launches
   need `shell:true` on win32 to resolve the `.cmd` shim. Cline streams its brief on stdin and uses the
-  child process cwd; the other launches quote spaceable args, and all value flags are token-validated.
+  child process cwd; Command Code also streams its brief on stdin. The other launches quote spaceable
+  args, and all value flags are token-validated.
   The `claude` and `cursor-agent` launches serialize a pre-joined
   command string through the shell on win32 for the same shim reason; `agy`, `kimi`, current
   `qodercli`, `vibe`, `aider`, `oz`, and `omp` installs use native binaries (pip puts a real `aider.exe` in

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`claude-delegate`](skills/claude-delegate/SKILL.md) | [Claude Code](https://code.claude.com/docs/en/overview) (`claude`) | `acceptEdits` + explicit tool surface | `--read-only` (`plan` mode) | `--resume-last`, `--session <id>` |
 | [`cline-delegate`](skills/cline-delegate/SKILL.md) | [Cline](https://github.com/cline/cline) (`cline`) | `--auto-approve true` in act mode; upstream sandbox not configured by the relay | `--plan` + `--auto-approve false` (relay-enforced pair) | — (headless JSON resume unsupported) |
 | [`codex-delegate`](skills/codex-delegate/SKILL.md) | [OpenAI Codex](https://github.com/openai/codex) (`codex`) | `--sandbox workspace-write` | `--read-only` | `--resume-last`, `--session <id>` |
-| [`commandcode-delegate`](skills/commandcode-delegate/SKILL.md) | [Command Code](https://commandcode.ai/docs/headless) (`cmd`) | `--yolo` — the only headless write state; no sandbox [^commandcode] | `--read-only` (withheld tools + `plan`) | `--continue-last`, `--session <id>` |
+| [`commandcode-delegate`](skills/commandcode-delegate/SKILL.md) | [Command Code](https://commandcode.ai/docs/headless) (`cmd`; `cmdc` on Windows) | `--yolo` — the only headless write state; no sandbox [^commandcode] | `--read-only` (withheld tools + `plan`) | `--continue-last`, `--session <id>` |
 | [`cursor-delegate`](skills/cursor-delegate/SKILL.md) | [Cursor Agent](https://cursor.com/cli) (`cursor-agent`) | `--force`; `--no-force` withholds command approval | `--read-only` (plan mode) | `--resume-last`, `--session <id>` |
 | [`grok-delegate`](skills/grok-delegate/SKILL.md) | Grok Build (`grok`) | workspace-scoped; `--full-access` opt-in | `--read-only` — best-effort [^grok] | `--resume-last`, `--session <id>` |
 | [`kimi-delegate`](skills/kimi-delegate/SKILL.md) | [Kimi Code](https://moonshotai.github.io/kimi-code/en/) (`kimi`) | `auto permission mode`, always | — [^none] | `--resume-last`, `--session <id>` |
@@ -291,9 +291,9 @@ Per skill — platform, CLI version, and what the run exercised:
   report itself can land in the discarded region. The diff is the deliverable, and a thin report
   means missing information, not a failed run.
 
-  Windows is untested and the relay refuses to guess there (the binary name `cmd` is `cmd.exe`); it
-  requires `COMMANDCODE_BIN` to be the real executable's absolute path, not the system command
-  interpreter.
+  Native Windows launch is contract-tested against the installed `cmdc.cmd` shape, including stdin
+  brief delivery and the `cmd.exe` collision guard. A live native Windows Command Code run remains
+  unverified; upstream recommends WSL for stable Windows use.
 - `warp-delegate` — macOS, `oz` 0.2026.05.27.15.44.stable_01: **live edit run verified**. A relay
   dispatch against a throwaway git repository had Warp add a function plus four assertions across
   two files; both project gates were re-run independently by the orchestrator, the diff matched the
@@ -346,7 +346,7 @@ Per skill — platform, CLI version, and what the run exercised:
   (versions vary by machine). Native Windows discover smoke not yet claimed.
 
 Not yet verified: native Windows launches for `claude`, exact-head `cline`, `grok`, `kimi`,
-`pi`, `qoder`, `vibe`, and `omp` (`codex`/`opencode`/`grok` have contract-tested `.cmd` shim handling;
+`pi`, `qoder`, `vibe`, and `omp` (`codex`/`opencode`/`grok`/`commandcode` have contract-tested `.cmd` shim handling;
 Cursor serializes a pre-joined, quoted command; Qoder and Vibe target their documented native executables).
 Claude's own shell sandbox is unsupported on native Windows regardless of launch mechanics, and upstream
 Vibe officially targets UNIX. A native Linux `cursor-agent` run is unverified. The full delegate →

--- a/skills/commandcode-delegate/SKILL.md
+++ b/skills/commandcode-delegate/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   Command Code while staying the reviewer. DO NOT USE for tasks small enough to do inline, or when the
   user wants the code written directly without delegating.
 license: MIT
-compatibility: Requires the Command Code CLI (`cmd`, from commandcode.ai) installed and authenticated via `cmd login`, Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux). On Windows the binary name collides with `cmd.exe`, so `COMMANDCODE_BIN` must be the real binary's absolute path, not the system command interpreter.
+compatibility: Requires the Command Code CLI (`cmd`, or `cmdc` on Windows, from commandcode.ai) installed and authenticated, Node 22+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux).
 metadata:
   version: 0.5.0
 ---
@@ -30,7 +30,7 @@ as designed-for, not yet proven.)
 - The task is small enough to just do inline — delegation overhead is not worth it.
 - The `cmd` CLI is not installed or not authenticated (run `cmd login`).
 - You want to write the code yourself, or you only need a review (Command Code has its own `/review`).
-- You are on native Windows without `COMMANDCODE_BIN` set — see the autonomy and platform notes below.
+- You are on native Windows and `cmdc --version` does not work. Upstream recommends WSL for stable Windows use.
 
 ## Read this before the first dispatch: the autonomy model
 
@@ -54,10 +54,10 @@ process. If writes outside the target tree are unacceptable, use an OS-enforced 
 
 1. `cmd --version` succeeds and `cmd status` reports authenticated. If not, install Command Code and
    run `cmd login`.
-2. **Confirm which `cmd` is on PATH.** The name is generic, so a shell builtin, an alias, or another
-   tool can shadow it — `command -v cmd` shows the active one. On native Windows `cmd` *is* `cmd.exe`;
-   the relay refuses to guess there and requires `COMMANDCODE_BIN` to be the real binary's absolute
-   path, not the system command interpreter. The relay records the version it actually ran into
+2. **Confirm the CLI on PATH.** On macOS/Linux, `command -v cmd` shows the active `cmd`. On native
+   Windows, use `cmdc --version`; `cmd` is the system shell. The relay uses `cmdc` there and launches
+   its npm `.cmd` shim through `cmd.exe`. `COMMANDCODE_BIN` remains an absolute-path override and must
+   never point to the system command interpreter. The relay records the version it ran in
    `result.json`, so a wrong binary is visible after the fact.
 3. You are in (or will point `--cd` at) the target git repository, and its tree is clean before you
    dispatch — a full-trust run is much easier to review against a clean baseline.

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -15,12 +15,11 @@ cmd --version         # the relay records this in result.json; confirm it is Com
 cmd status            # must report authenticated (else `cmd login`)
 ```
 
-On native Windows, `cmd` resolves to `cmd.exe`. The relay refuses to run there rather than hand your
-brief to a shell: set `COMMANDCODE_BIN` to the Command Code binary's absolute path, not `COMSPEC`, and
-note that it must be a real executable — the relay never launches through a shell, so a `.cmd`/`.bat`
-wrapper will not start.
-Windows is untested for this skill. The same variable overrides the binary on any platform when several
-installs compete.
+On native Windows, use `cmdc`; `cmd` is the system shell. The relay launches the installed `cmdc.cmd`
+shim through `cmd.exe`, while the brief stays on stdin and variable argument values stay restricted to
+shell-safe tokens. Native Windows launch is contract-tested, but a live Command Code run is still
+unverified. `COMMANDCODE_BIN` remains an absolute-path override, including for `.cmd`/`.bat` shims,
+and must never point to `COMSPEC`.
 
 ## Dispatching
 
@@ -169,7 +168,7 @@ process has exited and `result.json` is written — not when a status line says 
 ## When a run misbehaves
 
 - **`status: commandcode_unavailable` (exit 127):** the binary isn't on PATH. Install Command Code, run
-  `cmd login`, or set `COMMANDCODE_BIN`, then re-dispatch.
+  `cmd login` (`cmdc login` on Windows), or set `COMMANDCODE_BIN`, then re-dispatch.
 - **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
   `cmd --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
   Command Code was never dispatched; only the relay's own artifacts may already exist under

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -149,7 +149,7 @@ const BIN = CONFIGURED_BIN && /[\\/]/.test(CONFIGURED_BIN)
   ? resolve(CONFIGURED_BIN)
   : CONFIGURED_BIN || DEFAULT_BIN;
 const WIN_SHELL = process.platform === "win32" && (!CONFIGURED_BIN || /\.(?:cmd|bat)$/i.test(BIN));
-const LAUNCH_BIN = WIN_SHELL ? `"${BIN}"` : BIN;
+const LAUNCH_BIN = WIN_SHELL && /[\\/]/.test(BIN) ? `"${BIN}"` : BIN;
 
 // Command Code's documented headless exit codes, for a summary hint that points at the
 // actual cause instead of a bare number.

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -30,14 +30,10 @@
  * It deliberately does NOT commit. Committing belongs to the reviewer, after it
  * reads the diff and re-runs the project gates.
  *
- * Windows: the Command Code binary is named `cmd`, which collides with the
- * system `cmd.exe`. Rather than risk driving a shell with your brief, the relay
- * refuses to guess there — set COMMANDCODE_BIN to the real binary's absolute path,
- * never the system command interpreter.
- * That path must be a real executable: this relay never launches through a
- * shell, so a `.cmd`/`.bat` wrapper cannot start. Windows is untested here.
- * The same variable overrides the binary on any platform when several installs
- * compete.
+ * Windows: Command Code installs as `cmdc` because `cmd` is the system shell.
+ * The relay launches that npm shim through cmd.exe, with the brief on stdin and
+ * every variable argv value token-validated. COMMANDCODE_BIN can still select
+ * an absolute executable or shim when several installs compete.
  *
  * Usage:
  *   node relay.mjs --brief <file> [options]
@@ -147,17 +143,18 @@ const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
 const PRIVATE_FILE_MODE = 0o600;
 
 const IMPLEMENTER_KEY = "commandcode";
-// `cmd` is Command Code's binary name; COMMANDCODE_BIN overrides it (and is required
-// on Windows, where the name collides with cmd.exe).
 const CONFIGURED_BIN = process.env.COMMANDCODE_BIN || null;
+const DEFAULT_BIN = process.platform === "win32" ? "cmdc" : "cmd";
 const BIN = CONFIGURED_BIN && /[\\/]/.test(CONFIGURED_BIN)
   ? resolve(CONFIGURED_BIN)
-  : CONFIGURED_BIN || "cmd";
+  : CONFIGURED_BIN || DEFAULT_BIN;
+const WIN_SHELL = process.platform === "win32" && (!CONFIGURED_BIN || /\.(?:cmd|bat)$/i.test(BIN));
+const LAUNCH_BIN = WIN_SHELL ? `"${BIN}"` : BIN;
 
 // Command Code's documented headless exit codes, for a summary hint that points at the
 // actual cause instead of a bare number.
 const EXIT_HINTS = new Map([
-  [3, "not authenticated — run `cmd login`, then re-dispatch"],
+  [3, `not authenticated — run \`${DEFAULT_BIN} login\`, then re-dispatch`],
   [4, "permission denied — an implementation run needs write access; this relay passes --yolo unless --read-only was set"],
   [5, "rate limit exceeded — wait and re-dispatch, or lower the model tier"],
   [6, "network failure — check connectivity and re-dispatch"],
@@ -291,9 +288,9 @@ function parseArgs(argv) {
   if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
     fail("--session must be a session id (letters, digits, . _ : -)");
   }
-  if (process.platform === "win32") {
-    if (!CONFIGURED_BIN || !isAbsolute(CONFIGURED_BIN)) {
-      fail("on Windows COMMANDCODE_BIN must be the absolute path of the Command Code executable");
+  if (process.platform === "win32" && CONFIGURED_BIN) {
+    if (!isAbsolute(CONFIGURED_BIN)) {
+      fail("on Windows COMMANDCODE_BIN must be an absolute path");
     }
     const comspec = process.env.ComSpec || process.env.COMSPEC;
     if (comspec && executablePathKey(BIN) === executablePathKey(comspec)) {
@@ -386,13 +383,10 @@ function commandCodeEnv(opts) {
 }
 
 async function commandCodeVersion(probeTimeoutMs, env, onChild) {
-  // Never launched through a shell — on Windows that would route the name `cmd` straight
-  // to cmd.exe. parseArgs requires COMMANDCODE_BIN there, and it must name a real
-  // executable: a .cmd/.bat wrapper cannot be started without the shell this relay refuses.
   const probe = await new Promise((resolveProbe) => {
-    const child = spawn(BIN, ["--version"], {
+    const child = spawn(LAUNCH_BIN, ["--version"], {
       stdio: ["ignore", "pipe", "pipe"],
-      shell: false,
+      shell: WIN_SHELL,
       detached: process.platform !== "win32",
       env,
     });
@@ -422,6 +416,9 @@ async function commandCodeVersion(probeTimeoutMs, env, onChild) {
   }
   if (probe.error?.code === "ENOENT") return { version: null, error: null };
   if (probe.error) return { version: null, error: probe.error };
+  if (WIN_SHELL && /not recognized as an internal or external command/i.test(probe.stderr)) {
+    return { version: null, error: null };
+  }
   if (probe.code !== 0) {
     return { version: null, error: Object.assign(new Error(`${BIN} --version failed`), { status: probe.code, stderr: probe.stderr }) };
   }
@@ -932,7 +929,7 @@ function reportUnavailable(writeResult, resultPath) {
     touchedFiles: null,
   });
   printSummary(result, resultPath);
-  process.stderr.write(`relay: \`${BIN}\` not found on PATH. Install Command Code, run \`cmd login\`, or point COMMANDCODE_BIN at the binary.\n`);
+  process.stderr.write(`relay: \`${BIN}\` not found on PATH. Install Command Code, run \`${DEFAULT_BIN} login\`, or point COMMANDCODE_BIN at the binary.\n`);
   process.exit(127);
 }
 
@@ -996,7 +993,7 @@ function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
 function dispatchToCommandCode(opts, brief, run, writeResult, env) {
   const argv = buildArgv(opts);
   // detached on POSIX: the child leads a new process group so killChild can fell the whole tree.
-  const child = spawn(BIN, argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: false, detached: process.platform !== "win32", env });
+  const child = spawn(LAUNCH_BIN, argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: WIN_SHELL, detached: process.platform !== "win32", env });
 
   const state = { sessionId: null, result: null, lastText: null, truncatedTail: false, deltas: [], pending: [], pendingChars: 0 };
   let stdoutBuf = "";

--- a/skills/delegate-setup/references/schema.md
+++ b/skills/delegate-setup/references/schema.md
@@ -80,7 +80,7 @@ Boolean dials: `readOnly`, `force`. All other dials are non-empty strings. Durat
 `timeout` use `h`/`m`/`s` (e.g. `30m`) and must fit the relay watchdog ceiling (~24.8 days).
 Do not combine `readOnly: true` with a write-capable `sandbox` / `permissionMode` / `force`.
 `model` / `provider` / OpenCode `variant` must match the bound relay’s token rules (e.g. Claude
-rejects spaces; Grok/Pi/Oh My Pi/OpenCode/Codex use a shell-safe token set — Windows `shell:true`
+rejects spaces; Grok/Pi/Oh My Pi/OpenCode/Codex/Command Code use a shell-safe token set — Windows `shell:true`
 launches, and Oh My Pi's flag-injection defense even without a shell).
 
 ## Helpers

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -115,7 +115,7 @@ function resolveLaunch(impl) {
     const configured = process.env.COMMANDCODE_BIN;
     if (process.platform === "win32" && !isAbsolute(configured)) return null;
     const command = /[\\/]/.test(configured) ? resolve(configured) : resolveBinary(configured);
-    if (!command || (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(command))) return null;
+    if (!command) return null;
     try {
       const comspec = process.env.ComSpec || process.env.COMSPEC;
       if (
@@ -129,7 +129,10 @@ function resolveLaunch(impl) {
     }
     return null;
   }
-  if (process.platform === "win32" && impl.key === "commandcode") return null;
+  if (process.platform === "win32" && impl.key === "commandcode") {
+    const command = resolveBinary("cmdc");
+    return command ? { path: command, command, prefixArgs: [] } : null;
+  }
   const onPath = resolveBinary(impl.binary);
   if (onPath) return { path: onPath, command: onPath, prefixArgs: [] };
   const candidates = impl.locate?.candidates?.[process.platform] ?? [];

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -112,8 +112,8 @@ export const IMPLEMENTERS = Object.freeze([
   {
     key: "commandcode",
     skill: "commandcode-delegate",
-    // Command Code's PATH name on non-Windows. On Windows resolveLaunch requires
-    // COMMANDCODE_BIN so discovery never mistakes cmd.exe for this implementer.
+    // Command Code uses `cmdc` on Windows because `cmd` is the system shell.
+    // resolveLaunch owns that platform-specific lookup.
     binary: "cmd",
     versionArgs: ["--version"],
     authProbe: { args: ["status"], successPattern: /Authenticated/i, failPattern: /not authenticated|logged out/i },

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -24,14 +24,11 @@ export const EXTRA_ARGS = {
 
 export const WIN = process.platform === "win32";
 
-// commandcode's binary is `cmd`, which IS cmd.exe on Windows — the relay refuses to
-// guess there and requires COMMANDCODE_BIN, so the shim is planted under its own name
-// and pointed at by that variable instead of by PATH (see install-shim).
 export const binaryName = (skill) =>
   skill === "qoder" ? "qodercli"
     : skill === "cursor" ? "cursor-agent"
       : skill === "warp" ? "oz"
-        : skill === "commandcode" ? "cmd"
+        : skill === "commandcode" ? (WIN ? "cmdc" : "cmd")
           : skill;
 
 export const relayPath = (testDir, skill) =>

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -14,7 +14,7 @@ export function installShim(h) {
   copyFileSync(join(fixturesDir, "fake-cli.cjs"), join(shimDir, "fake-cli.cjs"));
 
   if (WIN) {
-    for (const skill of ["claude", "cline", "codex", "opencode", "grok", "cursor", "pi", "copilot", "zcode"]) {
+    for (const skill of ["claude", "cline", "codex", "opencode", "grok", "cursor", "pi", "copilot", "zcode", "commandcode"]) {
       writeFileSync(join(shimDir, `${binaryName(skill)}.cmd`), `@node "%~dp0fake-cli.cjs" %*\r\n`);
     }
     const windir = process.env.WINDIR || "C:\\Windows";
@@ -22,7 +22,7 @@ export function installShim(h) {
       join(windir, "Microsoft.NET", "Framework64", "v4.0.30319", "csc.exe"),
       join(windir, "Microsoft.NET", "Framework", "v4.0.30319", "csc.exe"),
     ].find((p) => existsSync(p));
-    h.check("windows: the in-box C# compiler exists (builds the native fake for agy/kimi/qoder/vibe/aider/oz/omp/commandcode)", Boolean(csc));
+    h.check("windows: the in-box C# compiler exists (builds the native fake for agy/kimi/qoder/vibe/aider/oz/omp)", Boolean(csc));
     if (csc) {
       const csFile = join(shimDir, "fake-cli.cs");
       copyFileSync(join(fixturesDir, "fake-cli.cs"), csFile);
@@ -37,9 +37,6 @@ export function installShim(h) {
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "aider.exe"));
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "oz.exe"));
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "omp.exe"));
-        // commandcode's relay never uses a shell, so on Windows its binary must be a real
-        // executable — a .cmd stand-in could not be launched the way the real one is.
-        copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "commandcode.exe"));
       } else {
         console.error(`${compiled.stdout ?? ""}${compiled.stderr ?? ""}`);
       }
@@ -54,14 +51,13 @@ export function installShim(h) {
 
   h.briefPath = join(h.scratch, "brief.txt");
   writeFileSync(h.briefPath, "smoke brief: run until killed.");
-  // COMMANDCODE_BIN pins the commandcode relay to the fake rather than to whatever `cmd`
-  // PATH would resolve to — mandatory on Windows (cmd.exe), and the honest choice on POSIX
-  // too, where an unrelated `cmd` may exist on the host.
+  // Pin POSIX to the fake because an unrelated `cmd` may exist on the host. Windows
+  // intentionally uses the `cmdc.cmd` shim on PATH, matching the npm install.
   h.baseEnv = {
     ...process.env,
     PATH: shimDir + delimiter + process.env.PATH,
     SMOKE_NODE: process.execPath,
-    COMMANDCODE_BIN: join(shimDir, WIN ? "commandcode.exe" : "cmd"),
+    COMMANDCODE_BIN: WIN ? "" : join(shimDir, "cmd"),
   };
 
   const slowWriteHook = join(h.scratch, "slow-result-write.cjs");

--- a/test/relay-smoke.mjs
+++ b/test/relay-smoke.mjs
@@ -10,7 +10,7 @@
  *                 result.json reports status "timeout". Driven for the timeout
  *                 matrix on both platforms. On Windows, claude and cursor
  *                 launch a .cmd shim through a serialized cmd.exe invocation,
- *                 while codex/opencode/grok/pi/cline/zcode use shell:true. These are exactly the
+ *                 while codex/opencode/grok/pi/cline/zcode/commandcode use shell:true. These are exactly the
  *                 cases a plain child.kill would miss; agy, aider, kimi, qoder, vibe, oz, and omp spawn a
  *                 native binary directly — a .cmd stand-in cannot represent them,
  *                 so the smoke compiles a real fake .exe with the C# compiler

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -46,8 +46,14 @@ if (h.WIN) {
       !existsSync(join(rejectedOutDir, "result.json")));
   }
   const { run, captured } = dispatch(h, "windows-cmdc-shim", []);
+  const windowsLaunchWorked = run.status === 0 && captured.brief.includes("smoke brief");
+  if (!windowsLaunchWorked) {
+    console.error(`commandcode windows stdout:\n${run.stdout}`);
+    console.error(`commandcode windows stderr:\n${run.stderr}`);
+    console.error(`commandcode windows capture: ${JSON.stringify(captured)}`);
+  }
   h.check("commandcode windows launch: cmdc.cmd receives the brief through stdin",
-    run.status === 0 && captured.brief.includes("smoke brief"));
+    windowsLaunchWorked);
   return;
 }
 {

--- a/test/relay/commandcode.mjs
+++ b/test/relay/commandcode.mjs
@@ -27,20 +27,7 @@ function dispatch(h, name, relayArgs, env = {}) {
 
 export async function runCommandcode(h) {
 if (h.WIN) {
-  // Windows support is unverified. Keep the collision guard covered without pretending
-  // the POSIX fixture scenarios exercise a native Command Code executable.
   const workDir = h.freshRepo("work-win-guard-commandcode");
-  const outDir = join(h.scratch, "out-win-guard-commandcode");
-  const guarded = spawnSync(process.execPath, [
-    h.relayPath("commandcode"),
-    "--brief", h.briefPath,
-    "--cd", workDir,
-    "--out-dir", outDir,
-  ], { env: { ...h.baseEnv, COMMANDCODE_BIN: "" }, encoding: "utf8" });
-  h.check("commandcode windows guard: refuses to run without COMMANDCODE_BIN",
-    guarded.status === 2 &&
-    /COMMANDCODE_BIN/.test(guarded.stderr) &&
-    !existsSync(join(outDir, "result.json")));
   const comspec = h.baseEnv.ComSpec || h.baseEnv.COMSPEC;
   for (const [name, commandCodeBin] of [
     ["bare cmd", "cmd"],
@@ -58,7 +45,9 @@ if (h.WIN) {
       /COMMANDCODE_BIN/.test(rejected.stderr) &&
       !existsSync(join(rejectedOutDir, "result.json")));
   }
-  console.log("  skip  commandcode dispatch scenarios: native Windows launch is unverified");
+  const { run, captured } = dispatch(h, "windows-cmdc-shim", []);
+  h.check("commandcode windows launch: cmdc.cmd receives the brief through stdin",
+    run.status === 0 && captured.brief.includes("smoke brief"));
   return;
 }
 {

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -83,9 +83,9 @@ export function runDelegateSetup(h) {
     });
     const commandCode = JSON.parse(withoutConfiguredCommandCode.stdout);
     h.check(
-      "discover does not mistake Windows cmd.exe for Command Code",
-      commandCode.missing.some(({ key }) => key === "commandcode") &&
-        !commandCode.discovered.some(({ key }) => key === "commandcode"),
+      "discover uses the Windows cmdc shim instead of cmd.exe",
+      commandCode.discovered.some(({ key, path }) =>
+        key === "commandcode" && /cmdc\.cmd$/i.test(path)),
     );
     const comspec = h.baseEnv.ComSpec || h.baseEnv.COMSPEC;
     for (const [name, commandCodeBin] of [
@@ -103,27 +103,17 @@ export function runDelegateSetup(h) {
           !rejectedReport.discovered.some(({ key }) => key === "commandcode"),
       );
     }
-    const withConfiguredCommandCode = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
-      encoding: "utf8",
-      env: h.baseEnv,
-    });
-    const configuredCommandCode = JSON.parse(withConfiguredCommandCode.stdout);
-    h.check(
-      "discover probes the configured Command Code executable on Windows",
-      configuredCommandCode.discovered.some(({ key, path }) =>
-        key === "commandcode" && path === h.baseEnv.COMMANDCODE_BIN),
-    );
     const commandCodeShim = join(h.scratch, "commandcode.cmd");
-    writeFileSync(commandCodeShim, "@exit /b 0\r\n");
+    writeFileSync(commandCodeShim, "@echo override-commandcode\r\n");
     const withCommandCodeShim = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
       encoding: "utf8",
       env: { ...h.baseEnv, COMMANDCODE_BIN: commandCodeShim },
     });
     const shimmedCommandCode = JSON.parse(withCommandCodeShim.stdout);
     h.check(
-      "discover rejects a Command Code .cmd shim that the relay cannot launch",
-      shimmedCommandCode.missing.some(({ key }) => key === "commandcode") &&
-        !shimmedCommandCode.discovered.some(({ key }) => key === "commandcode"),
+      "discover probes a configured Command Code .cmd shim",
+      shimmedCommandCode.discovered.some(({ key, path, version }) =>
+        key === "commandcode" && path === commandCodeShim && version === "override-commandcode"),
     );
   }
 

--- a/test/relay/read-only-tripwire.mjs
+++ b/test/relay/read-only-tripwire.mjs
@@ -177,7 +177,7 @@ export async function runReadOnlyTripwire(h) {
     ...(!h.WIN ? [{ name: "artifact-symlink-target-write", artifactsInside: true, artifactSymlink: true, expected: true, commandcodeExit: 2, commandcodeResult: false }] : []),
   ];
   const tripwireSkills = ["claude", "grok", ...(!h.WIN ? ["commandcode"] : [])];
-  if (h.WIN) console.log("  skip  commandcode tripwire scenarios: native Windows launch is unverified");
+  if (h.WIN) console.log("  skip  commandcode tripwire scenarios: Git-visible tripwire coverage is POSIX-only");
   for (const skill of tripwireSkills) {
     for (const scenario of scenarios) await runScenario(h, skill, scenario);
   }


### PR DESCRIPTION
> *This was generated by AI during triage.*

Closes #97.

## What changed

- Use Command Code’s official `cmdc` alias on native Windows instead of the reserved `cmd` name.
- Launch the npm `.cmd` shim through `cmd.exe`; the brief remains on stdin and variable argument values remain token-validated.
- Make `delegate-setup` discover `cmdc` and accept an absolute `.cmd` override while retaining the `cmd.exe` collision guard.
- Replace the skipped Windows path with a focused `cmdc.cmd` dispatch check.

## Root cause

The relay required a native executable and rejected `.cmd`/`.bat` wrappers. The npm package installs Windows shims, and the upstream Windows contract names `cmdc` as the non-conflicting alias, so a standard native Windows install could not dispatch.

## Verification

- `node test/relay-smoke.mjs --only commandcode`
- `node test/relay-smoke.mjs --only delegate-setup`
- `node test/relay-parity.mjs`
- `node test/relay-isolated.mjs`
- `node test/event-scanner.mjs`
- `node test/relay-smoke.mjs`
- `npx -y skills add . --list`

All passed locally on macOS. Windows Actions must pass before merge; this does not claim a live native Windows Command Code run.