### PR TITLE
fix(codex): persist the full stderr stream to the run dir

### DIFF
--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -71,8 +71,9 @@ filtered environment is used for preflight and dispatch.
 - `finalMessage` — Codex's own final report (the `<structured_output_contract>` you asked for)
 - `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report — `git` missing, or a non-repo run under `--skip-git-repo-check`; `[]` means git ran and the tree is clean
 - `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSONL event stream, and the final-message file
+- `stderrPath` — the complete stderr stream in `stderr.txt`, including diagnostics omitted from the summary
 - `workdir`, `sandbox`, `model`, `effort`, `resumeLast`, `session`, `cleanEnv`, `keepEnv`, `startedAt`, `finishedAt` — `sandbox` is the applied mode, or a note that Codex used its active config on an unqualified resume; `session` is the explicit session id, or `null` for fresh and `--resume-last` runs; `keepEnv` records names only, never values
-- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `codex_unavailable`, and launch failures
+- `stderrTail` — up to 20 nonblank lines from the final 64 KiB of stderr; a partial first line is marked as truncated. Present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `codex_unavailable`, and launch failures. Read `stderrPath` for the complete diagnostics.
 - `error` — present on a launch failure, and on `timeout` and `aborted` runs
 
 The helper also prints a summary to stdout and exits with Codex's exit code, so a wrapping script can
