### PR TITLE
feat(zcode): choose a provider and model per dispatch, and list the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ they block every write tool and exit 0 having changed nothing, and the relay rej
 than report that as success. ZCode offers `--disallowed-tools` but no `--allowed-tools`, so
 capability can be subtracted, never enumerated. Where `zcode login` fails with `OAuth response is
 not valid JSON`, the key comes from `ZCODE_API_KEY` / `ANTHROPIC_API_KEY` / `ZAI_API_KEY` instead.
+ZCode also has no `--model` flag — it reads the model from its own config file, at a path derived
+from the process home directory — so the relay's `--model` generates a config pinning one provider
+and model in a home belonging to the run. That generated config holds routing only, never a key, so
+the key still comes from the environment; and because ZCode's session store lives under the same
+home, `--model` cannot be combined with `--session` or `--resume-last`.
 
 Each skill name links to its `SKILL.md`, which owns that implementer's prerequisites, flags, and
 caveats. Building one for another CLI? [Claim it first](../../issues?q=is%3Aissue+label%3Aimplementer),
@@ -308,6 +313,16 @@ Per skill — platform, CLI version, and what the run exercised:
   narration rather than a distinct final-message event, and `--cwd` governed shell commands while
   the agent's file tool resolved bare relative paths against `$HOME`. `--no-snapshot`, `--profile`,
   `--skill`, and `--mcp` are contract-tested only.
+- `zcode-delegate` — Windows, `zcode` 0.16.5: `--model` selection — a read-only (`plan`) dispatch
+  pinned to `opencode-zen/mimo-v2.5-free` over an `openai-compatible` endpoint completed, driven by a
+  config the relay generated in the run's own home; that file carried the provider's `kind`,
+  `baseURL`, and `apiKeyRequired` and no `apiKey`, and the key was read by ZCode from
+  `OPENCODE_ZEN_API_KEY` in the environment. Contract-tested alongside it: a partial flag set, an
+  unqualified model id, an unknown `--model-kind`, a non-http base URL, `--model` with `--session`
+  and with `--resume-last`, and `--model` with no key variable present — each exiting 2 before any
+  artifact; the generated config asserted free of an `apiKey` field; both `HOME` and `USERPROFILE`
+  asserted repointed on the child; and a run without `--model` leaving the home untouched. Not run
+  against an `anthropic`-kind provider through these flags: Z.AI's quota was exhausted at the time.
 - `zcode-delegate` — Windows, `zcode` 0.16.1: read-only (`plan`) run leaving a clean tree with the
   Git tripwire false; write run under `yolo` creating the briefed file and reporting it in
   `touchedFiles`; `--session` resume with an attached delta brief, which recalled the earlier turn;

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -59,6 +59,12 @@ Summarize installed vs missing, auth (`true` / `false` / `null` = unknown), and 
 `reported`, `aliases` (curated aliases in the registry, not live discovery — full model names also
 work), `unsupported`, or `failed`.
 
