### PR TITLE
docs: record codex-delegate's first end-to-end verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,9 +322,18 @@ Per skill — platform, CLI version, and what the run exercised:
   absent from the shared read-only tripwire scenario matrix, which runs `claude` and `grok` only —
   its tripwire helpers are parity-enforced byte-identical, but no zcode-specific worktree-state run
   is recorded. No macOS or Linux run is recorded.
-- `codex-delegate`, `opencode-delegate`, `vibe-delegate` — contract-tested only: argument validation,
+- `codex-delegate` — macOS, `codex` codex-cli 0.150.1: fresh `workspace-write` dispatch against a
+  throwaway repo created the briefed file and reported it in `touchedFiles`, with `status:
+  "completed"` and exit 0; a `--read-only` dispatch left the tree clean (`touchedFiles: []`) and
+  returned a `threadId`; a follow-up `--session <id>` resume against that thread was asked to recall
+  a word from the first turn without it being named again — the delta brief said only "the word you
+  picked a moment ago" — and it answered correctly, confirming the resumed turn saw prior context, not
+  just that the id was accepted. Contract-tested: argument validation,
   bounded version preflight, missing binary, result parsing, and whole-process-tree timeout/abort
-  cleanup. No end-to-end run is recorded here.
+  cleanup. No Windows or Linux run is recorded.
+- `opencode-delegate`, `vibe-delegate` — contract-tested only: argument validation, bounded version
+  preflight, missing binary, result parsing, and whole-process-tree timeout/abort cleanup. No
+  end-to-end run is recorded here.
 - `cline-delegate` — macOS, `cline` 3.0.52: current-binary unauthenticated plan probe reached
   `run_start` with the fixed positional instruction plus the real brief on stdin, accepted a
   provider-local model id, parsed the failing `run_result`, and left the tree clean. Contract-tested:


### PR DESCRIPTION
## Summary
- Reviewed `codex-delegate` (SKILL.md, relay.mjs, references) for bugs — none found; args/flags/config keys match the installed `codex` CLI, and all contract tests + the full relay smoke suite pass on master.
- The README's Verification status list still had `codex-delegate` grouped under "contract-tested only ... No end-to-end run is recorded here." That was stale, so this replaces it with what I actually ran.

## What I ran
Against `codex` codex-cli 0.150.1 on macOS, using a throwaway git repo:
- A fresh `workspace-write` dispatch (no flags) created the briefed file and reported it in `touchedFiles`, exit 0 / `status: "completed"`.
- A `--read-only` dispatch left the tree clean (`touchedFiles: []`) and returned a `threadId`.
- A `--session <id>` resume against that thread was given a delta brief that never restated the fact from turn one ("reply with the word you picked a moment ago, followed by -2") and answered correctly — confirming the resumed turn actually saw prior context, not just that the id was accepted.

No code changes — `codex-delegate` didn't need any. This is a docs-only PR to keep the verification claim honest per CONTRIBUTING's "claim only what's been run."

## Test plan
- [x] `node test/relay-smoke.mjs --only codex` — all green
- [x] `node test/relay-smoke.mjs` (full suite) — all green
- [x] Three live dispatches against real `codex` codex-cli 0.150.1 as described above