@@ -102,7 +103,7 @@ process has exited and `result.json` is written — not when a status line says 
   `codex --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
   codex was never dispatched; only the relay's own artifacts may already exist under `--out-dir`.
   Check the install by running `codex --version` yourself.
-- **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
+- **`status: failed`:** read `result.json`'s `stderrTail`, the full `stderrPath` log, and the tail of `eventsPath` for the cause.
   Common causes: an auth lapse, an invalid `--model` or unsupported `--effort`, or a sandbox that
   blocked something the task needed. Fix the cause and re-dispatch; don't paper over it by doing the
   work yourself unless that's what the user wants.

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -56,8 +56,9 @@
  *
  * Result: written to <out-dir>/result.json and summarized on stdout —
  *   status, exitCode, signal, codexVersion, threadId (for a later resume), finalMessage
- *   (Codex's own report), touchedFiles (git porcelain, null if git can't report), and the paths to
- *   events.jsonl and final.txt.
+ *   (Codex's own report), touchedFiles (git porcelain, null if git can't report), stderrTail on a
+ *   run that did not succeed, and the paths to events.jsonl, final.txt and stderr.txt. stderr.txt
+ *   holds the complete stderr stream; stderrTail is only its last 20 lines.
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `codex` binary exits 127;
@@ -409,10 +410,12 @@ function prepareRunDir(opts, brief) {
     eventsPath: join(outDir, "events.jsonl"),
     finalPath: join(outDir, "final.txt"),
     briefPath: join(outDir, "brief.txt"),
+    stderrPath: join(outDir, "stderr.txt"),
     resultPath: join(outDir, "result.json"),
   };
   writeFileSync(run.briefPath, brief, "utf8");
   writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
   return run;
 }
 
@@ -440,6 +443,7 @@ function makeResultWriter(opts, version, run) {
       briefPath: run.briefPath,
       eventsPath: run.eventsPath,
       finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      stderrPath: run.stderrPath,
       ...extra,
     };
     // Publish atomically so a polling orchestrator never reads a half-written file
@@ -458,9 +462,27 @@ function reportUnavailable(writeResult, resultPath) {
   process.exit(127);
 }
 
+// `codex exec` writes its whole transcript to stderr — the banner, every tool call, and the
+// full output of every command it runs — so on a failing run the line that explains the
+// failure is routinely hundreds of lines back and a bounded in-memory tail drops it. Persist
+// all of it beside the other run artifacts, the way claude-delegate already does, and let
+// result.json carry the tail as a summary that points at the complete file.
+function stderrTail(stderrPath) {
+  try {
+    return readFileSync(stderrPath, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trimEnd())
+      .filter((line) => line.trim())
+      .slice(-20);
+  } catch {
+    return [];
+  }
+}
+
 function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
   const timedOut = error?.code === "ETIMEDOUT";
   const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
   const message = timedOut
     ? `codex --version preflight timed out after ${probeTimeoutMs}ms; Codex was not dispatched`
     : `codex --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Codex was not dispatched`;
@@ -471,7 +493,7 @@ function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
     threadId: null,
     finalMessage: "",
     touchedFiles: gitTouchedFiles(opts.cd),
-    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    stderrTail: stderrTail(run.stderrPath),
     error: message,
   });
   printSummary(result, run.resultPath);
@@ -489,12 +511,10 @@ function dispatchToCodex(opts, brief, run, writeResult, env) {
 
   let threadId = null;
   let stdoutBuf = "";
-  const stderrTail = [];
 
   // Decode across chunk boundaries: a multibyte UTF-8 character split between
   // two data events would otherwise decode as U+FFFD and corrupt the report.
   const stdoutDecoder = new StringDecoder("utf8");
-  const stderrDecoder = new StringDecoder("utf8");
 
   child.stdout.on("data", (chunk) => {
     stdoutBuf += stdoutDecoder.write(chunk);
@@ -510,11 +530,7 @@ function dispatchToCodex(opts, brief, run, writeResult, env) {
 
   child.stderr.on("data", (chunk) => {
     process.stderr.write(chunk); // surface Codex progress live for the orchestrator
-    const text = stderrDecoder.write(chunk);
-    for (const line of text.split("\n")) {
-      if (line.trim()) stderrTail.push(line.trimEnd());
-    }
-    while (stderrTail.length > 20) stderrTail.shift();
+    appendFileSync(run.stderrPath, chunk);
   });
 
   let settled = false;
@@ -558,7 +574,7 @@ function dispatchToCodex(opts, brief, run, writeResult, env) {
         threadId,
         finalMessage,
         touchedFiles: gitTouchedFiles(opts.cd),
-        stderrTail: stderrTail.slice(-20),
+        stderrTail: stderrTail(run.stderrPath),
         error: `the relay was killed by ${sig}; codex was terminated with it — inspect the working tree before re-dispatching`,
       };
       const result = writeResult(abortedFields);
@@ -606,7 +622,7 @@ function dispatchToCodex(opts, brief, run, writeResult, env) {
       threadId,
       finalMessage,
       touchedFiles: gitTouchedFiles(opts.cd),
-      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(succeeded ? {} : { stderrTail: stderrTail(run.stderrPath) }),
       ...(watchdogFired ? { error: `codex did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
     });
     printSummary(result, run.resultPath);

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -58,7 +58,8 @@
  *   status, exitCode, signal, codexVersion, threadId (for a later resume), finalMessage
  *   (Codex's own report), touchedFiles (git porcelain, null if git can't report), stderrTail on a
  *   run that did not succeed, and the paths to events.jsonl, final.txt and stderr.txt. stderr.txt
- *   holds the complete stderr stream; stderrTail is only its last 20 lines.
+ *   holds the complete stderr stream; stderrTail is up to 20 nonblank lines from its final
+ *   64 KiB, with a partial first line marked as truncated.
  *
  * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
  * before any run and writes no result file; a missing `codex` binary exits 127;
@@ -73,7 +74,7 @@
  */
 
 import {spawn, execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync, openSync, fstatSync, readSync, closeSync } from "node:fs";
 import {join, resolve, basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir } from "node:os";
@@ -81,6 +82,7 @@ import { StringDecoder } from "node:string_decoder";
 
 const VERSION_PROBE_TIMEOUT_MS = 10_000;
 const MAX_TIMER_MS = 2_147_483_647;
+const MAX_STDERR_TAIL_BYTES = 64 * 1024;
 const SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -462,20 +464,36 @@ function reportUnavailable(writeResult, resultPath) {
   process.exit(127);
 }
 