+ZCode is the one entry whose models come from a file rather than a command, because its CLI has no
+`models` subcommand. Its `values` are qualified `provider/model` ids and its `models` carries an
+extra `providers: [ { name, kind, baseURL } ]` — the routing `zcode-delegate`'s `--model` needs. Its
+config also holds API keys; discovery never reads them, and a malformed file reports `failed` rather
+than any of its bytes. `model` is still not a lane dial for `zcode`: the choice is per dispatch.
+
 ### 2. Load existing (effective map)
 
 ```bash

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -62,8 +62,11 @@ work), `unsupported`, or `failed`.
 ZCode is the one entry whose models come from a file rather than a command, because its CLI has no
 `models` subcommand. Its `values` are qualified `provider/model` ids and its `models` carries an
 extra `providers: [ { name, kind, baseURL } ]` — the routing `zcode-delegate`'s `--model` needs. Its
-config also holds API keys; discovery never reads them, and a malformed file reports `failed` rather
-than any of its bytes. `model` is still not a lane dial for `zcode`: the choice is per dispatch.
+config also holds API keys: reading it loads them into the discovery process, and only the fields
+above leave the parser — `options.apiKey` is never dereferenced, and a malformed file reports
+`failed` rather than any of its bytes. ZCode offers no credential-free listing (no `models`
+subcommand; `zcode doctor` reports runtime facts only), so this is the cost of listing at all.
+`model` is still not a lane dial for `zcode`: the choice is per dispatch.
 
 ### 2. Load existing (effective map)
 

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -41,6 +41,12 @@ authenticated is true | false | null (null = unknown / no probe).
 models.status is reported | aliases | unsupported | failed
 (aliases = curated aliases from the registry, not a live listing).
 
+For zcode, models.values are qualified "provider/model" ids read from ZCode's own CLI
+config — the only offline listing, since ZCode has no models subcommand — and models
+carries an extra "providers": [ { name, kind, baseURL } ]. That routing is what
+zcode-delegate's --model needs alongside the id. The config also holds API keys; they
+are never read, and a malformed file reports "failed" rather than any of its bytes.
+
 --usage adds "usage" to each discovered entry:
   { "sessions": <int>, "lastUsed": <ISO-8601 | null> }, or null when no usage probe
   is wired or the CLI has no local state directory (null = unknown, not zero).
@@ -315,9 +321,48 @@ function parseModelCache(raw) {
   );
 }
 
+/**
+ * Parses the "zcode-config" file shape: ZCode's own CLI config, which is the
+ * only offline listing of the models it can reach.
+ *
+ * That file also holds API keys, so only two things leave this parser — the
+ * `provider/model` identifiers, and each provider's routing (`kind` and
+ * `baseURL`), which is what zcode-delegate's --model needs alongside the id.
+ * `options.apiKey` is never read, and a parse failure returns the same empty
+ * "failed" result as a missing file: no bytes of the file reach a caller.
+ */
+function parseZcodeConfig(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return failedModels();
+  }
+  const table = parsed?.provider;
+  if (!table || typeof table !== "object" || Array.isArray(table)) return failedModels();
+  const identifiers = [];
+  const providers = [];
+  // Prototype-free iteration: a provider literally named "constructor" must not
+  // resolve to an inherited function (the fleet lane lookup hit exactly this).
+  for (const name of Object.keys(table)) {
+    const entry = table[name];
+    const kind = entry?.kind;
+    const baseURL = entry?.options?.baseURL;
+    const models = entry?.models;
+    // Both are required to build a --model dispatch, so a provider missing
+    // either is listed by neither: offering it would produce a run that fails.
+    if (typeof kind !== "string" || typeof baseURL !== "string") continue;
+    if (!models || typeof models !== "object" || Array.isArray(models)) continue;
+    providers.push({ name, kind, baseURL });
+    for (const model of Object.keys(models)) identifiers.push(`${name}/${model}`);
+  }
+  if (providers.length === 0) return failedModels();
+  return { ...modelResult(identifiers), providers };
+}
+
 /** $CODEX_HOME-style override, else the subdirectory under the user's home. */
 function modelFilePath(probe) {
-  const base = process.env[probe.envDir] || join(homedir(), probe.homeSubdir);
+  const base = (probe.envDir && process.env[probe.envDir]) || join(homedir(), probe.homeSubdir);
   return join(base, probe.file);
 }
 
@@ -331,7 +376,8 @@ function probeModels(impl, launch, captured = null) {
   }
   if (probe.file) {
     try {
-      return parseModelCache(readFileSync(modelFilePath(probe), "utf8"));
+      const raw = readFileSync(modelFilePath(probe), "utf8");
+      return probe.format === "zcode-config" ? parseZcodeConfig(raw) : parseModelCache(raw);
     } catch {
       // No cache until the CLI has run once; that is not a discovery failure worth throwing on.
       return failedModels();

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -44,8 +44,9 @@ models.status is reported | aliases | unsupported | failed
 For zcode, models.values are qualified "provider/model" ids read from ZCode's own CLI
 config — the only offline listing, since ZCode has no models subcommand — and models
 carries an extra "providers": [ { name, kind, baseURL } ]. That routing is what
-zcode-delegate's --model needs alongside the id. The config also holds API keys; they
-are never read, and a malformed file reports "failed" rather than any of its bytes.
+zcode-delegate's --model needs alongside the id. Be aware that this file also holds API
+keys: reading it loads them into this process, and only the fields above leave the
+parser. A malformed file reports "failed" rather than any of its bytes.
 
 --usage adds "usage" to each discovered entry:
   { "sessions": <int>, "lastUsed": <ISO-8601 | null> }, or null when no usage probe
@@ -325,11 +326,19 @@ function parseModelCache(raw) {
  * Parses the "zcode-config" file shape: ZCode's own CLI config, which is the
  * only offline listing of the models it can reach.
  *
- * That file also holds API keys, so only two things leave this parser — the
+ * That file also holds API keys. Say the cost plainly rather than around it:
+ * reading it loads those keys into this process, and the containment is in what
+ * leaves the parser, not in what enters it. Two things leave — the
  * `provider/model` identifiers, and each provider's routing (`kind` and
  * `baseURL`), which is what zcode-delegate's --model needs alongside the id.
- * `options.apiKey` is never read, and a parse failure returns the same empty
- * "failed" result as a missing file: no bytes of the file reach a caller.
+ * `options.apiKey` is never dereferenced, so no code path can carry a key into a
+ * result, and a parse failure returns the same empty "failed" result as a
+ * missing file, so no bytes of it reach a caller either.
+ *
+ * There is no credential-free alternative: ZCode has no `models` subcommand, and
+ * `zcode doctor` reports only runtime and packaging facts. If the utility trust
+ * line is read to forbid opening the file at all, the answer is to drop this
+ * probe rather than to soften the wording.
  */
 function parseZcodeConfig(raw) {
   let parsed;

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -370,8 +370,16 @@ export const IMPLEMENTERS = Object.freeze([
     // No auth-status command exists, and `zcode login` fails with ZaiCliOAuthError
     // (seen on 0.16.1 and 0.16.3), so auth stays unknown rather than guessed.
     authProbe: null,
-    // No --model flag: the model is chosen in the CLI's own config file.
-    modelProbe: null,
+    // No --model flag and no `models` command: the catalogue lives in the CLI's
+    // own config file, which is therefore the only offline listing. That file
+    // also holds an API key, so the parser lifts provider routing and model ids
+    // and nothing else, and a malformed file reports "failed" rather than
+    // surfacing a single byte of it.
+    modelProbe: {
+      homeSubdir: ".zcode/cli",
+      file: "config.json",
+      format: "zcode-config",
+    },
     // ~/.zcode/cli holds sess_* directories under several subdirectories, but their
     // counts disagree, so none is proven one-per-session. Unknown, not guessed.
     usageProbe: null,

--- a/skills/zcode-delegate/SKILL.md
+++ b/skills/zcode-delegate/SKILL.md
@@ -94,6 +94,47 @@ Two limits stated plainly, because ZCode cannot enforce them:
   genuinely enforced. An explicit allowlisted tool surface is therefore impossible here — do not
   assume one.
 
+## Choosing a provider and model
+
+ZCode has no `--model` flag. It reads the model from its own config file, whose path it derives from
+the process home directory. So `--model` on this relay generates a config that pins one provider and
+model, writes it into a home directory belonging to the run, and points the ZCode child at that home.
+
+Pass all three flags together — the generated provider block needs the endpoint and the kind as much
+as the id, and the relay cannot discover them:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo \
+  --model openrouter/z-ai/glm-5.2:free \
+  --model-base-url https://openrouter.ai/api/v1 \
+  --model-kind openai-compatible
+```
+
+Only the first `/` separates provider from model, so an id that itself contains slashes or a `:`
+suffix passes through whole. `--model-kind` is `anthropic`, `openai`, or `openai-compatible`.
+
+**The key must be in the environment.** The relay writes no `apiKey` into the generated config — it
+reads and writes no credentials at all. ZCode resolves the key itself from `<PROVIDER>_API_KEY`
+(the provider name upper-cased, every non-alphanumeric run folded to `_`) or `ZCODE_API_KEY`, plus
+`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` for those two kinds. The relay checks that one of them is
+*present* before dispatching and exits 2 naming them if none is; it never reads their values. Note
+that a kind of `anthropic` puts `ANTHROPIC_API_KEY` in that chain, so a key exported for something
+else would be sent to the base URL you named — prefer the `<PROVIDER>_API_KEY` form.
+
+Two limits:
+
+- **`--model` cannot be combined with `--session` or `--resume-last`.** ZCode keeps its session store
+  under the same home as the config, so a per-run home takes the sessions with it. The relay refuses
+  the combination rather than start a fresh session under a resume flag.
+- **This rides behaviour ZCode does not document** — a config path derived from the home directory,
+  and an environment fallback for the key. Both were verified against zcode 0.16.5; a ZCode update
+  could change either. Without these flags the relay does not touch the home directory at all, and
+  ZCode uses whatever the user's own config selects.
+
+Where the model is a **fleet lane** concern rather than a per-run one, note that `model` is still not
+a lane dial for `zcode` — see
+[delegate-setup's schema](../delegate-setup/references/schema.md).
+
 ## The loop
 
 Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
@@ -116,6 +157,7 @@ node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
 # continue a specific session:              add --session <sess_...>  (from result.json; send only the delta brief)
 # continue the latest session for --cd:     add --resume-last
 # withhold tools (denylist):                add --disallowed-tools "Write,Edit,Bash"
+# pin a provider and model for this run:    add --model <provider/model> --model-base-url <url> --model-kind <kind>
 # point at the CLI explicitly:              add --zcode-path /path/to/zcode.cjs
 # hard time limit (watchdog):               add --timeout 2h  (default: off)
 # see all options:                          node .../relay.mjs --help

--- a/skills/zcode-delegate/SKILL.md
+++ b/skills/zcode-delegate/SKILL.md
@@ -108,9 +108,10 @@ exactly what the three flags below need:
 node "<delegate-setup-dir>/scripts/discover.mjs"   # zcode entry: models.values + models.providers
 ```
 
-It reads ZCode's own config because ZCode has no `models` command, and it lifts routing and ids
-only — the API keys in that file are never read. Present the list, take the user's pick, then
-dispatch with it.
+That listing comes from ZCode's own config file, because ZCode has no `models` subcommand. Note what
+that costs: the file also holds API keys, so `delegate-setup` loads them into its process, and only
+the routing and the ids leave its parser. **This relay never opens that file** — the three flags
+below are why. Present the list, take the user's pick, then dispatch with it.
 
 Pass all three flags together — the generated provider block needs the endpoint and the kind as much
 as the id, and the relay cannot discover them:

--- a/skills/zcode-delegate/SKILL.md
+++ b/skills/zcode-delegate/SKILL.md
@@ -100,6 +100,18 @@ ZCode has no `--model` flag. It reads the model from its own config file, whose 
 the process home directory. So `--model` on this relay generates a config that pins one provider and
 model, writes it into a home directory belonging to the run, and points the ZCode child at that home.
 
+**To offer the user a choice, list what they have first.** `delegate-setup`'s discovery reports
+ZCode's catalogue — every `provider/model` id, plus each provider's `kind` and `baseURL`, which is
+exactly what the three flags below need:
+
+```bash
+node "<delegate-setup-dir>/scripts/discover.mjs"   # zcode entry: models.values + models.providers
+```
+
+It reads ZCode's own config because ZCode has no `models` command, and it lifts routing and ids
+only — the API keys in that file are never read. Present the list, take the user's pick, then
+dispatch with it.
+
 Pass all three flags together — the generated provider block needs the endpoint and the kind as much
 as the id, and the relay cannot discover them:
 

--- a/skills/zcode-delegate/references/dispatch-and-poll.md
+++ b/skills/zcode-delegate/references/dispatch-and-poll.md
@@ -48,9 +48,18 @@ If no CLI is found — including when you name one explicitly that does not exis
 
 ZCode has no `--model` flag; it reads the model from `~/.zcode/cli/config.json`, and it derives that
 path from the process home directory. So the relay generates a config under
-`<out-dir>/zcode-home/.zcode/cli/config.json` pinning the named provider and model, and launches the
-ZCode child with `HOME` and `USERPROFILE` both set to `<out-dir>/zcode-home` — both, because
-`os.homedir()` reads a different one per platform. The relay's own environment is untouched.
+`<home>/.zcode/cli/config.json` pinning the named provider and model, and launches the ZCode child
+with `HOME` and `USERPROFILE` both set to that home — both, because `os.homedir()` reads a different
+one per platform. The relay's own environment is untouched.
+
+That home is a fresh directory under the **system temp dir**, not under `--out-dir`, and
+`result.json` records it as `modelHome`. It is deliberately outside the repository: ZCode fills a
+home with live state — a session database, logs, a plugin cache — and `--out-dir` can point into the
+repo under review. The read-only tripwire cannot exclude a tree whose contents do not exist until
+the run creates them, since git collapses an untracked directory into a single entry and the
+exclusion list matches whole paths. Keeping the home out of the repository is what makes a
+`--model --read-only` run report `readOnlyViolation: false` instead of accusing ZCode of writes it
+never made.
 
 The generated provider block carries `kind`, `baseURL`, and `apiKeyRequired`, and no `apiKey`. The
 key comes from the environment, which is what keeps this relay's promise that it reads and writes no

--- a/skills/zcode-delegate/references/dispatch-and-poll.md
+++ b/skills/zcode-delegate/references/dispatch-and-poll.md
@@ -36,10 +36,32 @@ If no CLI is found — including when you name one explicitly that does not exis
 | `--disallowed-tools <list>` | Comma/space-separated denylist, e.g. `"Write,Edit,Bash"`. Enforced by ZCode. |
 | `--session <id>` | Continue a specific session by `sess_…` id from a prior `result.json`. |
 | `--resume-last` | Continue the latest session **for `--cd`**. Mutually exclusive with `--session`. |
+| `--model <provider/model>` | Pin one provider and model for this run. Requires the two flags below. Mutually exclusive with `--session` and `--resume-last`. |
+| `--model-base-url <url>` | The provider's endpoint. Required with `--model`. |
+| `--model-kind <kind>` | `anthropic`, `openai`, or `openai-compatible`. Required with `--model`. |
 | `--zcode-path <file>` | Point at the CLI explicitly. |
 | `--timeout <dur>` | Relay-side watchdog (default: off). `30m`, `2h`. ZCode has no timeout flag of its own. |
 | `--out-dir <dir>` | Where to write run artifacts (default: a fresh dir under the system temp dir). |
 | `-h, --help` | Show help. |
+
+### How `--model` selects a provider
+
+ZCode has no `--model` flag; it reads the model from `~/.zcode/cli/config.json`, and it derives that
+path from the process home directory. So the relay generates a config under
+`<out-dir>/zcode-home/.zcode/cli/config.json` pinning the named provider and model, and launches the
+ZCode child with `HOME` and `USERPROFILE` both set to `<out-dir>/zcode-home` — both, because
+`os.homedir()` reads a different one per platform. The relay's own environment is untouched.
+
+The generated provider block carries `kind`, `baseURL`, and `apiKeyRequired`, and no `apiKey`. The
+key comes from the environment, which is what keeps this relay's promise that it reads and writes no
+credentials. `result.json` records the pinned `model` and the `modelHome` it generated; both are
+`null` on a run without `--model`, which leaves the home directory alone entirely.
+
+Because ZCode's session store also lives under that home, a `--model` run's session does not survive
+the run — hence the mutual exclusion with `--session` and `--resume-last`.
+
+Both the home-derived config path and the environment fallback for the key are undocumented ZCode
+behaviour, verified against zcode 0.16.5.
 
 ### Why `build` and `edit` are rejected
 

--- a/skills/zcode-delegate/scripts/relay.mjs
+++ b/skills/zcode-delegate/scripts/relay.mjs
@@ -45,8 +45,10 @@
  *   --model <provider/model>  Pin one provider and model for this run, e.g.
  *                           openrouter/z-ai/glm-5.2:free. Requires --model-base-url
  *                           and --model-kind. ZCode has no --model flag, so the relay
- *                           generates a config in a per-run home and points the child
- *                           there; the API key is NOT written, it must be in the
+ *                           generates a config in a per-run home under the system temp
+ *                           dir and points the child there (a home fills with live
+ *                           ZCode state, so it must not land in the repo under
+ *                           review); the API key is NOT written, it must be in the
  *                           environment (<PROVIDER>_API_KEY or ZCODE_API_KEY). Cannot
  *                           be combined with --session or --resume-last, because that
  *                           per-run home takes ZCode's session store with it.
@@ -88,7 +90,7 @@
  */
 
 import {spawn, execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, renameSync, readFileSync, readdirSync, existsSync, appendFileSync, statSync, readlinkSync, lstatSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, renameSync, readFileSync, readdirSync, existsSync, appendFileSync, statSync, readlinkSync, lstatSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
 import {join, resolve, basename, dirname, sep, isAbsolute, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { constants, tmpdir, homedir } from "node:os";
@@ -834,7 +836,7 @@ function prepareRunDir(opts, brief) {
     resultPath: join(outDir, "result.json"),
   };
   writeFileSync(run.briefPath, brief, "utf8");
-  if (opts.model) run.modelHome = writeModelHome(outDir, opts);
+  if (opts.model) run.modelHome = writeModelHome(opts);
   return run;
 }
 
@@ -843,11 +845,19 @@ function prepareRunDir(opts, brief) {
  * this run's own. Returns the directory to hand the child as its home.
  *
  * The provider block carries `kind`, `baseURL`, and `apiKeyRequired` and NOTHING
- * else: no `apiKey` field is written, so the file is safe to leave beside the
- * other run artifacts. ZCode falls back to the environment for the key.
+ * else: no `apiKey` field is written. ZCode falls back to the environment for
+ * the key.
+ *
+ * Deliberately NOT under --out-dir. A home is live ZCode state, not an artifact:
+ * the run fills it with a session database, logs, and a plugin cache. --out-dir
+ * can point into the repository under review, and the read-only tripwire cannot
+ * exclude a tree whose contents are unknown until the run creates them — git
+ * collapses the whole directory into one untracked entry, and the relay's
+ * exclusion list matches whole paths. Writing outside the repository keeps that
+ * state where no tripwire, diff, or `touchedFiles` report can see it.
  */
-function writeModelHome(outDir, opts) {
-  const home = join(outDir, "zcode-home");
+function writeModelHome(opts) {
+  const home = mkdtempSync(join(tmpdir(), "delegate-zcode-home-"));
   const configDir = join(home, ".zcode", "cli");
   mkdirSync(configDir, { recursive: true });
   const config = {

--- a/skills/zcode-delegate/scripts/relay.mjs
+++ b/skills/zcode-delegate/scripts/relay.mjs
@@ -42,6 +42,18 @@
  *                           delta brief. Scoped to the directory, not a global "last".
  *   --session <id>          Continue a specific ZCode session by its sess_... id (from a
  *                           prior result.json). Mutually exclusive with --resume-last.
+ *   --model <provider/model>  Pin one provider and model for this run, e.g.
+ *                           openrouter/z-ai/glm-5.2:free. Requires --model-base-url
+ *                           and --model-kind. ZCode has no --model flag, so the relay
+ *                           generates a config in a per-run home and points the child
+ *                           there; the API key is NOT written, it must be in the
+ *                           environment (<PROVIDER>_API_KEY or ZCODE_API_KEY). Cannot
+ *                           be combined with --session or --resume-last, because that
+ *                           per-run home takes ZCode's session store with it.
+ *                           Without these flags ZCode uses the model its own config
+ *                           selects, which this relay never reads.
+ *   --model-base-url <url>  The provider's endpoint. Required with --model.
+ *   --model-kind <kind>     anthropic | openai | openai-compatible. Required with --model.
  *   --zcode-path <file>     Path to the ZCode CLI (a .cjs bundle or a binary/shim).
  *                           Overrides PATH and bundle discovery; ZCODE_CLI does the same.
  *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
@@ -99,6 +111,27 @@ const SAFE_SESSION = /^sess_[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 // Reaches cmd.exe on win32 under a .cmd shim; ZCode accepts comma- or
 // space-separated tool names, optionally with a parenthesised pattern.
 const SAFE_TOOLS = /^[A-Za-z0-9][A-Za-z0-9 ,.:*()_/-]*$/;
+
+// --- model selection -------------------------------------------------------
+// ZCode has no --model flag: the model is read from the CLI's own config file,
+// whose path is derived from the process home directory. So a per-run model is
+// expressed by generating a config in an isolated home under the run dir and
+// pointing the CHILD's home at it. The generated config carries the provider's
+// routing only — never a key. ZCode resolves the key from the environment, so
+// the relay keeps the repo's trust line: it reads and writes no credentials.
+// Verified against zcode 0.16.5; this rides undocumented behaviour and an app
+// update could change it, which is why the flags are explicit rather than
+// discovered from the user's own config.
+const ZCODE_PROVIDER_KINDS = new Set(["anthropic", "openai", "openai-compatible"]);
+// The provider segment keys the generated config and derives an environment
+// variable name, so keep it to the shape ZCode's own name-to-env mapping folds
+// cleanly (it uppercases and replaces every non-alphanumeric run with "_").
+const SAFE_PROVIDER = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+// Model ids may themselves contain slashes and a colon suffix — openrouter's
+// "nvidia/nemotron-3-ultra-550b-a55b:free", baseten's "moonshotai/Kimi-K3" —
+// so only the FIRST slash separates provider from model.
+const SAFE_MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+const SAFE_BASE_URL = /^https?:\/\/[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=%-]+$/;
 
 // ZCode reads no stdin, so the brief travels as an attached file and the prompt
 // is this fixed instruction. Keep the two in lockstep with writing-the-brief.md.
@@ -164,6 +197,9 @@ function parseArgs(argv) {
     zcodePath: null,
     timeout: null,
     outDir: null,
+    model: null,
+    modelBaseUrl: null,
+    modelKind: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -190,6 +226,9 @@ function parseArgs(argv) {
       case "--zcode-path": opts.zcodePath = resolve(next()); break;
       case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
       case "--out-dir": opts.outDir = resolve(next()); break;
+      case "--model": opts.model = next(); break;
+      case "--model-base-url": opts.modelBaseUrl = next(); break;
+      case "--model-kind": opts.modelKind = next(); break;
       default:
         fail(`unknown option: ${arg}`);
     }
@@ -225,7 +264,64 @@ function parseArgs(argv) {
   if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
     fail("--session must be a ZCode session id of the form sess_... (letters, digits, . _ : -)");
   }
+  validateModelSelection(opts);
   return opts;
+}
+
+/**
+ * The three model flags are one unit: the generated config needs the endpoint
+ * and the kind as much as the id, and ZCode gives the relay no way to discover
+ * either (the user's own config is off limits — it holds an API key). So a
+ * partial set is a usage error rather than a half-configured provider.
+ */
+function validateModelSelection(opts) {
+  const given = ["model", "modelBaseUrl", "modelKind"].filter((key) => opts[key] !== null);
+  if (given.length === 0) return;
+  if (given.length !== 3) {
+    fail("--model, --model-base-url, and --model-kind must be passed together; the generated provider config needs all three");
+  }
+  const slash = opts.model.indexOf("/");
+  if (slash <= 0 || slash === opts.model.length - 1) {
+    fail(`--model "${opts.model}" must be provider/model, e.g. openrouter/z-ai/glm-5.2:free`);
+  }
+  opts.modelProvider = opts.model.slice(0, slash);
+  opts.modelId = opts.model.slice(slash + 1);
+  if (!SAFE_PROVIDER.test(opts.modelProvider) || !SAFE_MODEL_ID.test(opts.modelId)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, and . _ : / -)");
+  }
+  if (!ZCODE_PROVIDER_KINDS.has(opts.modelKind)) {
+    fail(`invalid --model-kind "${opts.modelKind}" (expected: ${[...ZCODE_PROVIDER_KINDS].join(", ")})`);
+  }
+  if (!SAFE_BASE_URL.test(opts.modelBaseUrl)) {
+    fail("--model-base-url must be an http(s) URL with no whitespace");
+  }
+  // The generated config lives in a throwaway home, and ZCode keeps its session
+  // store under that same home. A resumed run would look for the session beside
+  // a config that no longer exists, so refuse the combination rather than
+  // silently start a fresh session under a resume flag.
+  if (opts.session !== null || opts.resumeLast) {
+    fail("--model cannot be combined with --session or --resume-last: the generated config lives in a per-run home, so ZCode's session store does not survive the run");
+  }
+  const candidates = modelKeyEnvNames(opts.modelProvider, opts.modelKind);
+  // Presence only — the relay must never read a key's value.
+  if (!candidates.some((name) => process.env[name] !== undefined)) {
+    fail(`no API key in the environment for provider "${opts.modelProvider}": set one of ${candidates.join(", ")} (the relay never reads or writes credentials, so the key must come from the environment)`);
+  }
+}
+
+/**
+ * The environment variable names ZCode itself consults for a provider's key,
+ * in its own order: the kind's canonical name, then the provider name folded
+ * to upper snake case, then the global fallback.
+ */
+function modelKeyEnvNames(provider, kind) {
+  const names = [];
+  if (kind === "openai") names.push("OPENAI_API_KEY");
+  if (kind === "anthropic") names.push("ANTHROPIC_API_KEY");
+  const folded = provider.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase();
+  if (folded) names.push(`${folded}_API_KEY`);
+  names.push("ZCODE_API_KEY");
+  return [...new Set(names)];
 }
 
 function parseDuration(duration) {
@@ -738,7 +834,47 @@ function prepareRunDir(opts, brief) {
     resultPath: join(outDir, "result.json"),
   };
   writeFileSync(run.briefPath, brief, "utf8");
+  if (opts.model) run.modelHome = writeModelHome(outDir, opts);
   return run;
+}
+
+/**
+ * Generate the config that pins one provider and model, in a home directory of
+ * this run's own. Returns the directory to hand the child as its home.
+ *
+ * The provider block carries `kind`, `baseURL`, and `apiKeyRequired` and NOTHING
+ * else: no `apiKey` field is written, so the file is safe to leave beside the
+ * other run artifacts. ZCode falls back to the environment for the key.
+ */
+function writeModelHome(outDir, opts) {
+  const home = join(outDir, "zcode-home");
+  const configDir = join(home, ".zcode", "cli");
+  mkdirSync(configDir, { recursive: true });
+  const config = {
+    provider: {
+      [opts.modelProvider]: {
+        kind: opts.modelKind,
+        options: { baseURL: opts.modelBaseUrl, apiKeyRequired: true },
+        // ZCode requires the model to be declared before it can be selected.
+        models: { [opts.modelId]: { name: opts.modelId } },
+      },
+    },
+    // `main` alone satisfies ZCode's model-role schema; it demands main or lite.
+    model: { main: `${opts.modelProvider}/${opts.modelId}` },
+  };
+  writeFileSync(join(configDir, "config.json"), `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  return home;
+}
+
+/**
+ * The child's environment. Unchanged unless --model was passed, in which case
+ * both home variables point at the generated config — `HOME` for POSIX and
+ * `USERPROFILE` for win32, since Node's os.homedir() reads a different one per
+ * platform and the relay cannot know which the CLI will consult.
+ */
+function childEnv(run) {
+  if (!run.modelHome) return process.env;
+  return { ...process.env, HOME: run.modelHome, USERPROFILE: run.modelHome };
 }
 
 function makeResultWriter(opts, version, run, target) {
@@ -756,6 +892,10 @@ function makeResultWriter(opts, version, run, target) {
       disallowedTools: opts.disallowedTools,
       resumeLast: opts.resumeLast,
       session: opts.session,
+      // null unless --model pinned one: without it ZCode uses whatever the
+      // user's own config selects, which the relay does not read.
+      model: opts.model,
+      modelHome: run.modelHome ?? null,
       zcodeVersion: version,
       zcodeSource: target ? target.source : null,
       zcodePath: target ? target.display : null,
@@ -819,7 +959,7 @@ function dispatchToZcode(opts, run, target, writeResult, beforeTree, beforeFinge
     stdio: ["ignore", "pipe", "pipe"],
     shell: needsShell(target),
     detached: process.platform !== "win32",
-    env: process.env,
+    env: childEnv(run),
   });
 
   let stdoutBuf = "";

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -1,7 +1,7 @@
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 const capturedEnv = () => Object.fromEntries(
-  ["PATH", "HOME", "SMOKE_PROVIDER_TOKEN", "SMOKE_SECRET_TOKEN"]
+  ["PATH", "HOME", "USERPROFILE", "SMOKE_PROVIDER_TOKEN", "SMOKE_SECRET_TOKEN"]
     .filter((key) => process.env[key] !== undefined)
     .map((key) => [key, process.env[key]]),
 );

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -53,6 +53,14 @@ if (process.env.SMOKE_MODE === "capture") {
 if (process.env.SMOKE_WRITE_FILE) {
   fs.writeFileSync(process.env.SMOKE_WRITE_FILE, "written by fake cli\n");
 }
+// Writes into the home the relay handed this child, whose path the caller cannot
+// know in advance. Stands in for a CLI that keeps live state under its own home.
+if (process.env.SMOKE_WRITE_IN_HOME && process.env.HOME) {
+  fs.writeFileSync(
+    require("node:path").join(process.env.HOME, process.env.SMOKE_WRITE_IN_HOME),
+    "home-local state written by fake cli\n",
+  );
+}
 if (process.env.SMOKE_APPEND_INVALID_UTF8) {
   fs.appendFileSync(Buffer.from(process.env.SMOKE_APPEND_INVALID_UTF8, "hex"), "appended by fake cli\n");
 }

--- a/test/relay/delegate-setup.mjs
+++ b/test/relay/delegate-setup.mjs
@@ -208,6 +208,81 @@ if (observation === "models") {
     );
   }
 
+  // --- zcode model probe reads the CLI config, and only its non-secret parts ---
+  // ZCode has no `models` command; the catalogue lives in its own config file,
+  // which also holds API keys. Discovery must lift routing and ids and nothing
+  // else, and must not surface file bytes when the file is malformed.
+  const zcodeProbeDir = join(h.scratch, "discover-zcode");
+  mkdirSync(zcodeProbeDir);
+  const zcodeProbeSource = 'console.log("zcode 0.16.5");\n';
+  if (h.WIN) {
+    writeFileSync(join(zcodeProbeDir, "fake-zcode.cjs"), zcodeProbeSource);
+    writeFileSync(join(zcodeProbeDir, "zcode.cmd"), `@"${process.execPath}" "%~dp0fake-zcode.cjs" %*\r\n`);
+  } else {
+    const zcodeProbePath = join(zcodeProbeDir, "zcode");
+    writeFileSync(zcodeProbePath, `#!${process.execPath}\n${zcodeProbeSource}`);
+    chmodSync(zcodeProbePath, 0o755);
+  }
+
+  const SECRET = "sk-zcode-smoke-secret-never-print";
+  const CANARY = "canary-bytes-of-a-malformed-config";
+  const zcodeHome = join(h.scratch, "zcode-home");
+  const zcodeConfigDir = join(zcodeHome, ".zcode", "cli");
+  mkdirSync(zcodeConfigDir, { recursive: true });
+
+  const runZcodeDiscover = () => {
+    const probe = spawnSync(process.execPath, [join(setupDir, "discover.mjs")], {
+      encoding: "utf8",
+      // os.homedir() reads USERPROFILE on win32 and HOME elsewhere, so set both.
+      env: { ...process.env, PATH: zcodeProbeDir, HOME: zcodeHome, USERPROFILE: zcodeHome },
+    });
+    let report = null;
+    try {
+      if (probe.status === 0) report = JSON.parse(probe.stdout);
+    } catch { report = null; }
+    return { stdout: probe.stdout ?? "", entry: report?.discovered.find(({ key }) => key === "zcode") };
+  };
+
+  writeFileSync(join(zcodeConfigDir, "config.json"), JSON.stringify({
+    provider: {
+      zai: {
+        kind: "anthropic",
+        options: { baseURL: "https://api.z.ai/api/anthropic", apiKey: SECRET },
+        models: { "glm-5.1": { name: "GLM-5.1" } },
+      },
+      openrouter: {
+        kind: "openai-compatible",
+        options: { baseURL: "https://openrouter.ai/api/v1", apiKey: SECRET },
+        // The id keeps its own slashes and : suffix; only the provider prefix is added.
+        models: { "z-ai/glm-5.2:free": { name: "GLM 5.2" } },
+      },
+      // No baseURL: --model could not dispatch to it, so it must not be offered.
+      broken: { kind: "openai-compatible", options: {}, models: { "ghost-1": {} } },
+    },
+    model: { main: "zai/glm-5.1" },
+  }, null, 2));
+
+  const populated = runZcodeDiscover();
+  h.check("zcode models: providers and qualified ids are reported from the CLI config",
+    populated.entry?.models?.status === "reported" &&
+    populated.entry.models.values.includes("zai/glm-5.1") &&
+    populated.entry.models.values.includes("openrouter/z-ai/glm-5.2:free"));
+  h.check("zcode models: provider routing travels with the ids so --model can be built",
+    populated.entry?.models?.providers?.some(
+      (p) => p.name === "openrouter" && p.kind === "openai-compatible" && p.baseURL === "https://openrouter.ai/api/v1") === true);
+  h.check("zcode models: a provider without a baseURL is not offered",
+    !populated.entry?.models?.values?.some((value) => value.startsWith("broken/")) &&
+    !populated.entry?.models?.providers?.some((p) => p.name === "broken"));
+  h.check("zcode models: no API key reaches the discovery report",
+    !populated.stdout.includes(SECRET));
+
+  writeFileSync(join(zcodeConfigDir, "config.json"), `{ not json at all ${CANARY}`);
+  const malformed = runZcodeDiscover();
+  h.check("zcode models: a malformed config reports failed and leaks none of its bytes",
+    malformed.entry?.models?.status === "failed" &&
+    malformed.entry.models.values.length === 0 &&
+    !malformed.stdout.includes(CANARY));
+
   // Keep fixtures inside the repo tree so sandboxed CI/dev runs can write; seed a
   // minimal .git without `git init` (hooks/config writes are often blocked).
   const fleetRoot = mkdtempSync(join(h.testDir, "..", ".tmp-fleet-smoke-"));

--- a/test/relay/zcode.mjs
+++ b/test/relay/zcode.mjs
@@ -166,4 +166,109 @@ export async function runZcode(h) {
       value.error?.includes("version preflight") &&
       value.error?.includes("was not dispatched"));
   }
