### PR TITLE
fix(test): let relay-isolated run from a non-ASCII checkout path

### DIFF
--- a/test/relay-isolated.mjs
+++ b/test/relay-isolated.mjs
@@ -16,7 +16,14 @@ const check = (name, condition) => {
 for (const relay of RELAYS) {
   const temp = mkdtempSync(join(tmpdir(), `delegate-skills-${relay}-`));
   try {
-    cpSync(join(here, "..", "skills", `${relay}-delegate`), join(temp, `${relay}-delegate`), { recursive: true });
+    // The filter is not filtering. It forces cpSync down its JavaScript copy path
+    // instead of the native fsBinding.cpSyncCopyDir, which kills the process on Windows
+    // - exit 0xC0000409, nothing thrown, nothing printed - when the source path contains
+    // any non-ASCII character. The source here is the checkout path, so without this a
+    // contributor whose clone sits under an accented or non-Latin directory sees this
+    // suite exit non-zero having printed nothing at all. Measured on Node v22.23.2 and
+    // v24.14.1, Windows 10.
+    cpSync(join(here, "..", "skills", `${relay}-delegate`), join(temp, `${relay}-delegate`), { recursive: true, filter: () => true });
     const result = spawnSync(process.execPath, ["scripts/relay.mjs", "--help"], {
       cwd: join(temp, `${relay}-delegate`),
       encoding: "utf8",


### PR DESCRIPTION
`test/relay-isolated.mjs` copies each skill directory with `cpSync(..., { recursive: true })`, and the source is the checkout path.

On Windows that call **kills the process outright** — exit `0xC0000409`, nothing thrown, nothing printed — when the source path contains any non-ASCII character. A contributor whose clone sits under an accented or non-Latin directory sees this suite exit non-zero with no output and nothing to go on. It reads as a broken test rather than a broken copy.

`C:\Users\José\...` is enough.

## The change

Passing a `filter` forces `cpSync` down its JavaScript copy path instead of the native `fsBinding.cpSyncCopyDir`, which is where the fault is. The comment says so, because a filter that filters nothing reads as dead code otherwise.

## What I measured

Windows 10 x64, Node **v22.23.2** and **v24.14.1** — identical on both, so this is not a recent regression:

- A clone under a directory named `upstream-é` fails this suite at exit 127 **before** the change and passes **after** it.
- `relay-parity`, `relay-isolated` and `event-scanner` all still pass from an ASCII path.

## Narrowing behind the diagnosis

| Case | Result |
| --- | --- |
| source `é` / `café` / `naïve` / `日本` / `مشاريع`, recursive | process killed, each |
| ASCII source, **destination** named `é` | ok |
| `cpSync` on a file, including one named `é.txt` | ok |
| directory **without** `recursive` | throws `ERR_FS_EISDIR`, correctly |
| `readdirSync` / `statSync` / `readFileSync` / `copyFileSync` / `renameSync` | ok, each |
| **empty** `é` directory, recursive | process killed |
| `fsPromises.cp`, identical arguments | ok |

So it is neither recursion depth nor directory contents, and only the source path matters. Reported upstream on [nodejs/node#63970](https://github.com/nodejs/node/issues/63970), which describes the same native fast path terminating the process on a different trigger.

## Re-verified before opening

2026-09-01, Node v24.14.1, Windows 10. A directory named `café` copied with `cpSync(src, dst, { recursive: true })` exits **127** with nothing thrown and nothing printed. The same call with `filter: () => true` added completes normally. [nodejs/node#63970](https://github.com/nodejs/node/issues/63970) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