-// `codex exec` writes its whole transcript to stderr — the banner, every tool call, and the
-// full output of every command it runs — so on a failing run the line that explains the
-// failure is routinely hundreds of lines back and a bounded in-memory tail drops it. Persist
-// all of it beside the other run artifacts, the way claude-delegate already does, and let
-// result.json carry the tail as a summary that points at the complete file.
+// ponytail: bound the summary to the final 64 KiB; read stderrPath for longer diagnostics.
+// Reading the whole log here can exhaust memory before publishing a failure or forwarding an abort.
 function stderrTail(stderrPath) {
+  let fd;
   try {
-    return readFileSync(stderrPath, "utf8")
+    fd = openSync(stderrPath, "r");
+    const size = fstatSync(fd).size;
+    const start = Math.max(0, size - MAX_STDERR_TAIL_BYTES);
+    const readStart = Math.max(0, start - 1);
+    const buffer = Buffer.alloc(size - readStart);
+    let bytesRead = 0;
+    while (bytesRead < buffer.length) {
+      const count = readSync(fd, buffer, bytesRead, buffer.length - bytesRead, readStart + bytesRead);
+      if (count === 0) break;
+      bytesRead += count;
+    }
+    let offset = start - readStart;
+    // The preceding byte distinguishes a cut line from a line starting at the window boundary.
+    const partialLine = offset > 0 && buffer[0] !== 0x0a;
+    while (partialLine && offset < bytesRead && (buffer[offset] & 0xc0) === 0x80) offset += 1;
+    const lines = buffer.subarray(offset, bytesRead).toString("utf8")
       .split(/\r?\n/)
-      .map((line) => line.trimEnd())
-      .filter((line) => line.trim())
-      .slice(-20);
+      .map((line) => line.trimEnd());
+    if (partialLine && lines[0]?.trim()) lines[0] = `[truncated; read stderrPath] ${lines[0]}`;
+    return lines.filter((line) => line.trim()).slice(-20);
   } catch {
+    // A missing or unreadable diagnostic must not prevent the run result from being published.
     return [];
+  } finally {
+    if (fd !== undefined) closeSync(fd);
   }
 }
 

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -73,6 +73,18 @@ if (process.env.SMOKE_GIT_RENAME_FROM && process.env.SMOKE_GIT_RENAME_TO) {
     "mv", "-f", process.env.SMOKE_GIT_RENAME_FROM, process.env.SMOKE_GIT_RENAME_TO,
   ]);
 }
+if (process.env.SMOKE_MODE === "codex-stderr-flood") {
+  // Stands in for a real `codex exec` transcript: codex streams the banner, its tool calls
+  // and the full output of every command it runs to stderr, so the line that explains the
+  // failure sits hundreds of lines above the end. Synchronous writes so every line lands
+  // before the process dies, and the unread brief on stdin exercises the swallowed-EPIPE path.
+  fs.writeSync(2, "early marker: the line that explains the failure\n");
+  for (let i = 0; i < 300; i += 1) {
+    fs.writeSync(2, `2026-01-01T00:00:00.${String(i).padStart(6, "0")}Z WARN fake cache: failed to renew cache TTL\n`);
+  }
+  fs.writeSync(2, "fatal: dispatch failed after the flood\n");
+  process.exit(1);
+}
 if (process.env.SMOKE_MODE === "aider-success") {
   fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
   // Mentions OPENAI_API_KEY in prose so a bare-substring matcher would false-fail.

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -73,6 +73,25 @@ if (process.env.SMOKE_GIT_RENAME_FROM && process.env.SMOKE_GIT_RENAME_TO) {
     "mv", "-f", process.env.SMOKE_GIT_RENAME_FROM, process.env.SMOKE_GIT_RENAME_TO,
   ]);
 }