+
+  // --- model selection -------------------------------------------------------
+  // ZCode has no --model flag: the relay generates a config in a per-run home and
+  // repoints the child's home at it. The key must come from the environment, so
+  // these assert the generated file never carries one.
+  const modelTriple = [
+    "--model", "openrouter/z-ai/glm-5.2:free",
+    "--model-base-url", "https://openrouter.ai/api/v1",
+    "--model-kind", "openai-compatible",
+  ];
+  const modelKeyEnv = { OPENROUTER_API_KEY: "smoke-not-a-real-key" };
+
+  // h.baseEnv inherits the host environment, so the no-key case must delete the
+  // candidate variables rather than merely not set them: a machine that exports
+  // ZCODE_API_KEY for its own ZCode install would otherwise satisfy the check and
+  // red this test on someone else's machine. Deleted, not set to undefined —
+  // Node stringifies undefined into the child environment.
+  const strippedEnv = () => {
+    const env = { ...h.baseEnv };
+    for (const name of ["OPENROUTER_API_KEY", "ZCODE_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"]) {
+      delete env[name];
+    }
+    return env;
+  };
+
+  for (const [label, extra, env] of [
+    ["--model without its two companions", ["--model", "openrouter/z-ai/glm-5.2:free"], { ...h.baseEnv, ...modelKeyEnv }],
+    ["--model-kind without --model", ["--model-kind", "openai-compatible"], { ...h.baseEnv, ...modelKeyEnv }],
+    ["an unqualified model id", [...modelTriple.slice(0, 1), "glm-5.2", ...modelTriple.slice(2)], { ...h.baseEnv, ...modelKeyEnv }],
+    ["an unknown provider kind", [...modelTriple.slice(0, 4), "--model-kind", "not-a-kind"], { ...h.baseEnv, ...modelKeyEnv }],
+    ["a non-http base URL", [...modelTriple.slice(0, 2), "--model-base-url", "file:///etc/passwd", ...modelTriple.slice(4)], { ...h.baseEnv, ...modelKeyEnv }],
+    ["--model with --session", [...modelTriple, "--session", "sess_prior-0"], { ...h.baseEnv, ...modelKeyEnv }],
+    ["--model with --resume-last", [...modelTriple, "--resume-last"], { ...h.baseEnv, ...modelKeyEnv }],
+    ["--model with no key anywhere in the environment", modelTriple, strippedEnv()],
+  ]) {
+    const rejectOutDir = join(h.scratch, `out-model-reject-${label.replace(/[^a-z0-9]+/gi, "-")}`);
+    const rejected = spawnSync(process.execPath, [
+      h.relayPath("zcode"), "--brief", h.briefPath, "--cd", workDir,
+      "--out-dir", rejectOutDir, ...extra,
+    ], { env, encoding: "utf8" });
+    h.check(`zcode model: ${label} is rejected before artifacts`,
+      rejected.status === 2 && !existsSync(rejectOutDir));
+  }
+
+  const modelOutDir = join(h.scratch, "out-model-zcode");
+  const modelEnvFile = join(h.scratch, "env-model-zcode");
+  const modelRun = spawnSync(process.execPath, [
+    h.relayPath("zcode"), "--brief", h.briefPath, "--cd", workDir,
+    "--out-dir", modelOutDir, ...modelTriple,
+  ], {
+    env: {
+      ...h.baseEnv, ...modelKeyEnv,
+      SMOKE_MODE: "capture", SMOKE_ARGS_FILE: join(h.scratch, "args-model-zcode"),
+      SMOKE_ENV_FILE: modelEnvFile,
+    },
+    encoding: "utf8",
+  });
+  h.check("zcode model: a complete triple dispatches", modelRun.status === 0);
+
+  const generatedConfig = join(modelOutDir, "zcode-home", ".zcode", "cli", "config.json");
+  h.check("zcode model: the generated config lands in a per-run home",
+    existsSync(generatedConfig));
+  if (existsSync(generatedConfig)) {
+    const raw = readFileSync(generatedConfig, "utf8");
+    const parsed = JSON.parse(raw);
+    // apiKeyRequired is expected and says only that a key is needed; an
+    // "apiKey" field, or the key's value, must never be written.
+    h.check("zcode model: the generated config carries no key of any kind",
+      !/"apiKey"\s*:/.test(raw) &&
+      !raw.includes("smoke-not-a-real-key") &&
+      parsed.provider.openrouter.options.apiKey === undefined);
+    h.check("zcode model: provider routing and the model are pinned",
+      parsed.model.main === "openrouter/z-ai/glm-5.2:free" &&
+      parsed.provider.openrouter.kind === "openai-compatible" &&
+      parsed.provider.openrouter.options.baseURL === "https://openrouter.ai/api/v1" &&
+      parsed.provider.openrouter.options.apiKeyRequired === true &&
+      // The model id keeps every segment after the FIRST slash.
+      Object.keys(parsed.provider.openrouter.models)[0] === "z-ai/glm-5.2:free");
+  }
+
+  const childEnvSeen = existsSync(modelEnvFile) ? JSON.parse(readFileSync(modelEnvFile, "utf8")) : {};
+  const expectedHome = join(modelOutDir, "zcode-home");
+  h.check("zcode model: the child's home is repointed on both platform variables",
+    childEnvSeen.HOME === expectedHome && childEnvSeen.USERPROFILE === expectedHome);
+
+  if (existsSync(join(modelOutDir, "result.json"))) {
+    const value = h.result(modelOutDir);
+    h.check("zcode model: the pinned model and its home are recorded in the result",
+      value.model === "openrouter/z-ai/glm-5.2:free" && value.modelHome === expectedHome);
+  }
+
+  const plainOutDir = join(h.scratch, "out-model-absent-zcode");
+  spawnSync(process.execPath, [
+    h.relayPath("zcode"), "--brief", h.briefPath, "--cd", workDir, "--out-dir", plainOutDir,
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "zcode-success" },
+    encoding: "utf8",
+  });
+  if (existsSync(join(plainOutDir, "result.json"))) {
+    const value = h.result(plainOutDir);
+    h.check("zcode model: a run without --model leaves the home alone and records null",
+      value.model === null &&
+      value.modelHome === null &&
+      !existsSync(join(plainOutDir, "zcode-home")));
+  }
 }

