### PR TITLE
feat(codex): isolate review config

### DIFF
--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -64,6 +64,7 @@ orchestrators use that same directory — if unsure where it landed, run
 ```bash
 node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # read-only (review/diagnosis, no edits):   add --read-only
+# isolated review (skip ambient MCP/user config): add --ignore-user-config
 # continue the exact Codex session:         add --session <threadId>  (from result.json; send only the delta brief)
 # fallback when no thread id is available:  add --resume-last
 # hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -43,6 +43,8 @@
  *   --clean-env             Launch Codex and its version preflight with only runtime basics.
  *                           Changes inherited variables only; does not protect files or other
  *                           same-user secrets.
+ *   --ignore-user-config    Do not load Codex user config. Authentication still uses CODEX_HOME;
+ *                           useful for isolated reviews that must not start ambient MCP servers.
  *   --keep-env <name>       Keep one additional variable under --clean-env (repeatable).
  *                           Required for environment-backed auth and other stripped variables.
  *   --skip-git-repo-check   Allow running outside a git repository.
@@ -145,6 +147,7 @@ function parseArgs(argv) {
     resumeLast: false,
     session: null,
     cleanEnv: false,
+    ignoreUserConfig: false,
     keepEnv: [],
     skipGitRepoCheck: false,
     timeout: null,
@@ -174,6 +177,7 @@ function parseArgs(argv) {
       case "--resume-last": opts.resumeLast = true; break;
       case "--session": opts.session = next(); break;
       case "--clean-env": opts.cleanEnv = true; break;
+      case "--ignore-user-config": opts.ignoreUserConfig = true; break;
       case "--keep-env": opts.keepEnv.push(next()); break;
       case "--skip-git-repo-check": opts.skipGitRepoCheck = true; break;
       case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
@@ -353,6 +357,7 @@ function timestamp() {
 
 function buildArgv(opts, finalPath) {
   const argv = ["exec"];
+  if (opts.ignoreUserConfig) argv.push("--ignore-user-config");
   const resuming = Boolean(opts.session || opts.resumeLast);
   // Codex accepts shared exec options before the resume subcommand. Reapply only
   // an explicitly selected sandbox; otherwise leave the active Codex config alone.
@@ -433,6 +438,7 @@ function makeResultWriter(opts, version, run) {
       resumeLast: opts.resumeLast,
       session: opts.session,
       cleanEnv: opts.cleanEnv,
+      ignoreUserConfig: opts.ignoreUserConfig,
       keepEnv: opts.keepEnv,
       codexVersion: version,
       startedAt: run.startedAt,

--- a/test/relay/codex.mjs
+++ b/test/relay/codex.mjs
@@ -14,6 +14,18 @@ h.check("codex effort: forwarded as a config override",
   effortRun.status === 0 && effortArgs.includes("-c") && effortArgs[effortArgs.indexOf("-c") + 1] === "model_reasoning_effort=low");
 h.check("codex effort: recorded in result.json",
   existsSync(join(effortOutDir, "result.json")) && h.result(effortOutDir).effort === "low");
+// ---- codex --ignore-user-config isolates reviews from ambient MCP/user config ----
+const isolatedOutDir = join(h.scratch, "out-ignore-user-config-codex");
+const isolatedArgsFile = join(h.scratch, "args-ignore-user-config-codex");
+const isolatedRun = spawnSync(process.execPath, [
+  h.relayPath("codex"), "--brief", h.briefPath, "--cd", h.freshRepo("work-ignore-user-config-codex"),
+  "--out-dir", isolatedOutDir, "--read-only", "--ignore-user-config",
+], { env: { ...h.baseEnv, SMOKE_MODE: "capture", SMOKE_ARGS_FILE: isolatedArgsFile }, encoding: "utf8" });
+const isolatedArgs = existsSync(isolatedArgsFile) ? JSON.parse(readFileSync(isolatedArgsFile, "utf8")) : [];
+h.check("codex ignore-user-config: forwarded before exec options",
+  isolatedRun.status === 0 && isolatedArgs[0] === "exec" && isolatedArgs[1] === "--ignore-user-config");
+h.check("codex ignore-user-config: recorded in result.json",
+  existsSync(join(isolatedOutDir, "result.json")) && h.result(isolatedOutDir).ignoreUserConfig === true);
 // ---- codex --clean-env isolates both preflight and dispatch ----
 const cleanEnvHelp = spawnSync(process.execPath, [h.relayPath("codex"), "--help"], { encoding: "utf8" });
 h.check("codex clean-env: help scopes the flag to inherited variables, not same-user secrets",


### PR DESCRIPTION
## Summary
- add a Codex relay flag that forwards \--ignore-user-config\`n- preserve CODEX_HOME authentication while skipping ambient user MCP/config startup
- record isolation mode in result.json
- add Windows-compatible relay smoke coverage

## Validation
- \
ode --check skills/codex-delegate/scripts/relay.mjs\`n- \
ode test/relay-smoke.mjs codex\ (Codex checks pass)

## Note
The repository-wide Windows test run still has pre-existing fixture PATH failures (colon-separated fake-bin paths causing az/gh ENOENT). This change does not modify those fixtures.

Dependency for the companion review-skills PR that capability-probes reviewer isolation.