+if (process.env.SMOKE_MODE === "codex-stderr-long-line") {
+  // The 64 KiB suffix starts inside a four-byte character.
+  fs.writeSync(2, "🐎".repeat(20000) + "fin");
+  process.exit(7);
+}
+if (process.env.SMOKE_MODE === "codex-stderr-window-boundary") {
+  const first = "first complete diagnostic\n";
+  const last = "\nlast diagnostic\n";
+  fs.writeSync(2, "outside window\n" + first +
+    " ".repeat(64 * 1024 - Buffer.byteLength(first + last)) + last);
+  process.exit(7);
+}
+if (process.env.SMOKE_MODE === "codex-stderr-large") {
+  // Many short lines make an unbounded split/map/filter allocate far more than the log.
+  const block = Buffer.from("x\n".repeat(32768));
+  for (let i = 0; i < 64; i += 1) fs.writeSync(2, block);
+  fs.writeSync(2, "\r\n  \r\nfatal: café انتهى 🐎\r\nlast diagnostic without newline");
+  process.exit(7);
+}
 if (process.env.SMOKE_MODE === "codex-stderr-flood") {
   // Stands in for a real `codex exec` transcript: codex streams the banner, its tool calls
   // and the full output of every command it runs to stderr, so the line that explains the

--- a/test/relay/codex.mjs
+++ b/test/relay/codex.mjs
@@ -104,4 +104,24 @@ const emptyEffortRun = spawnSync(process.execPath,
   [h.relayPath("codex"), "--brief", h.briefPath, "--effort", ""],
   { env: h.baseEnv, encoding: "utf8" });
 h.check("codex effort: an empty value is rejected", emptyEffortRun.status === 2);
+// ---- codex stderr: the full log survives a transcript longer than the tail ----
+const floodOutDir = join(h.scratch, "out-stderr-flood-codex");
+const floodRun = spawnSync(process.execPath,
+  [h.relayPath("codex"), "--brief", h.briefPath, "--cd", h.freshRepo("work-stderr-flood-codex"), "--out-dir", floodOutDir],
+  { env: { ...h.baseEnv, SMOKE_MODE: "codex-stderr-flood" }, encoding: "utf8" });
+const floodResult = existsSync(join(floodOutDir, "result.json")) ? h.result(floodOutDir) : null;
+const floodTail = floodResult?.stderrTail ?? [];
+const floodLog = floodResult?.stderrPath && existsSync(floodResult.stderrPath)
+  ? readFileSync(floodResult.stderrPath, "utf8")
+  : "";
+h.check("codex stderr: the flooded run still fails with the implementer's exit",
+  floodRun.status === 1 && floodResult?.status === "failed" && floodResult.exitCode === 1);
+h.check("codex stderr: result.json points at the full log",
+  Boolean(floodResult?.stderrPath) && existsSync(floodResult.stderrPath));
+h.check("codex stderr: the full log keeps a diagnostic the tail cannot hold",
+  floodLog.includes("early marker") && !floodTail.some((line) => line.includes("early marker")));
+h.check("codex stderr: the full log drops nothing",
+  floodLog.split("\n").filter((line) => line.includes("failed to renew cache TTL")).length === 300);
+h.check("codex stderr: the tail stays bounded and ends at the failure",
+  floodTail.length === 20 && Boolean(floodTail.at(-1)?.includes("fatal: dispatch failed")));
 }

--- a/test/relay/codex.mjs
+++ b/test/relay/codex.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export async function runCodex(h) {
@@ -124,4 +124,38 @@ h.check("codex stderr: the full log drops nothing",
   floodLog.split("\n").filter((line) => line.includes("failed to renew cache TTL")).length === 300);
 h.check("codex stderr: the tail stays bounded and ends at the failure",
   floodTail.length === 20 && Boolean(floodTail.at(-1)?.includes("fatal: dispatch failed")));
+
+// PR #102: a small heap must still publish the failure after a large stderr stream.
+const largeOutDir = join(h.scratch, "out-stderr-large-codex");
+const largeRun = spawnSync(process.execPath,
+  ["--max-old-space-size=32", h.relayPath("codex"), "--brief", h.briefPath,
+    "--cd", h.freshRepo("work-stderr-large-codex"), "--out-dir", largeOutDir],
+  { env: { ...h.baseEnv, SMOKE_MODE: "codex-stderr-large" }, stdio: "ignore", timeout: 30_000 });
+const largeResult = existsSync(join(largeOutDir, "result.json")) ? h.result(largeOutDir) : null;
+h.check("codex stderr: large logs preserve the failure result under a small heap",
+  largeRun.status === 7 && largeResult?.status === "failed" && largeResult.exitCode === 7);
+h.check("codex stderr: the tail preserves logical lines, UTF-8, and an unterminated final line",
+  JSON.stringify(largeResult?.stderrTail) === JSON.stringify([
+    ...Array(18).fill("x"), "fatal: café انتهى 🐎", "last diagnostic without newline",
+  ]));
+h.check("codex stderr: the complete large stream remains on disk",
+  existsSync(join(largeOutDir, "stderr.txt")) &&
+  statSync(join(largeOutDir, "stderr.txt")).size === 4 * 1024 * 1024 +
+    Buffer.byteLength("\r\n  \r\nfatal: café انتهى 🐎\r\nlast diagnostic without newline"));
+
+for (const [mode, expectedTail] of [
+  ["codex-stderr-long-line", ["[truncated; read stderrPath] " + "🐎".repeat(16383) + "fin"]],
+  ["codex-stderr-window-boundary", ["first complete diagnostic", "last diagnostic"]],
+  ["codex-version-fail", ["fake version failure"]],
+]) {
+  const outDir = join(h.scratch, `out-${mode}`);
+  const run = spawnSync(process.execPath,
+    ["--max-old-space-size=32", h.relayPath("codex"), "--brief", h.briefPath,
+      "--cd", h.freshRepo(`work-${mode}`), "--out-dir", outDir],
+    { env: { ...h.baseEnv, SMOKE_MODE: mode }, stdio: "ignore", timeout: 30_000 });
+  const result = existsSync(join(outDir, "result.json")) ? h.result(outDir) : null;
+  h.check(`codex stderr: ${mode} preserves the bounded diagnostic and failure code`,
+    run.status === 7 && result?.status === "failed" && result.exitCode === 7 &&
+    JSON.stringify(result.stderrTail) === JSON.stringify(expectedTail));
+}
 }


### PR DESCRIPTION
## Problem

`codex exec` writes its whole transcript to stderr: the startup banner, every tool call, and the full stdout and stderr of every command it runs. A trivial `codex exec --sandbox read-only` run against a repo whose command emitted 300 lines produced **324 stderr lines**, 302 of them forwarded subprocess output.

The relay kept a 20-line in-memory rolling tail and persisted stderr nowhere else, so `result.json` on a failing run carried the last 20 lines of whatever command happened to run last, and everything above was discarded with no way to recover it. Running that real captured transcript through the current collector:

```
warn line 285
…
warn line 300
codex
Exit code: `3`
tokens used
8,940
```

The banner, `session id`, `model:`, `sandbox:` and the `exec` line were all evicted. `claude-delegate` does not have this problem because it already streams stderr to `<out-dir>/stderr.txt` (`skills/claude-delegate/scripts/relay.mjs:1052`); `codex-delegate` was the outlier.

## Change

Stream stderr to `<out-dir>/stderr.txt` and publish `stderrPath` on every result, matching `claude-delegate`. `stderrTail` keeps its existing shape and meaning — last 20 lines — and its helper is byte-identical to claude-delegate's. Preflight failures write the probe's stderr to the same file, so `stderrPath` is meaningful on every code path. The live passthrough to the relay's own stderr is untouched.

Net effect on the relay: one in-memory buffer and one `StringDecoder` removed.

## What ran

macOS 26.5.2 (arm64, build 25F84), Node 26.5.0, codex-cli 0.146.0.

- `node test/relay-smoke.mjs` — all green
- `node test/relay-parity.mjs` — all checks passed
- `node test/relay-isolated.mjs` — all checks passed
- `node test/event-scanner.mjs` — 23 passed, 0 failed
- `npx skills add . --list` — exit 0
- Live `codex exec --sandbox read-only` running a command that writes 300 lines to stderr — confirmed codex forwards subprocess stderr into its own stderr (302 of 325 lines), which is what makes the 20-line window insufficient.
- Non-vacuity: the five new checks run against the pre-change relay give 3 FAIL — `stderrPath` absent, the full log absent, lines dropped. The two that pass are the invariants the change must not break (the run still fails with the implementer's exit; the tail stays bounded at 20 and ends at the failure).

## Note, not in this diff

`skills/codex-delegate/references/dispatch-and-poll.md` points a reader at `events.jsonl` when diagnosing a failed run. `stderr.txt` is now worth naming there too. Left out as a separate concern.