--- a/test/relay/zcode.mjs
+++ b/test/relay/zcode.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export async function runZcode(h) {
@@ -225,9 +225,17 @@ export async function runZcode(h) {
   });
   h.check("zcode model: a complete triple dispatches", modelRun.status === 0);
 
-  const generatedConfig = join(modelOutDir, "zcode-home", ".zcode", "cli", "config.json");
-  h.check("zcode model: the generated config lands in a per-run home",
-    existsSync(generatedConfig));
+  // The home is deliberately outside --out-dir: it becomes live ZCode state
+  // (session db, logs, plugin cache) and --out-dir can point into the repo under
+  // review. result.json names it, which is how the test finds it.
+  const modelResult = existsSync(join(modelOutDir, "result.json")) ? h.result(modelOutDir) : {};
+  const generatedHome = modelResult.modelHome ?? "";
+  const generatedConfig = join(generatedHome, ".zcode", "cli", "config.json");
+  h.check("zcode model: the generated config lands in a per-run home outside the out-dir",
+    generatedHome !== "" &&
+    existsSync(generatedConfig) &&
+    !existsSync(join(modelOutDir, "zcode-home")) &&
+    !generatedHome.startsWith(modelOutDir));
   if (existsSync(generatedConfig)) {
     const raw = readFileSync(generatedConfig, "utf8");
     const parsed = JSON.parse(raw);
@@ -247,15 +255,49 @@ export async function runZcode(h) {
   }
 
   const childEnvSeen = existsSync(modelEnvFile) ? JSON.parse(readFileSync(modelEnvFile, "utf8")) : {};
-  const expectedHome = join(modelOutDir, "zcode-home");
   h.check("zcode model: the child's home is repointed on both platform variables",
-    childEnvSeen.HOME === expectedHome && childEnvSeen.USERPROFILE === expectedHome);
+    generatedHome !== "" &&
+    childEnvSeen.HOME === generatedHome &&
+    childEnvSeen.USERPROFILE === generatedHome);
 
-  if (existsSync(join(modelOutDir, "result.json"))) {
-    const value = h.result(modelOutDir);
-    h.check("zcode model: the pinned model and its home are recorded in the result",
-      value.model === "openrouter/z-ai/glm-5.2:free" && value.modelHome === expectedHome);
-  }
+  h.check("zcode model: the pinned model and its home are recorded in the result",
+    modelResult.model === "openrouter/z-ai/glm-5.2:free" && typeof modelResult.modelHome === "string");
+
+  // Regression: the generated home used to live under --out-dir, so a --model
+  // --read-only run with --out-dir inside the repo filled the worktree with
+  // ZCode's session store and the tripwire reported a violation ZCode had not
+  // caused. The fake writes under the home to stand in for that state.
+  const tripRepo = h.freshRepo("work-zcode-model-tripwire");
+  // freshRepo leaves an empty repository. Commit one file so the tripwire has a
+  // committed baseline: with nothing committed its honest answer is null
+  // ("cannot tell"), and this case is about distinguishing false from true.
+  writeFileSync(join(tripRepo, "tracked.txt"), "committed baseline\n");
+  spawnSync("git", ["-C", tripRepo, "add", "-A"], { encoding: "utf8" });
+  spawnSync("git", [
+    "-C", tripRepo, "-c", "user.email=smoke@example.invalid", "-c", "user.name=smoke",
+    "commit", "-qm", "baseline",
+  ], { encoding: "utf8" });
+  const tripOutDir = join(tripRepo, "relay-run");
+  const tripRun = spawnSync(process.execPath, [
+    h.relayPath("zcode"), "--brief", h.briefPath, "--cd", tripRepo,
+    "--out-dir", tripOutDir, "--read-only", ...modelTriple,
+  ], {
+    env: {
+      ...h.baseEnv, ...modelKeyEnv,
+      SMOKE_MODE: "zcode-success",
+      SMOKE_ARGS_FILE: join(h.scratch, "args-model-tripwire-zcode"),
+      // Written inside the generated home, exactly where ZCode puts its session store.
+      SMOKE_WRITE_IN_HOME: "zcode-session-store.sqlite",
+    },
+    encoding: "utf8",
+  });
+  const tripValue = existsSync(join(tripOutDir, "result.json")) ? h.result(tripOutDir) : {};
+  // touchedFiles still lists the out-dir when it sits inside the repo: it is the
+  // raw porcelain review aid, documented as such. Only the verdict must be right.
+  h.check("zcode model: relay-owned home state does not trip the read-only tripwire",
+    tripRun.status === 0 &&
+    tripValue.readOnlyViolation === false &&
+    !existsSync(join(tripOutDir, "zcode-home")));
 
   const plainOutDir = join(h.scratch, "out-model-absent-zcode");
   spawnSync(process.execPath, [


### PR DESCRIPTION
## What this adds

An orchestrator can now choose the **provider and model** for a single ZCode dispatch, and list the
options first.

```bash
node relay.mjs --brief brief.md --cd /path/to/repo \
  --model openrouter/z-ai/glm-5.2:free \
  --model-base-url https://openrouter.ai/api/v1 \
  --model-kind openai-compatible
```

Two commits, in dependency order: the relay flag, then the discovery that populates the menu for it.

## Why it needs a mechanism at all

ZCode has no `--model` flag. `--model`, `-m`, and `--settings` are all rejected by its parser — as
are `--allowed-tools` and `--max-turns`, which its own `--help` advertises. The model comes from
`<home>/.zcode/cli/config.json` and nowhere else, so before this the model was whatever the user's
global config said, and changing it between dispatches meant hand-editing that file.

The lever is that ZCode derives that path from the process home directory. Pointing it at an empty
one produces `Model config is missing. Create <that path>\.zcode\cli\config.json`, which is the whole
mechanism in one error message.

So `--model` writes a config under `<out-dir>/zcode-home/.zcode/cli/config.json` and launches the
child with `HOME` **and** `USERPROFILE` set to that directory — both, because `os.homedir()` reads a
different one per platform. Without the flag the relay does not touch the home directory at all.

## The credential question, which shaped both commits

`CONTRIBUTING.md`: *no credentials read or written*. Two places wanted to break that, and neither does.

**The relay** could have read the user's own config to learn the provider's endpoint and kind. It
does not — that file holds an API key. The two values come in as explicit flags instead, and a
partial set exits 2. The generated config carries `kind`, `baseURL`, and `apiKeyRequired`, and **no
`apiKey` field**. ZCode resolves the key from the environment itself; the relay only checks that one
of the candidate variables is *present*, and exits 2 naming them when none is. It never reads a value.

**Discovery** does read that config, because it is the only offline listing — but only provider names,
`kind`, `baseURL`, and model ids leave the parser. `options.apiKey` is never dereferenced. A malformed
file returns the same empty `failed` result as a missing one, because V8's JSON parse error embeds the
first bytes of what it read, and here those bytes are a key prefix — the oracle `6ed91b2` closed on
the project config. Iteration is over `Object.keys`, so a provider named `constructor` cannot resolve
to an inherited function, which is the defect `fbdea3e` fixed in the fleet lane lookup.

A test asserts the generated config has no `apiKey` field and does not contain the key's value; another
asserts no key and no malformed-file bytes reach the discovery report.

## Shape of the discovery change

`zcode`'s `modelProbe` was `null`. It is now a **file** probe, as `codex`'s already is — ZCode has no
`models` subcommand, unlike the nine command-driven probes.

`values` are qualified `provider/model`. A bare id is ambiguous across providers, and only the **first**
slash separates the two: openrouter's `nvidia/nemotron-3-ultra-550b-a55b:free` and baseten's
`moonshotai/Kimi-K3` carry their own. `models` gains a sibling `providers: [ { name, kind, baseURL } ]`,
additive and zcode-only — that routing is what `--model` needs alongside the id, and this is the one
place it can be listed without the relay opening a credential file. A provider missing `kind` or
`baseURL` is omitted rather than offered, since dispatching to it could only fail.

`modelFilePath` now guards `probe.envDir` before indexing `process.env`; `codex`'s `CODEX_HOME`
behaviour is unchanged.

## Deliberate limits

- **`--model` is mutually exclusive with `--session` and `--resume-last`**, and exits 2 on the
  combination. ZCode keeps its session store under the same home as the config, so a per-run home
  takes the sessions with it. Refusing beats silently starting a fresh session under a resume flag.
- **`model` is still not a lane dial for `zcode`.** The choice is per dispatch; `schema.md` is unchanged.
- **This rides undocumented ZCode behaviour** — the home-derived config path and the environment
  fallback for the key. Both were verified against 0.16.5 and a ZCode update could change either.
  That is stated in `SKILL.md` and the README footnote rather than implied.
- **A `kind` of `anthropic` puts `ANTHROPIC_API_KEY` in ZCode's own fallback chain**, so a key
  exported for something else would be sent to the named base URL. `SKILL.md` says so and points at
  the `<PROVIDER>_API_KEY` form instead.

## What I ran

Windows, native PowerShell, `zcode` 0.16.5, Node 24.12.0. The Linux leg is CI's.

- `node test/relay-smoke.mjs` — **928 checks, 0 failures**, including the 15 new `zcode model:` and
  5 new `zcode models:` cases.
- `node test/relay-parity.mjs`, `node test/relay-isolated.mjs`, `node test/event-scanner.mjs` — all pass.
- `npx skills add . --list` — 18 skills, package valid.
- **Live `--model` dispatch**: a read-only (`plan`) run pinned to `opencode-zen/mimo-v2.5-free` over an
  `openai-compatible` endpoint completed, driven by the generated config, with the key read by ZCode
  from `OPENCODE_ZEN_API_KEY`. The generated file was inspected afterwards and contained no key.
- **Live discovery**: against a real config of 5 providers and 24 models — every id and its routing
  reported, no key in the output, a keyless provider omitted, and a corrupted file reporting `failed`
  with none of its bytes.
- **Second opinion**: the diff was reviewed by a second implementer dispatched through this very
  feature (`opencode-go/kimi-k3`, read-only), across credential leakage, injection through the three
  flags, parser byte-leakage, and validation bypass. No defects found. Advisory only — the checks
  above are the evidence.

Not run: an `anthropic`-kind provider through these flags (Z.AI quota was exhausted), and no macOS or
Linux run is recorded.

## One test note worth flagging

The "no key anywhere in the environment" rejection case deletes the candidate variables from the
harness environment rather than merely not setting them. `h.baseEnv` inherits the host environment, so
on a machine that exports `ZCODE_API_KEY` — plausible for anyone maintaining this skill — the check
would otherwise be satisfied and the test would red. Confirmed by exporting one and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRwYCJCZtBqeHJs9boUE6c
