### PR TITLE
feat: add devin-delegate implementer skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,13 @@
 
 This repo is a [Skills CLI](https://github.com/vercel-labs/skills) package of **delegation skills** —
 skills that let an orchestrating agent drive a separate CLI coding agent as an implementer, then review
-and land the result. Seventeen implementer skills ship today: `claude-delegate` (Claude Code),
+and land the result. Eighteen implementer skills ship today: `claude-delegate` (Claude Code),
 `cline-delegate` (Cline CLI), `codex-delegate` (OpenAI Codex), `opencode-delegate` (OpenCode),
 `agy-delegate` (Google Antigravity), `grok-delegate` (Grok Build), `kimi-delegate` (Kimi Code),
 `qoder-delegate` (Qoder CLI), `vibe-delegate` (Mistral Vibe), `cursor-delegate` (Cursor Agent CLI),
 `pi-delegate` (Pi CLI), `omp-delegate` (Oh My Pi), `aider-delegate` (Aider), `copilot-delegate` (GitHub Copilot CLI),
-`warp-delegate` (Warp Agent CLI), `zcode-delegate` (Z.AI ZCode), and `commandcode-delegate` (Command Code); siblings like
+`warp-delegate` (Warp Agent CLI), `zcode-delegate` (Z.AI ZCode), `commandcode-delegate` (Command Code), and
+`devin-delegate` (Devin CLI); siblings like
 `gemini-delegate` can be added
 later without renaming the repo. One **utility** skill
 ships alongside them: `delegate-setup` (configure fleet lanes — setup only, never dispatches).
@@ -21,7 +22,7 @@ jargon. Use these terms; don't invent synonyms.
 | --- | --- | --- |
 | **delegate** / **delegation** | the activity, and this skill family | "relay" (as the activity), "hand-off", "offload" |
 | **orchestrator** | the driving agent (Claude Code, …) | "controller", "driver" |
-| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Oh My Pi, Aider, Copilot, Warp, ZCode, Command Code) | "worker", "sub-agent", "executor" |
+| **implementer** | the separate agent (Claude, Cline, Codex, OpenCode, Antigravity, Grok, Kimi, Qoder, Vibe, Cursor, Pi, Oh My Pi, Aider, Copilot, Warp, ZCode, Command Code, Devin) | "worker", "sub-agent", "executor" |
 | **brief** | the self-contained task spec sent to the implementer | "task file", "the prompt", "the spec" |
 | **gates** | the project's test/lint/build commands | "checks", "CI" |
 | **dispatch** | sending the brief to the implementer | "fire off", "kick off" |
@@ -47,6 +48,7 @@ jargon. Use these terms; don't invent synonyms.
 | `--message-file`, `--yes-always`, `--suggest-shell-commands`, `--auto-commits`/`--dirty-commits`, `--dry-run`, `--edit-format`, `--architect`, `--file`/`--read`, `chat history` | Aider's own terms — use verbatim when discussing `aider` | Aider has no sandbox, no permission modes, and no session ids; don't imply any. `--file`/`--read` scope the chat context — never call them a boundary |
 | `session`, `-p`/`--prompt`, `--output-format json` (JSONL), `tools`, `--allow-all-tools`, `mode plan`, `--resume`/`--continue`, `--model`, `--effort`, `copilot login` / env tokens, `sandbox` (experimental, MXC) | GitHub Copilot CLI's own terms — use verbatim when discussing `copilot` | don't paraphrase them |
 | `mode` (`build`/`edit`/`plan`/`yolo`), `session` (`sess_…`), `goal` (`--target`), `--attach`, `app-server`, `plugins`, `skills` | ZCode's own terms — use verbatim when discussing `zcode` | don't call `mode` a sandbox or a permission mode; never present `build`/`edit` as usable headlessly |
+| `session`, `--continue` / `-c`, `--resume` / `-r`, `--print` / `-p` (print mode), `--prompt-file`, `permission mode` (`normal`/`accept-edits`/`smart`/`dangerous`/`autonomous`), `--sandbox`, `--model`, `--respect-workspace-trust`, `--export` (ATIF), `devin list`, `devin auth` | Devin's own terms — use verbatim when discussing `devin` | don't paraphrase them; never claim the relay uses `--sandbox` or that `autonomous` works headlessly; "Devin" is the local CLI, not Devin Cloud |
 
 Banned on sight: coined umbrella terms in user-facing surfaces (README headings, `skills.sh.json`
 titles); any reference to the author's local machine or config; model/version pins (`GPT-5.x` →
@@ -55,7 +57,7 @@ version a run was made against is what makes the claim checkable; and claims tha
 ("verified" without a run → hedge or cut). Every
 CLI flag, field, and command in the docs must match the installed implementer CLI (`claude` /
 `cline` / `codex` / `opencode` / `agy` / `grok` / `kimi` / `qodercli` / `vibe` / `cursor-agent` / `pi` /
-`aider` / `copilot` / `oz` / `omp` / `zcode` / `cmd`) and the skill's `relay.mjs`.
+`aider` / `copilot` / `oz` / `omp` / `zcode` / `cmd` / `devin`) and the skill's `relay.mjs`.
 
 ## Conventions
 
@@ -96,7 +98,7 @@ CLI flag, field, and command in the docs must match the installed implementer CL
   args, and all value flags are token-validated.
   The `claude` and `cursor-agent` launches serialize a pre-joined
   command string through the shell on win32 for the same shim reason; `agy`, `kimi`, current
-  `qodercli`, `vibe`, `aider`, `oz`, and `omp` installs use native binaries (pip puts a real `aider.exe` in
+  `qodercli`, `vibe`, `aider`, `oz`, `omp`, and `devin` installs use native binaries (pip puts a real `aider.exe` in
   Scripts, so that launch needs no `shell:true`). The `oz` launch must never gain a shell on any
   platform: `oz agent run` takes the brief as its `--prompt` argv value (its `-f/--file` config path
   does not satisfy the required prompt group), and a shell would reinterpret that text. `zcode` is resolved rather than assumed — `--zcode-path`/`ZCODE_CLI`, then PATH, then the

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Skip setup when you want one implementer or one-off dials. Pick the skill for a 
 | [`codex-delegate`](skills/codex-delegate/SKILL.md) | [OpenAI Codex](https://github.com/openai/codex) (`codex`) | `--sandbox workspace-write` | `--read-only` | `--resume-last`, `--session <id>` |
 | [`commandcode-delegate`](skills/commandcode-delegate/SKILL.md) | [Command Code](https://commandcode.ai/docs/headless) (`cmd`; `cmdc` on Windows) | `--yolo` — the only headless write state; no sandbox [^commandcode] | `--read-only` (withheld tools + `plan`) | `--continue-last`, `--session <id>` |
 | [`cursor-delegate`](skills/cursor-delegate/SKILL.md) | [Cursor Agent](https://cursor.com/cli) (`cursor-agent`) | `--force`; `--no-force` withholds command approval | `--read-only` (plan mode) | `--resume-last`, `--session <id>` |
+| [`devin-delegate`](skills/devin-delegate/SKILL.md) | [Devin CLI](https://devin.ai/docs) (`devin`) | `--permission-mode smart` default; `dangerous` opt-in; no `--sandbox` [^devin] | `--read-only` (`--permission-mode normal` — headless rejects writes/exec) | `--resume-last` (`--continue`), `--session <id>` (`--resume`) |
 | [`grok-delegate`](skills/grok-delegate/SKILL.md) | Grok Build (`grok`) | workspace-scoped; `--full-access` opt-in | `--read-only` — best-effort [^grok] | `--resume-last`, `--session <id>` |
 | [`kimi-delegate`](skills/kimi-delegate/SKILL.md) | [Kimi Code](https://moonshotai.github.io/kimi-code/en/) (`kimi`) | `auto permission mode`, always | — [^none] | `--resume-last`, `--session <id>` |
 | [`opencode-delegate`](skills/opencode-delegate/SKILL.md) | [OpenCode](https://opencode.ai) (`opencode`) | agent `build` (`--model` required) | `--read-only` (agent `plan`) | `--resume-last`, `--session <id>` |
@@ -90,6 +91,13 @@ the brief's path list is guidance, not containment. A worktree isolates the chec
 container or another OS-enforced sandbox is required when writes outside the target tree are
 unacceptable. `touchedFiles` is a review aid based on `git status`; it cannot show ignored files or
 writes outside the repository.
+
+[^devin]: Devin's `--sandbox` forces `autonomous` mode, under which the `edit`/`write` tools still
+prompt. A `--print` run cannot answer a prompt — it rejects the tool and continues — so
+`--sandbox`/`autonomous` is unusable headlessly and this relay never passes `--sandbox`. Default write
+autonomy is `--permission-mode smart`; `dangerous` is the unrestricted opt-in. `accept-edits` alone
+cannot run an implementation (its first gate command is rejected). Canonical names only:
+`normal`/`accept-edits`/`smart`/`dangerous` — not the aliases `auto`/`yolo`/`bypass`.
 
 [^none]: No CLI-enforced read-only mode. `touchedFiles` and the diff are what you review against, not
 a guarantee: they are post-run `git status` in the workspace, so they cannot show ignored files,
@@ -252,6 +260,11 @@ Per skill — platform, CLI version, and what the run exercised:
   `--read-only` touching nothing; `--session <id>` resume applying a delta brief; usage errors exiting
   2. A maintainer-run native macOS plan-mode smoke against the same version captured model, session,
   and usage with no touched files.
+- `devin-delegate` — macOS, `devin` 3000.10.21: contract-tested against the shared smoke matrix.
+  Live `--print` write run against a throwaway git repo created `probe.txt` containing `ok`, with
+  `status: "completed"`, `permissionMode: "smart"`, and a real ATIF `sessionId`. A follow-up
+  `--resume-last` (`--continue`) delta brief appended a second line to that file with the same
+  session id. Native Windows is unverified (docs route Windows through WSL).
 - `grok-delegate` — macOS, `grok` 0.2.101: streaming-json report capture, file-based brief delivery,
   resume; read-only is best-effort by measurement, hence the violation flag.
 - `kimi-delegate` — macOS, `kimi` 0.24.0: headless `-p` edit run, stream-json parsing, and both

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -21,7 +21,8 @@
         "copilot-delegate",
         "warp-delegate",
         "zcode-delegate",
-        "commandcode-delegate"
+        "commandcode-delegate",
+        "devin-delegate"
       ]
     },
     {

--- a/skills/delegate-setup/references/schema.md
+++ b/skills/delegate-setup/references/schema.md
@@ -63,12 +63,18 @@ later-edited project config fails closed until it is reviewed and written again 
 | `copilot` | copilot-delegate | `copilot` | model, effort, timeout, readOnly |
 | `warp` | warp-delegate | `oz` | model, timeout |
 | `zcode` | zcode-delegate | `zcode` | permissionMode, timeout, readOnly |
+| `devin` | devin-delegate | `devin` | model, permissionMode, timeout, readOnly |
 
 ZCode carries its `--mode` as `permissionMode`, and only `plan` and `yolo` are accepted: ZCode also
 documents `build` and `edit`, but a headless run has no permission client, so those two block every
 write tool and exit 0 having changed nothing. ZCode has no `--model` flag — the model is chosen in
 the CLI's own config file — so `model` is not a dial for `zcode` lanes. ZCode also ships its CLI
 inside the desktop app rather than on PATH, so discovery falls back to the installed app bundle.
+
+Devin's `permissionMode` accepts only `normal` / `accept-edits` / `smart` / `dangerous`. `autonomous`
+requires `--sandbox`, under which edit/write tools still prompt — unusable headlessly, and this
+relay never passes `--sandbox`. Aliases `auto` / `yolo` / `bypass` map to those canonical names on
+the CLI; a lane must use the canonical name.
 
 OpenCode uses `variant` for reasoning intensity, not `effort`. Do not write `effort` on an `opencode` lane.
 Oh My Pi (`omp`) uses the lane `effort` dial for omp's `--thinking` (`off`, `auto`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). Do not write `thinking` as a lane field.

--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -41,6 +41,7 @@ import {
   QODER_PERMISSION,
   TIMEOUT_RE,
   ZCODE_MODE,
+  DEVIN_PERMISSION,
 } from "./implementers.mjs";
 
 /** Same ceiling relays use for --timeout (Node setTimeout max ~24.8 days). */
@@ -189,6 +190,13 @@ function validateAutonomyConsistency(implementer, lane, laneName, label) {
   ) {
     return `${label}: lane ${laneName}: readOnly contradicts permissionMode ${JSON.stringify(lane.permissionMode)}`;
   }
+  if (
+    implementer === "devin" &&
+    typeof lane.permissionMode === "string" &&
+    lane.permissionMode !== "normal"
+  ) {
+    return `${label}: lane ${laneName}: readOnly contradicts permissionMode ${JSON.stringify(lane.permissionMode)}`;
+  }
   if (implementer === "cursor" && lane.force === true) {
     return `${label}: lane ${laneName}: readOnly contradicts force true`;
   }
@@ -256,6 +264,9 @@ function validateDialValue(implementer, field, value, laneName, label) {
   if (field === "permissionMode" && implementer === "zcode" && !ZCODE_MODE.includes(value)) {
     return `${label}: lane ${laneName}.permissionMode must be one of: ${ZCODE_MODE.join(", ")}`;
   }
+  if (field === "permissionMode" && implementer === "devin" && !DEVIN_PERMISSION.includes(value)) {
+    return `${label}: lane ${laneName}.permissionMode must be one of: ${DEVIN_PERMISSION.join(", ")}`;
+  }
   if (field === "variant") {
     // OpenCode appends --variant on win32 shell:true; reject cmd metacharacters.
     if (!MODEL_TOKEN.shellSafe.test(value)) {
@@ -288,6 +299,7 @@ function validateModelOrProvider(implementer, field, value, laneName, label) {
     implementer === "omp" ||
     implementer === "opencode" ||
     implementer === "commandcode" ||
+    implementer === "devin" ||
     // codex (and any other win32 shell:true relay) must not accept cmd metacharacters in -m.
     implementer === "codex" ||
     IMPLEMENTER_BY_KEY[implementer]?.winShell

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -380,6 +380,21 @@ export const IMPLEMENTERS = Object.freeze([
     winShell: false,
 
   },
+  {
+    key: "devin",
+    skill: "devin-delegate",
+    binary: "devin",
+    versionArgs: ["version"],
+    versionFallbackArgs: ["--version"],
+    authProbe: { args: ["auth", "status"], successPattern: /logged in/i, failPattern: /not logged in|logged out/i },
+    // `devin models list --format json` exists but no list format parses the
+    // families/aliases JSON yet — document `devin models list` for users.
+    modelProbe: null,
+    // Sessions live in ~/.local/share/devin/cli/sessions.db (sqlite) — no honest file count.
+    usageProbe: null,
+    supports: ["model", "permissionMode", "timeout", "readOnly"],
+    winShell: false,
+  },
 ]);
 
 /** Prototype-free map so names like "toString" cannot pass as implementers. */
@@ -411,6 +426,12 @@ export const QODER_PERMISSION = Object.freeze([
  * the same reason, so a lane must not be able to select one either.
  */
 export const ZCODE_MODE = Object.freeze(["plan", "yolo"]);
+/**
+ * Devin's --permission-mode. `autonomous` is excluded — it needs `--sandbox`, and
+ * in sandbox sessions edit/write tools still prompt, which headless runs cannot
+ * answer. Aliases `auto`/`yolo`/`bypass` excluded — canonical names only.
+ */
+export const DEVIN_PERMISSION = Object.freeze(["normal", "accept-edits", "smart", "dangerous"]);
 /** Positive h/m/s duration, same shape relays accept. */
 export const TIMEOUT_RE = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/;
 

--- a/skills/delegate-setup/scripts/lane.mjs
+++ b/skills/delegate-setup/scripts/lane.mjs
@@ -105,6 +105,10 @@ function normalizeDials(implementerKey, raw) {
     if (dials.permissionMode === undefined) dials.permissionMode = "plan";
     delete dials.readOnly;
   }
+  if (implementerKey === "devin" && dials.readOnly === true) {
+    if (dials.permissionMode === undefined) dials.permissionMode = "normal";
+    delete dials.readOnly;
+  }
   if (implementerKey === "omp" && typeof dials.effort === "string") {
     dials.thinking = dials.effort;
     delete dials.effort;

--- a/skills/devin-delegate/SKILL.md
+++ b/skills/devin-delegate/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: devin-delegate
+description: >-
+  Delegate a coding task to the local Devin CLI (`devin`, Cognition's terminal agent) as a
+  background implementer, then review its diff and land it yourself. Use this whenever the user
+  wants to hand implementation work to the local Devin CLI — phrasings like "delegate to Devin",
+  "have Devin do X", "run it through Devin", "use the Devin CLI to implement/fix/refactor", or "have
+  devin CLI do this" — or to run a queue of coding tasks through Devin while staying the reviewer.
+  Prefer it when the user will review the diff and commit it themselves. This skill drives the
+  local `devin` binary, not Devin Cloud. DO NOT USE for Devin Cloud, for tasks small enough to do
+  inline, or when the user wants the code written directly without delegating.
+license: MIT
+compatibility: Requires the `devin` CLI (Cognition's local terminal agent) installed and authenticated (`devin auth login`, or `devin setup`), Node 18+, and git. The orchestrating agent must be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows). Native Windows is unverified (docs route Windows through WSL).
+metadata:
+  version: 0.5.0
+---
+
+# Devin Delegate
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the local Devin CLI (`devin`) — then review what it produced and land it yourself.
+You write the brief and own the judgment; Devin does the typing under an explicit permission mode;
+you verify and commit.
+
+This is the **local** `devin` binary, not Devin Cloud. Nothing here is specific to one orchestrating
+agent. The loop needs only the ability to run a shell command and read a file, so it works the same
+whether you are Claude Code, Cursor, OpenCode with a selected model, or any comparable agent.
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `devin` CLI is not installed or not authenticated (`devin auth status` should print
+  `Logged in (via Devin).`).
+- The user asked for Devin Cloud, not the local terminal agent.
+- You want to write the code yourself, or you only need a review without an implementer run.
+
+## Prerequisites (check once)
+
+1. `devin version` (or `devin --version`) succeeds. If not, install via the Devin CLI installer
+   ([devin.ai/docs](https://devin.ai/docs)), then authenticate with `devin auth login` (or
+   `devin setup`). `devin update` exists for later upgrades. There is no npm package to install.
+2. **Confirm which `devin` is on PATH.** `command -v devin` shows the active binary and `devin version`
+   its version — the relay records the version it ran into `result.json`, so a stale binary is
+   visible after the fact.
+3. You are in (or will point `--cd` at) the target git repository.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Devin sees **only** the text you send — no orchestrator chat history, no shared context. Everything
+the task needs goes in the brief: the goal, the current state, what to change, what to leave
+untouched, the project's **actual** gate commands (discover them from the repo's CLAUDE.md/AGENTS.md/
+Makefile — do not assume), and a report contract. Tell Devin it will **not** commit (you will). Keep
+one task per brief. Full guidance and a template: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to Devin with the bundled helper. It wraps `devin --print`, captures the run, and
+writes a structured `result.json` — so your only job is "run a command, read a file." (`<skill-dir>`
+below is this skill's installed directory — the folder containing this `SKILL.md`, i.e. the
+directory you loaded the skill from. Claude Code prints it as "Base directory for this skill" when
+the skill loads; on other orchestrators use that same directory — if unsure where it landed, run
+`find ~ -name relay.mjs -path '*devin-delegate*'` and substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (writes and exec rejected headlessly): add --read-only
+# continue the previous Devin session:         add --resume-last  (send only the delta brief)
+# hard time limit (watchdog):                   add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
+# see all options:                              node .../relay.mjs --help
+```
+
+The helper defaults to `--permission-mode smart` (the write-capable default that can actually finish
+an implementation under `--print`) and writes its artifacts to a temp dir, so the repo under review
+stays clean. It **never commits** — see step 5. Mechanics, flags, and the `result.json` shape:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Devin finishes, so back it with whatever your orchestrator offers and resume
+when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job`
+  in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a `status`. (A
+  pre-run usage error — bad args or an empty brief — instead exits with code 2 and a stderr message and
+  writes no result file, so check the exit code too. A missing `devin` binary exits 127 but *does*
+  write a `result.json` with status `devin_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and
+the process has exited. Read the working tree, not a status line. The implementer's full report is
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
+`--print` prints only that final assistant response as plain text; there is no event stream.
+
+### 4. Review — do not trust the self-report
+
+Devin's `result.json` includes its own summary and gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did Devin do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+**The orchestrator commits.** Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
+  review again.
+
+## Autonomy model
+
+Devin's default permission mode is `normal` (alias `auto`): read-only tools auto-run, everything else
+prompts. Under `--print`, a tool call that needs approval is **rejected**, not hung — stderr gets
+`warning: rejected a tool call that requires confirmation. Running in non-interactive mode.` and the
+run continues, exiting 0. So `accept-edits` alone cannot run an implementation (its first gate command
+is rejected). The relay therefore always sets `--permission-mode` explicitly, and the write default
+is `smart`:
+
+| Relay flag | What Devin gets | Use when |
+| --- | --- | --- |
+| *(default)* | `--permission-mode smart` | Normal implementation — workspace file edits auto; a fast model auto-runs clearly-safe shell commands and fetches; package installs, mutating git, `rm`/`sudo`/destructive commands still prompt (and under `--print` a prompt is a rejection) |
+| `--read-only` | `--permission-mode normal` | Review / diagnosis — headless `normal` rejects writes **and** exec at the tool boundary. The git tripwire still runs. |
+| `--full-access` | `--permission-mode dangerous` | Unrestricted auto-approve; opt-in. Aliases `yolo`/`bypass` exist on the CLI; this relay accepts only the canonical name. |
+
+`--permission-mode <mode>` is also a direct passthrough (and a fleet-lane dial) for the canonical
+values `normal`, `accept-edits`, `smart`, and `dangerous`. `accept-edits` auto-runs workspace file
+edits and still prompts for shell/fetch — under `--print` those prompts are rejections, so it cannot
+finish a typical implementation. `autonomous` is rejected: it needs `--sandbox`, and in sandbox
+sessions the `edit`/`write` tools still prompt, which a headless run cannot answer.
+
+**This relay never passes `--sandbox`.** `--sandbox` forces `autonomous` mode, and that combination is
+broken headlessly (edit/write still prompt; `--print` rejects them). Do not add it.
+
+`--print` also refuses to start in an untrusted workspace. The relay always passes
+`--respect-workspace-trust false` so a dispatch against a throwaway or newly cloned repo is not
+blocked by that gate.
+
+**`--read-only` is enforced at Devin's tool boundary**, unlike grok's advisory plan mode: headless
+`normal` rejects writes and exec. The relay still reports `readOnlyViolation` from git porcelain plus
+fingerprints of already-dirty Git-visible paths — `true` when either signal proves a change, `false`
+when coverage is complete and detects none, and `null` when coverage is incomplete. Ignored paths,
+submodule internals, perfect restores, and attribution of concurrent changes remain outside it, so
+the diff review stays the guarantee.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report Devin's design decisions, defensible-but-unasked turns, and
+non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if correct
+completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
+is in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief Devin can
+  execute blind: structure, XML blocks, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the rework cycle via `--resume-last`.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.

--- a/skills/devin-delegate/SKILL.md
+++ b/skills/devin-delegate/SKILL.md
@@ -146,6 +146,12 @@ broken headlessly (edit/write still prompt; `--print` rejects them). Do not add 
 `--respect-workspace-trust false` so a dispatch against a throwaway or newly cloned repo is not
 blocked by that gate.
 
+The child environment removes only inherited `WINDSURF_API_KEY`. Windsurf terminals inject that
+variable; Devin's ACP agent prefers it over the stored `devin auth` login and then fails with
+`failed to start ACP agent session`. Every other entry is preserved, and version preflight uses
+the same environment. A user who deliberately sets `WINDSURF_API_KEY` for Devin has it ignored by
+the relay and should use `devin auth login` instead.
+
 **`--read-only` is enforced at Devin's tool boundary**, unlike grok's advisory plan mode: headless
 `normal` rejects writes and exec. The relay still reports `readOnlyViolation` from git porcelain plus
 fingerprints of already-dirty Git-visible paths — `true` when either signal proves a change, `false`

--- a/skills/devin-delegate/references/dispatch-and-poll.md
+++ b/skills/devin-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,182 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `devin --print` (print mode), runs the brief
+under an explicit permission mode, captures everything, and writes a structured `result.json`.
+Your job collapses to: run one command, then read one file. Everything Devin-specific lives in
+the helper, which is what keeps the loop portable across orchestrators.
+
+This is the **local** `devin` binary, not Devin Cloud.
+
+## Before the first run: check the binary
+
+Two gotchas, both worth 30 seconds:
+
+```bash
+command -v devin      # the active binary
+devin version         # or `devin --version`; recorded into result.json
+devin auth status     # expect: Logged in (via Devin).
+```
+
+List available models with `devin models list` (JSON is `devin models list --format json`). `--model`
+accepts fuzzy names and aliases (e.g. `opus`).
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for Devin (default: current directory). The child process cwd pins the workspace. |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Devin model (default: Devin's own configured default). Fuzzy names and aliases are accepted. |
+| `--permission-mode <m>` | Direct passthrough: `normal` \| `accept-edits` \| `smart` \| `dangerous`. Canonical names only. |
+| `--read-only` | Review/diagnosis (`--permission-mode normal`). Headless `normal` rejects writes and exec. The relay also reports a tri-state Git-visible change tripwire. |
+| `--full-access` | Unrestricted auto-approve (`--permission-mode dangerous`); opt-in. |
+| `--resume-last` | Continue the most recent Devin session for this cwd (`devin --continue`); send only the delta brief. |
+| `--session <id>` | Continue a specific session id (`devin --resume <id>`); mutually exclusive with `--resume-last`. |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Default autonomy (neither `--read-only` nor `--full-access`) is **`--permission-mode smart`**. Devin's
+native default is `normal`, which rejects every write and exec under `--print`; the relay always
+sets the mode explicitly.
+
+`--sandbox` is never passed. It forces `autonomous` mode, and in autonomous sessions the `edit` /
+`write` tools still prompt — a `--print` run cannot answer, so those tools are rejected and the run
+continues having changed nothing. `--permission-mode autonomous` and the aliases `auto` / `yolo` /
+`bypass` are rejected the same way: use the canonical names.
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only Devin's edits and nothing of the helper's own.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `tool` — `"devin"`
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `devin_unavailable`
+- `exitCode` — mirrors Devin's exit code; `128` plus the signal number if the child was killed; `127` if `devin` isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
+- `signal` — the signal that killed the child, otherwise `null`
+- `devinVersion` — the binary that actually ran
+- `sessionId` — from the ATIF export's `session_id` after the run (or the `--session` id you passed, if the export is missing). Feed this to a later `--session <id>` (or use `--resume-last`)
+- `finalMessage` — Devin's own final report (the `<structured_output_contract>` you asked for): trimmed `--print` stdout
+- `usage` — always `null`; `--print` has no token event stream, and sessions live in a sqlite `sessions.db` with no honest per-session file count
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report; `[]` means git ran and the tree is clean
+- `briefPath` / `finalPath` / `stderrPath` / `exportPath` — the exact brief relay sent, the captured `--print` stdout, stderr, and the ATIF export (`session.atif.json`) when Devin wrote one
+- `workdir`, `autonomy`, `permissionMode`, `model`, `resumeLast`, `startedAt`, `finishedAt`
+- `readOnlyViolation` — present on dispatched `--read-only` (and `--permission-mode normal`) runs: `true` when parsed git porcelain or the working-tree/index fingerprint of an already-dirty Git-visible path proves a change; `false` when coverage is complete and detects none; `null` when coverage is incomplete. Ignored paths, submodule internals, perfect restores, and attribution remain outside it — the diff review, not this flag, is the guarantee
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `devin_unavailable`, and launch failures
+- `error` — present on a launch failure, and on `timeout` and `aborted` runs
+
+There is **no** `events.jsonl`. `--print` emits only the final assistant response as plain text.
+
+The helper also prints a summary to stdout and exits with Devin's exit code, so a wrapping script
+can branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until Devin finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job` in PowerShell,
+  `start /b` in cmd). A run is done when `result.json` exists with a `status`. **But** a pre-run usage
+  error (bad args, empty brief) exits with code 2 *before* writing any file — so check the exit code
+  too, don't only watch for the file. (A missing `devin` binary exits 127 but *does* write a
+  `result.json` with status `devin_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: devin_unavailable` (exit 127):** `devin` isn't on PATH or isn't found. Install via the
+  Devin CLI installer and `devin auth login`, then re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `devin version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
+  Devin was never dispatched; only the relay's own artifacts may already exist under `--out-dir`.
+  Check the install by running `devin version` yourself.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to Devin. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `stderr.txt` directly.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
+- **`status: failed`:** read `result.json`'s `stderrTail` and `stderr.txt` for the cause.
+  Common causes: an auth lapse (`devin auth status`), an untrusted workspace (the relay already
+  passes `--respect-workspace-trust false`), an invalid `--model`, or a permission-mode rejection
+  (look for `rejected a tool call that requires confirmation` — that run needed `smart` or
+  `dangerous`, not `accept-edits`). Fix the cause and re-dispatch; don't paper over it by doing the
+  work yourself unless that's what the user wants.
+- **Empty `finalMessage`:** Devin exited before printing a final response. Treat as a failed run;
+  `stderr.txt` usually shows where it stopped.
+- **`sessionId` is `null`:** `--print` does not print a session id on stdout. The relay always
+  passes `--export <outDir>/session.atif.json` and reads `session_id` from that file. If the file
+  is missing or unparseable, the id is null (unless you passed `--session`). Do not guess from
+  `devin list` — concurrent runs in the same workdir make newest-entry guessing wrong.
+
+## Recovering lost work
+
+`--print` has no event stream to reconstruct from. If finished work is lost — the run killed late,
+or the working tree damaged afterward — inspect the working tree and `stderr.txt` before
+re-dispatching. The ATIF export (`session.atif.json`) records `session_id`, `steps`, and
+`final_metrics` when Devin wrote it; treat any reconstruction as unverified until it matches a
+working-tree diff. When the tree still holds the work, preserve the tree rather than replaying
+anything.
+
+## What the helper is doing (and the alternatives)
+
+Under the hood the helper runs roughly:
+
+```bash
+# fresh run (default smart permission mode)
+devin --print --respect-workspace-trust false --permission-mode smart \
+  --export <out>/session.atif.json --prompt-file <brief.txt>
+
+# resume most recent session for this cwd
+devin --print --respect-workspace-trust false -c --permission-mode smart \
+  --export <out>/session.atif.json --prompt-file <delta.txt>
+
+# resume a specific session
+devin --print --respect-workspace-trust false -r <id> --permission-mode smart \
+  --export <out>/session.atif.json --prompt-file <delta.txt>
+```
+
+No positional prompt is passed: bare positionals are parsed as `[PATH]...` and conflict with
+`--print`'s optional `PROMPT` argument. The brief is always `--prompt-file`. Autonomy flags are
+re-passed on resume because headless permission mode may not inherit.
+
+**Prompt delivery:** `--prompt-file`, never argv and never stdin — so the brief stays out of the host
+process list, isn't bounded by the OS argument-length cap, and a brief that begins with `-` can't
+be misread as a flag. The relay writes the brief you pass (via `--brief` or stdin) to a file and
+points `--prompt-file` at it.
+
+Two alternatives exist if you ever want them, but the helper is the recommended path:
+
+- **Raw `devin --print --prompt-file`** — fine for one-offs; you give up the captured `result.json`,
+  touched-files summary, ATIF session-id extraction, and the `--respect-workspace-trust false` pin
+  the helper does for you.
+- **Interactive `devin`** — the TUI. Out of scope for this skill; print mode is the path the relay
+  drives.
+
+## The commit boundary
+
+The helper never commits — by design, not omission. The robust contract is: Devin edits the working
+tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/devin-delegate/references/dispatch-and-poll.md
+++ b/skills/devin-delegate/references/dispatch-and-poll.md
@@ -20,6 +20,11 @@ devin auth status     # expect: Logged in (via Devin).
 List available models with `devin models list` (JSON is `devin models list --format json`). `--model`
 accepts fuzzy names and aliases (e.g. `opus`).
 
+The relay strips inherited `WINDSURF_API_KEY` from the child environment (Windsurf terminals inject
+it; Devin's ACP agent prefers it over the stored `devin auth` login and then fails). Running `devin`
+by hand from a Windsurf terminal needs `unset WINDSURF_API_KEY` (or
+`env -u WINDSURF_API_KEY devin ...`).
+
 ## Dispatching
 
 ```bash
@@ -120,11 +125,12 @@ process has exited and `result.json` is written — not when a status line says 
   or a supervisor timeout, not an implementer error. Free up host memory or split the task into
   smaller briefs, then re-dispatch.
 - **`status: failed`:** read `result.json`'s `stderrTail` and `stderr.txt` for the cause.
-  Common causes: an auth lapse (`devin auth status`), an untrusted workspace (the relay already
-  passes `--respect-workspace-trust false`), an invalid `--model`, or a permission-mode rejection
-  (look for `rejected a tool call that requires confirmation` — that run needed `smart` or
-  `dangerous`, not `accept-edits`). Fix the cause and re-dispatch; don't paper over it by doing the
-  work yourself unless that's what the user wants.
+  Common causes: an auth lapse (`devin auth status`), `failed to start ACP agent session` from an
+  inherited `WINDSURF_API_KEY` when Devin is launched outside the relay, an untrusted workspace
+  (the relay already passes `--respect-workspace-trust false`), an invalid `--model`, or a
+  permission-mode rejection (look for `rejected a tool call that requires confirmation` — that run
+  needed `smart` or `dangerous`, not `accept-edits`). Fix the cause and re-dispatch; don't paper
+  over it by doing the work yourself unless that's what the user wants.
 - **Empty `finalMessage`:** Devin exited before printing a final response. Treat as a failed run;
   `stderr.txt` usually shows where it stopped.
 - **`sessionId` is `null`:** `--print` does not print a session id on stdout. The relay always

--- a/skills/devin-delegate/references/multi-task-queues.md
+++ b/skills/devin-delegate/references/multi-task-queues.md
@@ -1,0 +1,67 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential.
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. Each fresh dispatch starts a **new** Devin session with no memory of
+the earlier run (unless you deliberately `--resume-last` / `--session`), so a constraint that emerged
+in task 2 must be restated in task 5's brief or it won't hold. This is the queue equivalent of keeping
+briefs self-contained.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions Devin made, non-blocking nitpicks, anything you want the
+  human to overrule or confirm. This is the section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/devin-delegate/references/review-and-land.md
+++ b/skills/devin-delegate/references/review-and-land.md
@@ -1,0 +1,135 @@
+# Review and land
+
+Devin did the typing; you own the judgment. This is where delegation earns its keep or quietly ships a
+mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
+reality, never against the self-report — and read the diff as generated code, which fails in ways a
+green gate can't see.**
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries Devin's own claim that the gates passed. Treat that as a claim, not evidence —
+re-run the project's actual test/lint/build commands in the working tree and read the output. And keep
+the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a gate,
+not just misreport it — that is what the test check above and the sweep below exist to catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+For `--read-only`, treat `readOnlyViolation: true` as proof of a detected Git-visible change and
+`null` as incomplete coverage. `false` does not cover ignored paths, submodule internals, perfect
+restores, or attribution; inspect the actual diff. Headless `--permission-mode normal` rejects writes
+and exec at the tool boundary, so a violation is unexpected — look at the tree before trusting the
+run.
+
+- **Scope creep** — did Devin change things the brief said to leave untouched? Unasked refactors,
+  renames, "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version?
+- **Quiet judgment calls** — sometimes Devin makes a defensible decision the brief didn't anticipate.
+  Don't just accept it because it looks reasonable; understand it and decide.
+- **Rejected tool calls** — under `--print`, a prompt is a rejection and the run can still exit 0.
+  If `stderr.txt` contains `rejected a tool call that requires confirmation`, the report may describe
+  work that never happened. Check the diff, not the narration.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If Devin couldn't implement something,
+  the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to Devin as a delta brief (below) or gets fixed in the tree before
+commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never Devin. This isn't a
+workaround for a missing feature; it's the deliberate boundary. Committing should be the act of the
+party that verified the work. Write a clear message describing what landed. If your project attributes
+co-authorship, that's the place for it.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same Devin session with
+just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
+
+`--resume-last` keeps Devin's context from the first run (via `devin --continue` / `-c`), so a short
+delta is enough. To resume a specific session from `result.json`'s `sessionId`, pass `--session <id>`
+instead (`devin --resume` / `-r`). Then review again — rework gets the same gate-rerun, test check,
+diff-read, and sweep as the original, no shortcuts. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** Devin made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or Devin's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/devin-delegate/references/writing-the-brief.md
+++ b/skills/devin-delegate/references/writing-the-brief.md
@@ -1,0 +1,122 @@
+# Writing the brief
+
+A brief is the entire task as Devin will see it. Devin runs in a fresh process with **no memory of
+your conversation, no access to your prior notes, and no shared context** — only the text you send and
+whatever it can read from the working tree (including the repo's own `AGENTS.md` when present).
+If a constraint isn't in the brief or discoverable in the repo, it doesn't exist for Devin. The
+single most common failure is a brief that assumes context Devin doesn't have.
+
+## The shape that works
+
+State the task, what "done" looks like, how to behave by default, and the few constraints that
+actually matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps Devin from
+wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences), tell Devin in the brief not to edit anything, and run with `--read-only`
+  (`--permission-mode normal`). Headless `normal` rejects writes and exec at the tool boundary; still
+  verify `touchedFiles` after the run.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`CLAUDE.md` / `AGENTS.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you a Devin that guesses — or skips.
+
+The default write mode is `--permission-mode smart`: workspace edits auto-run, and a fast model
+auto-runs clearly-safe shell commands and fetches. Package installs, mutating git, `rm`/`sudo`, and
+destructive commands still prompt — and under `--print` a prompt is a **rejection**, not a hang.
+Name the gate commands in the brief, and do not ask Devin to `git commit`. If a task needs
+unrestricted tools, that is `--full-access` (`--permission-mode dangerous`), an explicit opt-in.
+
+## Honor the repo's conventions
+
+House rules in the repo (style, forbidden patterns, commit conventions) already apply when Devin reads
+them. If the project forbids certain things in code — say, spec/ticket IDs in comments, process
+language like "MVP"/"for now"/"phase N", or specific test conventions — restate the load-bearing ones
+in the brief too, because compliance is only as reliable as what's in front of the implementer.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and
+suggest a roadmap" produces a muddled run; split it into separate dispatches. One brief → one Devin
+run → one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/devin-delegate/scripts/relay.mjs
+++ b/skills/devin-delegate/scripts/relay.mjs
@@ -38,6 +38,11 @@
  * refuses untrusted workspaces; the relay always passes
  * `--respect-workspace-trust false`.
  *
+ * The child environment removes only inherited WINDSURF_API_KEY (injected by
+ * Windsurf terminals; Devin's ACP agent prefers it over the stored `devin auth`
+ * login and fails with `failed to start ACP agent session`). Every other entry
+ * is preserved. Version preflight uses the same environment.
+ *
  * The brief is handed to Devin via `--prompt-file`, never argv and never as a
  * positional: bare positionals are `[PATH]...` and conflict with `--print`'s
  * optional PROMPT arg. `--prompt-file` keeps the brief out of the host process
@@ -315,6 +320,18 @@ function versionProbeTimeout(opts) {
   return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
 }
 
+function childEnvironment() {
+  const env = { ...process.env };
+  if (process.platform === "win32") {
+    for (const key of Object.keys(env)) {
+      if (key.toUpperCase() === "WINDSURF_API_KEY") delete env[key];
+    }
+  } else {
+    delete env.WINDSURF_API_KEY;
+  }
+  return env;
+}
+
 function devinVersion(probeTimeoutMs) {
   // Native binary on every documented platform (macOS/Linux; Windows native is unverified
   // and docs route it through WSL). Launch without a shell: there is no `.cmd` shim to
@@ -325,6 +342,7 @@ function devinVersion(probeTimeoutMs) {
         encoding: "utf8",
         timeout,
         killSignal: "SIGKILL",
+        env: childEnvironment(),
       }).trim();
       return { version: version || "unknown", error: null };
     } catch (error) {
@@ -767,7 +785,7 @@ function dispatchToDevin(opts, run, writeResult) {
   // Native binary: no shell. The brief is delivered via --prompt-file (never argv).
   const child = spawn("devin", argv, {
     cwd: opts.cd,
-    env: { ...process.env },
+    env: childEnvironment(),
     stdio: ["ignore", "pipe", "pipe"],
     detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
   });

--- a/skills/devin-delegate/scripts/relay.mjs
+++ b/skills/devin-delegate/scripts/relay.mjs
@@ -183,7 +183,9 @@ function parseArgs(argv) {
       case "--model": opts.model = next(); flagged.add("model"); break;
       case "--permission-mode": opts.permissionMode = next(); flagged.add("permissionMode"); break;
       case "--read-only": opts.autonomy = "read-only"; flagged.add("autonomy"); flagged.add("readOnly"); break;
-      case "--full-access": opts.autonomy = "full-access"; flagged.add("autonomy"); break;
+      // permissionMode is flagged too: an explicit --full-access must override a lane's
+      // permissionMode dial the same way --read-only does, not conflict with it.
+      case "--full-access": opts.autonomy = "full-access"; flagged.add("autonomy"); flagged.add("permissionMode"); break;
       case "--resume-last": opts.resumeLast = true; break;
       case "--session": opts.session = next(); break;
       case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
@@ -867,7 +869,9 @@ function dispatchToDevin(opts, run, writeResult) {
         // the child may flush files during the grace window; refresh the snapshot so the
         // artifact matches the tree the orchestrator will actually find
         const touchedAfterGrace = gitTouchedFiles(opts.cd);
-        writeResult({ ...abortedFields, sessionId: resolvedSessionId(), touchedFiles: touchedAfterGrace, ...readOnlyFlag() });
+        // Re-assemble the report: stdout flushed during the grace window must reach
+        // the final write — with no event stream, this is the only copy.
+        writeResult({ ...abortedFields, sessionId: resolvedSessionId(), finalMessage: assembleFinal(), touchedFiles: touchedAfterGrace, ...readOnlyFlag() });
         process.exit(result.exitCode);
       }, 2000);
     });

--- a/skills/devin-delegate/scripts/relay.mjs
+++ b/skills/devin-delegate/scripts/relay.mjs
@@ -1,0 +1,987 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · devin-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the local Devin CLI (`devin --print`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Devin-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. This is the local `devin` binary, not Devin Cloud.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `devin` and `git`. The `devin` process it
+ * launches does authenticate — exactly as you do at the terminal. Read this
+ * file before you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job —
+ * after it reviews the diff and re-runs the project gates.
+ *
+ * Devin's default permission mode is `normal` (alias `auto`): read-only tools
+ * auto-run, everything else prompts. Under `--print`, a tool that needs approval
+ * is REJECTED, not hung — so `accept-edits` cannot finish an implementation (its
+ * first gate command is rejected). The relay always sets `--permission-mode`:
+ *   default        — `--permission-mode smart` (workspace edits auto; clearly-safe
+ *                     shell/fetch auto; package installs, mutating git, rm/sudo
+ *                     still prompt — and under `--print` a prompt is a rejection)
+ *   --read-only    — `--permission-mode normal` (headless rejects writes AND exec)
+ *   --full-access  — `--permission-mode dangerous` (unrestricted; opt-in)
+ *
+ * `--read-only` is enforced at Devin's tool boundary (headless `normal` rejects
+ * writes and exec). The relay still reports `readOnlyViolation` as true when git
+ * porcelain or an already-dirty Git-visible path proves a change, false when
+ * coverage is complete and detects none, and null when coverage is incomplete. It
+ * cannot attribute a concurrent change to Devin and does not cover ignored paths.
+ *
+ * `--sandbox` is never passed: it forces `autonomous` mode, and in autonomous
+ * sessions the edit/write tools still prompt — broken headlessly. `--print` also
+ * refuses untrusted workspaces; the relay always passes
+ * `--respect-workspace-trust false`.
+ *
+ * The brief is handed to Devin via `--prompt-file`, never argv and never as a
+ * positional: bare positionals are `[PATH]...` and conflict with `--print`'s
+ * optional PROMPT arg. `--prompt-file` keeps the brief out of the host process
+ * list and clear of the OS arg-length cap.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for Devin (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Devin model (default: Devin's own configured default).
+ *   --permission-mode <m>  normal | accept-edits | smart | dangerous
+ *                           (canonical names only; default follows autonomy).
+ *   --read-only             Review/diagnosis (`--permission-mode normal`).
+ *   --full-access           Unrestricted auto-approve (`--permission-mode dangerous`); opt-in.
+ *   --resume-last           Continue the most recent Devin session for this cwd
+ *                           (`devin --continue`); send only the delta brief.
+ *   --session <id>          Continue a specific session id (`devin --resume`); send
+ *                           only the delta brief. Mutually exclusive with --resume-last.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the devin child is killed
+ *                           and result.json gets status "timeout".
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, devinVersion, sessionId (from the ATIF export, for a later
+ *   resume), finalMessage (Devin's own --print report), touchedFiles (git porcelain,
+ *   null if git can't report), and the paths to final.txt, stderr.txt, and
+ *   session.atif.json.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `devin` binary exits 127;
+ * otherwise the exit code mirrors Devin's own (0 success, non-zero failure). If
+ * the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to devin), or devin_unavailable. An
+ * orchestrator that polls for the
+ * file must therefore also treat a non-zero exit with no file as a usage error.
+ */
+
+import { spawn, execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, readdirSync, existsSync, appendFileSync, lstatSync, readlinkSync, openSync, readSync, closeSync, realpathSync, rmSync } from "node:fs";
+import { join, relative, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+import { TextDecoder } from "node:util";
+
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+const AUTONOMY_MODES = new Set(["workspace-write", "read-only", "full-access"]);
+const PERMISSION_MODES = new Set(["normal", "accept-edits", "smart", "dangerous"]);
+const REJECTED_PERMISSION = {
+  autonomous: "--permission-mode autonomous requires --sandbox, under which edit/write tools still prompt; a --print run cannot answer, so this relay never uses autonomous. Use smart (default) or dangerous.",
+  auto: `--permission-mode auto is an alias of normal; pass --permission-mode normal`,
+  yolo: `--permission-mode yolo is an alias of dangerous; pass --permission-mode dangerous`,
+  bypass: `--permission-mode bypass is an alias of dangerous; pass --permission-mode dangerous`,
+};
+
+const IMPLEMENTER_KEY = "devin";
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    permissionMode: null,
+    autonomy: "workspace-write",
+    resumeLast: false,
+    session: null,
+    timeout: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--permission-mode": opts.permissionMode = next(); flagged.add("permissionMode"); break;
+      case "--read-only": opts.autonomy = "read-only"; flagged.add("autonomy"); flagged.add("readOnly"); break;
+      case "--full-access": opts.autonomy = "full-access"; flagged.add("autonomy"); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  // The watchdog is relay-only (the Devin launch has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  if (!AUTONOMY_MODES.has(opts.autonomy)) {
+    fail(`invalid autonomy "${opts.autonomy}"`);
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive");
+  }
+  if (opts.permissionMode !== null) {
+    if (Object.hasOwn(REJECTED_PERMISSION, opts.permissionMode)) {
+      fail(REJECTED_PERMISSION[opts.permissionMode]);
+    }
+    if (!PERMISSION_MODES.has(opts.permissionMode)) {
+      fail(`unsupported --permission-mode: ${opts.permissionMode} (expected: ${[...PERMISSION_MODES].join(", ")})`);
+    }
+  }
+  if (opts.autonomy === "read-only") {
+    if (opts.permissionMode !== null && opts.permissionMode !== "normal") {
+      fail(`--read-only conflicts with --permission-mode ${opts.permissionMode}; read-only runs use Devin's normal mode`);
+    }
+    opts.permissionMode = "normal";
+  } else if (opts.autonomy === "full-access") {
+    if (opts.permissionMode !== null && opts.permissionMode !== "dangerous") {
+      fail(`--full-access conflicts with --permission-mode ${opts.permissionMode}; full-access runs use Devin's dangerous mode`);
+    }
+    opts.permissionMode = "dangerous";
+  } else if (opts.permissionMode === null) {
+    opts.permissionMode = "smart";
+  }
+  // Headless normal is real read-only at the tool boundary; keep the git tripwire.
+  if (opts.permissionMode === "normal") opts.autonomy = "read-only";
+  else if (opts.permissionMode === "dangerous") opts.autonomy = "full-access";
+  // These values reach argv only (native binary, no win32 shell), but keep the same
+  // token shape siblings use so a brief cannot inject flag-like junk.
+  const safeToken = /^[A-Za-z0-9][A-Za-z0-9._:\/-]*$/;
+  for (const flag of ["model", "session"]) {
+    if (opts[flag] !== null && !safeToken.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to devin --print --prompt-file\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once Devin is running, so the preflight needs a bound of its
+  // own: a version probe that never returns would wedge the relay here, before any
+  // result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function devinVersion(probeTimeoutMs) {
+  // Native binary on every documented platform (macOS/Linux; Windows native is unverified
+  // and docs route it through WSL). Launch without a shell: there is no `.cmd` shim to
+  // resolve, and a shell would reinterpret `--prompt-file` contents if it ever leaked.
+  const probe = (argv, timeout = probeTimeoutMs) => {
+    try {
+      const version = execFileSync("devin", argv, {
+        encoding: "utf8",
+        timeout,
+        killSignal: "SIGKILL",
+      }).trim();
+      return { version: version || "unknown", error: null };
+    } catch (error) {
+      if (error?.code === "ENOENT") return { version: null, error: null };
+      // Anything else — a hung probe we killed, or a real non-zero exit — means Devin is
+      // installed but not usable. Reporting that as "unavailable" would send the caller
+      // off to reinstall a binary that is already there.
+      return { version: null, error };
+    }
+  };
+  // Prefer `devin version` (documented subcommand); fall back to `--version` for builds that
+  // only answer the flag. A missing binary and a hung probe are both conclusive, though:
+  // retrying either would only spend the bound a second time.
+  const startedAt = performance.now();
+  const documented = probe(["version"]);
+  if (documented.version || !documented.error || documented.error.code === "ETIMEDOUT") return documented;
+  const remainingMs = Math.floor(probeTimeoutMs - (performance.now() - startedAt));
+  if (remainingMs <= 0) return { version: null, error: { code: "ETIMEDOUT" } };
+  return probe(["--version"], remainingMs);
+}
+
+// Porcelain status alone cannot see every write. A path that is " M file" before a run and
+// " M file" after it produces an identical line, so comparing status lines proves nothing about
+// its contents — which is why the read-only tripwire below fingerprints the already-dirty paths
+// as well. Two sentinels stand for "could not fingerprint"; they are never treated as unchanged.
+const FINGERPRINT_UNREADABLE = "<unreadable>";
+const FINGERPRINT_DIRECTORY = "<directory>";
+
+function gitRepoRoot(cwd) {
+  // Porcelain paths are relative to the repository ROOT, not to the directory git ran in
+  // (--porcelain forces status.relativePaths off). Joining them against a --cd that is a
+  // subdirectory would look for <repo>/src/src/file and find nothing at either end.
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).replace(/\n$/, "") || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitStatusEntries(cwd) {
+  // -z so a path containing a space, a quote, or a newline stays one field rather than being
+  // quoted and escaped; -uall so an untracked directory is expanded into its files, because a
+  // collapsed "?? dir/" line never changes when a file inside it does.
+  try {
+    const output = execFileSync("git", ["status", "--porcelain", "-z", "-uall"], {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const fields = new TextDecoder("utf-8", { fatal: true }).decode(output)
+      .split("\0").filter((field) => field.length > 0);
+    const entries = [];
+    for (let i = 0; i < fields.length; i += 1) {
+      const entry = fields[i];
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      // R and C can sit in EITHER status column, and under -z such an entry is followed by its
+      // origin path as its own unprefixed field. Consume that field in both cases. A rename
+      // origin belongs in the dirty set (the file moved away from it); a copy origin does not,
+      // since a copy source can be a perfectly clean file.
+      const renamed = status.includes("R");
+      const copied = status.includes("C");
+      let origin = null;
+      if (renamed || copied) {
+        i += 1;
+        origin = fields[i] ?? null;
+      }
+      entries.push({ status, path, origin });
+    }
+    return entries;
+  } catch {
+    return null;
+  }
+}
+
+function dirtyPaths(cwd) {
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const paths = [];
+  for (const entry of entries) {
+    paths.push(entry.path);
+    if (entry.status.includes("R") && entry.origin !== null) paths.push(entry.origin);
+  }
+  return paths;
+}
+
+function asciiFold(value) {
+  return value.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+}
+
+function canonicalFilePath(path) {
+  const absolute = resolve(path);
+  let parent;
+  try { parent = realpathSync.native(dirname(absolute)); } catch { return absolute; }
+  const leaf = basename(absolute);
+  const canonical = join(parent, leaf);
+  try { lstatSync(canonical); } catch { return canonical; }
+  try {
+    const entries = readdirSync(parent);
+    if (entries.includes(leaf)) return canonical;
+    const matches = entries.filter((entry) => asciiFold(entry) === asciiFold(leaf));
+    return join(parent, matches.length === 1 ? matches[0] : leaf);
+  } catch {
+    return canonical;
+  }
+}
+
+function gitPathKey(root, path) {
+  let canonicalRoot;
+  try { canonicalRoot = realpathSync.native(root); } catch { canonicalRoot = resolve(root); }
+  const key = relative(canonicalRoot, canonicalFilePath(path));
+  return process.platform === "win32" ? key.replaceAll("\\", "/") : key;
+}
+
+function gitPathIsExcluded(root, path, excluded, foldedExcluded) {
+  return excluded.has(path) ||
+    (foldedExcluded.has(asciiFold(path)) && excluded.has(gitPathKey(root, join(root, path))));
+}
+
+function gitTripwireState(cwd, excludedPaths) {
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return entries.flatMap((entry) => [
+    [entry.status, "path", entry.path],
+    ...(entry.origin === null ? [] : [[entry.status.replace(/[^RC]/g, " "), "origin", entry.origin]]),
+  ]
+    .filter(([, , path]) => !gitPathIsExcluded(root, path, excluded, foldedExcluded)));
+}
+
+function pathFingerprint(absolutePath) {
+  // Identity, not just bytes: a retargeted symlink, a flipped mode bit, or a file replaced by a
+  // directory are all writes, and none of them change file contents.
+  let stats;
+  try {
+    stats = lstatSync(absolutePath);
+  } catch (error) {
+    // Absence is a state, not a failure - it differs from every real fingerprint, so a deletion
+    // or a re-creation still registers. Any other errno means we genuinely cannot tell.
+    return error && error.code === "ENOENT" ? "absent" : FINGERPRINT_UNREADABLE;
+  }
+  if (stats.isSymbolicLink()) {
+    try {
+      return `symlink:${readlinkSync(absolutePath, { encoding: "buffer" }).toString("hex")}`;
+    } catch {
+      return FINGERPRINT_UNREADABLE;
+    }
+  }
+  // A directory in the dirty set is a submodule, whose contents belong to another repository.
+  // Reported as unknown coverage rather than silently passed off as unchanged.
+  if (stats.isDirectory()) return FINGERPRINT_DIRECTORY;
+  if (!stats.isFile()) return FINGERPRINT_UNREADABLE;
+  let fd;
+  try {
+    // Streamed rather than read whole: an unignored multi-gigabyte artifact must not be pulled
+    // into memory just to answer whether it changed.
+    const hash = createHash("sha256");
+    fd = openSync(absolutePath, "r");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      const read = readSync(fd, buffer, 0, buffer.length, null);
+      if (read <= 0) break;
+      hash.update(buffer.subarray(0, read));
+    }
+    return `file:${(stats.mode & 0o7777).toString(8)}:${hash.digest("hex")}`;
+  } catch {
+    return FINGERPRINT_UNREADABLE;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+  }
+}
+
+function gitIndexFingerprints(root, paths) {
+  if (paths.length === 0) return new Map();
+  try {
+    const output = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const wanted = new Set(paths);
+    const prints = new Map(paths.map((path) => [path, []]));
+    for (const field of new TextDecoder("utf-8", { fatal: true }).decode(output).split("\0")) {
+      if (!field) continue;
+      const separator = field.indexOf("\t");
+      if (separator === -1) return null;
+      const path = field.slice(separator + 1);
+      if (wanted.has(path)) prints.get(path).push(field.slice(0, separator));
+    }
+    return prints;
+  } catch {
+    return null;
+  }
+}
+
+function fingerprintPaths(root, paths) {
+  // `complete` goes false the moment one path cannot be fingerprinted, so the caller reports
+  // "unknown" instead of an unearned clean bill of health.
+  const indexPrints = gitIndexFingerprints(root, paths);
+  const prints = new Map();
+  let complete = indexPrints !== null;
+  for (const path of paths) {
+    const file = pathFingerprint(join(root, path));
+    if (file === FINGERPRINT_UNREADABLE || file === FINGERPRINT_DIRECTORY) complete = false;
+    prints.set(path, { file, index: indexPrints?.get(path) ?? null });
+  }
+  return { prints, complete };
+}
+
+function fingerprintDirtyPaths(cwd, excludedPaths) {
+  // Only the already-dirty set is covered. A path that is clean at dispatch and gets written
+  // surfaces as a brand-new porcelain line anyway, and fingerprinting a whole repository per run
+  // would cost far more than the case it covers.
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const paths = dirtyPaths(cwd);
+  if (paths === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return {
+    root,
+    ...fingerprintPaths(root, paths.filter((path) => !gitPathIsExcluded(root, path, excluded, foldedExcluded))),
+  };
+}
+
+function changedDirtyPaths(before) {
+  // Re-fingerprint exactly the baseline paths, not whatever happens to be dirty now: a path the
+  // run newly dirtied is already reported by the porcelain comparison, and letting an unreadable
+  // one of those blind this signal would be a regression, not caution.
+  if (!before) return { changed: [], complete: false };
+  const now = fingerprintPaths(before.root, [...before.prints.keys()]);
+  const changed = [];
+  for (const [path, print] of before.prints) {
+    const current = now.prints.get(path);
+    const fileKnown = print.file !== FINGERPRINT_UNREADABLE && current.file !== FINGERPRINT_UNREADABLE;
+    const fileChanged = fileKnown &&
+      !(print.file === FINGERPRINT_DIRECTORY && current.file === FINGERPRINT_DIRECTORY) &&
+      current.file !== print.file;
+    const indexChanged = print.index !== null && current.index !== null &&
+      JSON.stringify(current.index) !== JSON.stringify(print.index);
+    if (fileChanged || indexChanged) changed.push(path);
+  }
+  return { changed: changed.sort(), complete: before.complete && now.complete };
+}
+
+function readOnlyVerdict(beforeTree, afterTree, beforeFingerprints) {
+  // Three-valued on purpose. Proof of a write settles it even when the other signal is unknown;
+  // only when nothing is proven AND coverage is incomplete is the answer genuinely unknown.
+  // Collapsing that last case to false is the false assurance a tripwire must never give.
+  const changed = changedDirtyPaths(beforeFingerprints);
+  const porcelainMoved =
+    beforeTree !== null && afterTree !== null && JSON.stringify(beforeTree) !== JSON.stringify(afterTree);
+  if (porcelainMoved || changed.changed.length > 0) return true;
+  if (beforeTree === null || afterTree === null || !changed.complete) return null;
+  return false;
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function autonomyFlags(permissionMode) {
+  // Maps the relay's three autonomy modes (and a --permission-mode passthrough)
+  // onto Devin's native --permission-mode. Devin's default is `normal`, which
+  // rejects writes and exec under --print — so every path sets the mode
+  // explicitly. Canonical values only; autonomous is rejected at parse time.
+  return ["--permission-mode", permissionMode];
+}
+
+function buildArgv(opts, run) {
+  // Native binary: paths with spaces ride argv. Never a positional prompt:
+  // `--print [<PROMPT>]` cannot be combined with `[PATH]...`.
+  const argv = [
+    "--print",
+    "--respect-workspace-trust", "false",
+  ];
+
+  if (opts.resumeLast) argv.push("-c");
+  else if (opts.session) argv.push("-r", opts.session);
+
+  // Re-pass autonomy on resume too — headless permission mode may not inherit.
+  argv.push(...autonomyFlags(opts.permissionMode));
+
+  if (opts.model) argv.push("--model", opts.model);
+
+  // Deliver the brief via a file, not argv: keeps it out of the host process
+  // list, isn't bounded by the OS arg-length cap, and a brief that begins with
+  // "-" can't be misread as a flag. prepareRunDir already wrote run.briefPath.
+  argv.push("--export", run.exportPath);
+  argv.push("--prompt-file", run.briefPath);
+  return argv;
+}
+
+function parseExportSessionId(exportPath) {
+  try {
+    const doc = JSON.parse(readFileSync(exportPath, "utf8"));
+    if (typeof doc.session_id === "string" && doc.session_id.trim()) return doc.session_id;
+  } catch {
+    // missing or unparseable export → caller keeps the --session id or null
+  }
+  return null;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only Devin's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    finalPath: join(outDir, "final.txt"),
+    stderrPath: join(outDir, "stderr.txt"),
+    exportPath: join(outDir, "session.atif.json"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  // A reused --out-dir must not advertise the previous run: a poller that races the
+  // dispatch would read the old result.json as if it were this run's, and a preflight
+  // failure or a run with no stdout would publish a finalPath for someone else's report.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  rmSync(run.exportPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "devin",
+      workdir: opts.cd,
+      autonomy: opts.autonomy,
+      permissionMode: opts.permissionMode,
+      model: opts.model,
+      resumeLast: opts.resumeLast,
+      devinVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      stderrPath: run.stderrPath,
+      exportPath: existsSync(run.exportPath) ? run.exportPath : null,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "devin_unavailable", exitCode: 127, signal: null, sessionId: null, finalMessage: "", usage: null, touchedFiles: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `devin` not found on PATH. Install via the Devin CLI installer (https://devin.ai/docs) and run `devin auth login`.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `devin version preflight timed out after ${probeTimeoutMs}ms; Devin was not dispatched`
+    : `devin version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Devin was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    usage: null,
+    touchedFiles: gitTouchedFiles(opts.cd),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToDevin(opts, run, writeResult) {
+  // Headless `normal` rejects writes and exec at the tool boundary; the tripwire
+  // still snapshots the tree so a run that reported clean while the tree moved
+  // cannot hide behind that enforcement.
+  const relayArtifacts = [run.briefPath, run.finalPath, run.resultPath, run.stderrPath, run.exportPath];
+  const beforeTree = opts.autonomy === "read-only" ? gitTripwireState(opts.cd, relayArtifacts) : null;
+  // Working-tree and index state for paths that are ALREADY dirty. Their porcelain lines will not
+  // move if the run edits them, so the line comparison alone cannot see those writes.
+  const beforeFingerprints = opts.autonomy === "read-only" ? fingerprintDirtyPaths(opts.cd, relayArtifacts) : null;
+  // every dispatched result that reports touchedFiles carries the verdict, aborted runs included -
+  // an aborted --read-only review can still have modified the tree
+  const readOnlyFlag = () =>
+    opts.autonomy === "read-only"
+      ? { readOnlyViolation: readOnlyVerdict(beforeTree, gitTripwireState(opts.cd, relayArtifacts), beforeFingerprints) }
+      : {};
+  const argv = buildArgv(opts, run);
+  // Native binary: no shell. The brief is delivered via --prompt-file (never argv).
+  const child = spawn("devin", argv, {
+    cwd: opts.cd,
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = opts.session || null;
+  let stdout = "";
+  const stderrTail = [];
+  let stderrRemainder = "";
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    stdout += stdoutDecoder.write(chunk);
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk); // surface Devin progress live for the orchestrator
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrRemainder + stderrDecoder.write(chunk);
+    const lines = text.split("\n");
+    stderrRemainder = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const flushStreams = () => {
+    stdout += stdoutDecoder.end();
+    const tail = stderrRemainder + stderrDecoder.end();
+    stderrRemainder = "";
+    if (tail.trim()) stderrTail.push(tail.trimEnd());
+    while (stderrTail.length > 20) stderrTail.shift();
+  };
+
+  const assembleFinal = () => {
+    const message = stdout.trim();
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  const resolvedSessionId = () => parseExportSessionId(run.exportPath) || sessionId;
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the Devin child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      flushStreams();
+      const touchedAtAbort = gitTouchedFiles(opts.cd);
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: resolvedSessionId(),
+        finalMessage: assembleFinal(),
+        usage: null,
+        touchedFiles: touchedAtAbort,
+        ...readOnlyFlag(),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; Devin was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        const touchedAfterGrace = gitTouchedFiles(opts.cd);
+        writeResult({ ...abortedFields, sessionId: resolvedSessionId(), touchedFiles: touchedAfterGrace, ...readOnlyFlag() });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    flushStreams();
+    const touchedFiles = gitTouchedFiles(opts.cd);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId: resolvedSessionId(),
+      finalMessage: assembleFinal(),
+      usage: null,
+      touchedFiles,
+      ...readOnlyFlag(),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    flushStreams();
+    const finalMessage = assembleFinal();
+    const touchedFiles = gitTouchedFiles(opts.cd);
+    // A timed-out run is never a success even if Devin handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      sessionId: resolvedSessionId(),
+      finalMessage,
+      usage: null,
+      touchedFiles,
+      ...readOnlyFlag(),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `Devin did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = devinVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+
+  dispatchToDevin(opts, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  Devin ${result.devinVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a Devin error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated Devin (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.readOnlyViolation === null) lines.push("warning: this --read-only run could not be verified - git could not report, or a submodule or unreadable path left coverage incomplete; inspect the working tree directly.");
+  if (result.readOnlyViolation === true) lines.push("warning: a git-visible change was detected during this --read-only run — headless --permission-mode normal rejects writes and exec, so inspect the diff before trusting the run.");
+  lines.push(`autonomy: ${result.autonomy}  ·  permission mode: ${result.permissionMode}`);
+  if (result.resumeLast) lines.push("mode: resumed most recent session (--continue)");
+  else if (result.sessionId && result.status !== "devin_unavailable") {
+    lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  }
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- Devin final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -19,6 +19,12 @@ const versionProbe = args.includes("--version") || args[0] === "version" || args
 if (versionProbe && process.env.SMOKE_PREFLIGHT_ENV_FILE) {
   fs.writeFileSync(process.env.SMOKE_PREFLIGHT_ENV_FILE, JSON.stringify(capturedEnv()));
 }
+if (versionProbe && process.env.SMOKE_DEVIN_PREFLIGHT_ENV_FILE) {
+  fs.writeFileSync(process.env.SMOKE_DEVIN_PREFLIGHT_ENV_FILE, JSON.stringify({
+    windsurfApiKey: process.env.WINDSURF_API_KEY ?? null,
+    smokeSecretToken: process.env.SMOKE_SECRET_TOKEN ?? null,
+  }));
+}
 if (versionProbe && process.env.SMOKE_PREFLIGHT_PID_FILE) {
   fs.writeFileSync(process.env.SMOKE_PREFLIGHT_PID_FILE, String(process.pid));
 }
@@ -212,6 +218,12 @@ if (process.env.SMOKE_MODE === "grok-read-only") {
 }
 if (process.env.SMOKE_MODE === "devin-success") {
   if (process.env.SMOKE_ARGS_FILE) fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
+  if (process.env.SMOKE_CAPTURE_FILE) {
+    fs.writeFileSync(process.env.SMOKE_CAPTURE_FILE, JSON.stringify({
+      windsurfApiKey: process.env.WINDSURF_API_KEY ?? null,
+      smokeSecretToken: process.env.SMOKE_SECRET_TOKEN ?? null,
+    }));
+  }
   const exportAt = args.indexOf("--export");
   if (exportAt !== -1 && args[exportAt + 1]) {
     fs.writeFileSync(args[exportAt + 1], JSON.stringify({

--- a/test/fixtures/fake-cli.cjs
+++ b/test/fixtures/fake-cli.cjs
@@ -210,6 +210,21 @@ if (process.env.SMOKE_MODE === "grok-read-only") {
   console.log(JSON.stringify({ type: "end", sessionId: "grok-session-1" }));
   process.exit(0);
 }
+if (process.env.SMOKE_MODE === "devin-success") {
+  if (process.env.SMOKE_ARGS_FILE) fs.writeFileSync(process.env.SMOKE_ARGS_FILE, JSON.stringify(args));
+  const exportAt = args.indexOf("--export");
+  if (exportAt !== -1 && args[exportAt + 1]) {
+    fs.writeFileSync(args[exportAt + 1], JSON.stringify({
+      schema_version: "ATIF-v1.7",
+      session_id: "devin-session-1",
+      agent: { name: "devin", version: "0.0.0-smoke", model_name: "fake-model" },
+      steps: [],
+      final_metrics: {},
+    }));
+  }
+  console.log("fake devin completed");
+  process.exit(0);
+}
 if (["omp-success", "omp-error"].includes(process.env.SMOKE_MODE)) {
   let brief = "";
   process.stdin.setEncoding("utf8");

--- a/test/fixtures/fake-cli.cs
+++ b/test/fixtures/fake-cli.cs
@@ -9,6 +9,10 @@ class FakeCli {
     var mode = Environment.GetEnvironmentVariable("SMOKE_MODE") ?? "";
     bool versionProbe = Array.IndexOf(args, "--version") >= 0
       || (args.Length > 0 && (args[0] == "version" || args[0] == "changelog"));
+    if (versionProbe) {
+      var preflightEnvFile = Environment.GetEnvironmentVariable("SMOKE_DEVIN_PREFLIGHT_ENV_FILE");
+      if (!String.IsNullOrEmpty(preflightEnvFile)) File.WriteAllText(preflightEnvFile, DevinEnvCapture());
+    }
     if (versionProbe && mode.EndsWith("-version-hang")) {
       Thread.Sleep(Timeout.Infinite);
       return 1;
@@ -103,6 +107,8 @@ class FakeCli {
     if (mode == "devin-success") {
       var argsFile = Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE");
       if (!String.IsNullOrEmpty(argsFile)) File.WriteAllLines(argsFile, args);
+      var captureFile = Environment.GetEnvironmentVariable("SMOKE_CAPTURE_FILE");
+      if (!String.IsNullOrEmpty(captureFile)) File.WriteAllText(captureFile, DevinEnvCapture());
       var exportAt = Array.IndexOf(args, "--export");
       if (exportAt >= 0 && exportAt + 1 < args.Length) {
         File.WriteAllText(args[exportAt + 1], "{\"schema_version\":\"ATIF-v1.7\",\"session_id\":\"devin-session-1\",\"agent\":{\"name\":\"devin\",\"version\":\"0.0.0-smoke\",\"model_name\":\"fake-model\"},\"steps\":[],\"final_metrics\":{}}");
@@ -120,6 +126,12 @@ class FakeCli {
     File.WriteAllText(Environment.GetEnvironmentVariable("SMOKE_PID_FILE"), Process.GetCurrentProcess().Id.ToString());
     Thread.Sleep(Timeout.Infinite);
     return 0;
+  }
+  static string DevinEnvCapture() {
+    var windsurf = Environment.GetEnvironmentVariable("WINDSURF_API_KEY");
+    var sentinel = Environment.GetEnvironmentVariable("SMOKE_SECRET_TOKEN");
+    return "{\"windsurfApiKey\":" + (windsurf == null ? "null" : JsonString(windsurf))
+      + ",\"smokeSecretToken\":" + (sentinel == null ? "null" : JsonString(sentinel)) + "}";
   }
   static string JsonString(string s) {
     if (s == null) s = "";

--- a/test/fixtures/fake-cli.cs
+++ b/test/fixtures/fake-cli.cs
@@ -5,7 +5,7 @@ using System.Threading;
 class FakeCli {
   static int Main(string[] args) {
     // Mirrors the .cjs fake: any probe form, and hang/fail selected by the mode's suffix,
-    // so a native-binary relay (agy, kimi, qoder, vibe, aider, oz, omp) enters the same preflight matrix.
+    // so a native-binary relay (agy, kimi, qoder, vibe, aider, oz, omp, devin) enters the same preflight matrix.
     var mode = Environment.GetEnvironmentVariable("SMOKE_MODE") ?? "";
     bool versionProbe = Array.IndexOf(args, "--version") >= 0
       || (args.Length > 0 && (args[0] == "version" || args[0] == "changelog"));
@@ -98,6 +98,16 @@ class FakeCli {
         Console.WriteLine("{\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"fake omp completed\"}],\"provider\":\"google\",\"model\":\"fake-model\",\"usage\":{\"input\":7,\"output\":2},\"stopReason\":\"stop\"}}");
       }
       Console.WriteLine("{\"type\":\"agent_end\",\"messages\":[]}");
+      return 0;
+    }
+    if (mode == "devin-success") {
+      var argsFile = Environment.GetEnvironmentVariable("SMOKE_ARGS_FILE");
+      if (!String.IsNullOrEmpty(argsFile)) File.WriteAllLines(argsFile, args);
+      var exportAt = Array.IndexOf(args, "--export");
+      if (exportAt >= 0 && exportAt + 1 < args.Length) {
+        File.WriteAllText(args[exportAt + 1], "{\"schema_version\":\"ATIF-v1.7\",\"session_id\":\"devin-session-1\",\"agent\":{\"name\":\"devin\",\"version\":\"0.0.0-smoke\",\"model_name\":\"fake-model\"},\"steps\":[],\"final_metrics\":{}}");
+      }
+      Console.WriteLine("fake devin completed");
       return 0;
     }
     var psi = new ProcessStartInfo {

--- a/test/harness/constants.mjs
+++ b/test/harness/constants.mjs
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode"];
+export const SKILLS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode", "devin"];
 
 export const EXTRA_ARGS = {
   claude: [],
@@ -20,6 +20,7 @@ export const EXTRA_ARGS = {
   warp: [],
   zcode: [],
   commandcode: [],
+  devin: [],
 };
 
 export const WIN = process.platform === "win32";

--- a/test/harness/install-shim.mjs
+++ b/test/harness/install-shim.mjs
@@ -22,7 +22,7 @@ export function installShim(h) {
       join(windir, "Microsoft.NET", "Framework64", "v4.0.30319", "csc.exe"),
       join(windir, "Microsoft.NET", "Framework", "v4.0.30319", "csc.exe"),
     ].find((p) => existsSync(p));
-    h.check("windows: the in-box C# compiler exists (builds the native fake for agy/kimi/qoder/vibe/aider/oz/omp)", Boolean(csc));
+    h.check("windows: the in-box C# compiler exists (builds the native fake for agy/kimi/qoder/vibe/aider/oz/omp/devin)", Boolean(csc));
     if (csc) {
       const csFile = join(shimDir, "fake-cli.cs");
       copyFileSync(join(fixturesDir, "fake-cli.cs"), csFile);
@@ -37,6 +37,9 @@ export function installShim(h) {
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "aider.exe"));
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "oz.exe"));
         copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "omp.exe"));
+        // Devin is a native binary (docs cover macOS/Linux; Windows native is unverified
+        // and there is no `.cmd` shim assumption), so the fake must be an .exe too.
+        copyFileSync(join(shimDir, "kimi.exe"), join(shimDir, "devin.exe"));
       } else {
         console.error(`${compiled.stdout ?? ""}${compiled.stderr ?? ""}`);
       }

--- a/test/relay-isolated.mjs
+++ b/test/relay-isolated.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode", "devin"];
 let failed = 0;
 const check = (name, condition) => {
   console.log(`${condition ? "  ok " : "  FAIL"}  ${name}`);

--- a/test/relay-parity.mjs
+++ b/test/relay-parity.mjs
@@ -4,8 +4,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode"];
-const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok", "zcode", "commandcode"];
+const RELAYS = ["claude", "cline", "codex", "opencode", "agy", "grok", "kimi", "qoder", "vibe", "cursor", "pi", "omp", "aider", "copilot", "warp", "zcode", "commandcode", "devin"];
+const READ_ONLY_TRIPWIRE_RELAYS = ["claude", "grok", "zcode", "commandcode", "devin"];
 const SYMBOLS = [
   ["MAX_TIMER_MS", "const", RELAYS],
   ["parseDuration", "function", RELAYS],

--- a/test/relay/devin.mjs
+++ b/test/relay/devin.mjs
@@ -1,0 +1,220 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readArgs(argsFile, win) {
+  if (!existsSync(argsFile)) return [];
+  return win
+    ? readFileSync(argsFile, "utf8").split(/\r?\n/).filter(Boolean)
+    : JSON.parse(readFileSync(argsFile, "utf8"));
+}
+
+export async function runDevin(h) {
+  const workDir = h.freshRepo("work-success-devin");
+
+  const outDir = join(h.scratch, "out-success-devin");
+  const argsFile = join(h.scratch, "args-success-devin");
+  const run = spawnSync(process.execPath, [
+    h.relayPath("devin"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", outDir,
+    "--model", "opus",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "devin-success", SMOKE_ARGS_FILE: argsFile },
+    encoding: "utf8",
+  });
+  const args = readArgs(argsFile, h.WIN);
+  const promptAt = args.indexOf("--prompt-file");
+  const briefViaFile = promptAt !== -1
+    && typeof args[promptAt + 1] === "string"
+    && existsSync(args[promptAt + 1])
+    && readFileSync(args[promptAt + 1], "utf8") === "smoke brief: run until killed.";
+  h.check("devin success: relay exits zero", run.status === 0);
+  h.check("devin success: print mode, prompt-file, and workspace-trust pins are present",
+    args.includes("--print")
+    && briefViaFile
+    && h.pair(args, "--respect-workspace-trust", "false")
+    && h.pair(args, "--permission-mode", "smart")
+    && !args.includes("--sandbox"));
+  h.check("devin success: model is forwarded and no positional prompt is used",
+    h.pair(args, "--model", "opus")
+    && args[args.length - 1] !== "smoke brief: run until killed.");
+  h.check("devin success: result.json exists", existsSync(join(outDir, "result.json")));
+  if (existsSync(join(outDir, "result.json"))) {
+    const value = h.result(outDir);
+    h.check("devin success: ATIF session id and print report are captured",
+      value.status === "completed"
+      && value.exitCode === 0
+      && value.sessionId === "devin-session-1"
+      && value.finalMessage === "fake devin completed"
+      && value.permissionMode === "smart"
+      && value.autonomy === "workspace-write"
+      && Array.isArray(value.touchedFiles)
+      && value.exportPath
+      && existsSync(value.exportPath)
+      && !existsSync(join(outDir, "events.jsonl")));
+  }
+
+  const readOnlyOutDir = join(h.scratch, "out-readonly-devin");
+  const readOnlyArgsFile = join(h.scratch, "args-readonly-devin");
+  const readOnlyRun = spawnSync(process.execPath, [
+    h.relayPath("devin"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", readOnlyOutDir,
+    "--read-only",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "devin-success", SMOKE_ARGS_FILE: readOnlyArgsFile },
+    encoding: "utf8",
+  });
+  const readOnlyArgs = readArgs(readOnlyArgsFile, h.WIN);
+  h.check("devin read-only: maps to --permission-mode normal",
+    readOnlyRun.status === 0
+    && h.pair(readOnlyArgs, "--permission-mode", "normal")
+    && existsSync(join(readOnlyOutDir, "result.json"))
+    && h.result(readOnlyOutDir).autonomy === "read-only"
+    && h.result(readOnlyOutDir).permissionMode === "normal"
+    && h.result(readOnlyOutDir).readOnlyViolation === false);
+
+  const fullOutDir = join(h.scratch, "out-full-access-devin");
+  const fullArgsFile = join(h.scratch, "args-full-access-devin");
+  const fullRun = spawnSync(process.execPath, [
+    h.relayPath("devin"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", fullOutDir,
+    "--full-access",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "devin-success", SMOKE_ARGS_FILE: fullArgsFile },
+    encoding: "utf8",
+  });
+  const fullArgs = readArgs(fullArgsFile, h.WIN);
+  h.check("devin full-access: maps to --permission-mode dangerous",
+    fullRun.status === 0
+    && h.pair(fullArgs, "--permission-mode", "dangerous")
+    && existsSync(join(fullOutDir, "result.json"))
+    && h.result(fullOutDir).autonomy === "full-access"
+    && h.result(fullOutDir).permissionMode === "dangerous");
+
+  const acceptOutDir = join(h.scratch, "out-accept-edits-devin");
+  const acceptArgsFile = join(h.scratch, "args-accept-edits-devin");
+  const acceptRun = spawnSync(process.execPath, [
+    h.relayPath("devin"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", acceptOutDir,
+    "--permission-mode", "accept-edits",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "devin-success", SMOKE_ARGS_FILE: acceptArgsFile },
+    encoding: "utf8",
+  });
+  const acceptArgs = readArgs(acceptArgsFile, h.WIN);
+  h.check("devin permission-mode: accept-edits is forwarded",
+    acceptRun.status === 0
+    && h.pair(acceptArgs, "--permission-mode", "accept-edits")
+    && existsSync(join(acceptOutDir, "result.json"))
+    && h.result(acceptOutDir).permissionMode === "accept-edits");
+
+  const resumeOutDir = join(h.scratch, "out-resume-last-devin");
+  const resumeArgsFile = join(h.scratch, "args-resume-last-devin");
+  const resumeRun = spawnSync(process.execPath, [
+    h.relayPath("devin"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", resumeOutDir,
+    "--resume-last",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "devin-success", SMOKE_ARGS_FILE: resumeArgsFile },
+    encoding: "utf8",
+  });
+  const resumeArgs = readArgs(resumeArgsFile, h.WIN);
+  h.check("devin resume-last: uses documented -c",
+    resumeRun.status === 0
+    && resumeArgs.includes("-c")
+    && !resumeArgs.includes("-r")
+    && existsSync(join(resumeOutDir, "result.json"))
+    && h.result(resumeOutDir).resumeLast === true
+    && h.result(resumeOutDir).sessionId === "devin-session-1");
+
+  const sessionOutDir = join(h.scratch, "out-session-devin");
+  const sessionArgsFile = join(h.scratch, "args-session-devin");
+  const sessionRun = spawnSync(process.execPath, [
+    h.relayPath("devin"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", sessionOutDir,
+    "--session", "indigo-entrance",
+  ], {
+    env: { ...h.baseEnv, SMOKE_MODE: "devin-success", SMOKE_ARGS_FILE: sessionArgsFile },
+    encoding: "utf8",
+  });
+  const sessionArgs = readArgs(sessionArgsFile, h.WIN);
+  h.check("devin session: uses documented -r",
+    sessionRun.status === 0
+    && h.pair(sessionArgs, "-r", "indigo-entrance")
+    && existsSync(join(sessionOutDir, "result.json"))
+    && h.result(sessionOutDir).sessionId === "devin-session-1");
+
+  const invalidOutDir = join(h.scratch, "out-invalid-permission-devin");
+  for (const mode of ["autonomous", "auto", "yolo", "bypass", "banana"]) {
+    const rejected = spawnSync(process.execPath, [
+      h.relayPath("devin"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", invalidOutDir,
+      "--permission-mode", mode,
+    ], { env: h.baseEnv, encoding: "utf8" });
+    h.check(`devin validation: --permission-mode ${mode} is rejected before artifacts`,
+      rejected.status === 2 && !existsSync(invalidOutDir));
+  }
+
+  const conflict = spawnSync(process.execPath, [
+    h.relayPath("devin"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", join(h.scratch, "out-conflict-devin"),
+    "--read-only",
+    "--permission-mode", "smart",
+  ], { env: h.baseEnv, encoding: "utf8" });
+  h.check("devin validation: --read-only conflicts with a write permission mode",
+    conflict.status === 2 && !existsSync(join(h.scratch, "out-conflict-devin")));
+
+  const missingOutDir = join(h.scratch, "out-unavailable-devin");
+  mkdirSync(missingOutDir);
+  writeFileSync(join(missingOutDir, "result.json"), "{\"status\":\"stale\"}\n");
+  writeFileSync(join(missingOutDir, "final.txt"), "stale final\n");
+  const missing = spawnSync(process.execPath, [
+    h.relayPath("devin"),
+    "--brief", h.briefPath,
+    "--cd", workDir,
+    "--out-dir", missingOutDir,
+  ], { env: { ...process.env, PATH: "" }, encoding: "utf8" });
+  h.check("devin unavailable: missing binary writes the structured result",
+    missing.status === 127
+    && existsSync(join(missingOutDir, "result.json"))
+    && h.result(missingOutDir).status === "devin_unavailable"
+    && !existsSync(join(missingOutDir, "final.txt")));
+
+  for (const [mode, expectedStatus, expectedExit] of [
+    ["devin-version-hang", "timeout", 124],
+    ["devin-version-fail", "failed", 7],
+  ]) {
+    const preflightOutDir = join(h.scratch, `out-${mode}`);
+    const preflight = spawnSync(process.execPath, [
+      h.relayPath("devin"),
+      "--brief", h.briefPath,
+      "--cd", workDir,
+      "--out-dir", preflightOutDir,
+      "--timeout", "1s",
+    ], { env: { ...h.baseEnv, SMOKE_MODE: mode }, encoding: "utf8", timeout: 5000 });
+    const preflightResult = existsSync(join(preflightOutDir, "result.json"))
+      ? h.result(preflightOutDir)
+      : {};
+    h.check(`devin preflight: ${mode} is explicit and prevents dispatch`,
+      preflight.status === expectedExit
+      && preflightResult.status === expectedStatus
+      && preflightResult.error?.includes("version preflight")
+      && preflightResult.error?.includes("was not dispatched"));
+  }
+}

--- a/test/relay/devin.mjs
+++ b/test/relay/devin.mjs
@@ -14,6 +14,8 @@ export async function runDevin(h) {
 
   const outDir = join(h.scratch, "out-success-devin");
   const argsFile = join(h.scratch, "args-success-devin");
+  const captureFile = join(h.scratch, "capture-success-devin.json");
+  const preflightEnvFile = join(h.scratch, "preflight-env-success-devin.json");
   const run = spawnSync(process.execPath, [
     h.relayPath("devin"),
     "--brief", h.briefPath,
@@ -21,7 +23,15 @@ export async function runDevin(h) {
     "--out-dir", outDir,
     "--model", "opus",
   ], {
-    env: { ...h.baseEnv, SMOKE_MODE: "devin-success", SMOKE_ARGS_FILE: argsFile },
+    env: {
+      ...h.baseEnv,
+      SMOKE_MODE: "devin-success",
+      SMOKE_ARGS_FILE: argsFile,
+      SMOKE_CAPTURE_FILE: captureFile,
+      SMOKE_DEVIN_PREFLIGHT_ENV_FILE: preflightEnvFile,
+      WINDSURF_API_KEY: "bogus-windsurf-key",
+      SMOKE_SECRET_TOKEN: "must-survive",
+    },
     encoding: "utf8",
   });
   const args = readArgs(argsFile, h.WIN);
@@ -54,6 +64,18 @@ export async function runDevin(h) {
       && value.exportPath
       && existsSync(value.exportPath)
       && !existsSync(join(outDir, "events.jsonl")));
+  }
+  h.check("devin success: fake captured the child environment", existsSync(captureFile));
+  if (existsSync(captureFile)) {
+    const capture = JSON.parse(readFileSync(captureFile, "utf8"));
+    h.check("devin success: inherited WINDSURF_API_KEY removed", capture.windsurfApiKey === null);
+    h.check("devin success: unrelated environment entries preserved", capture.smokeSecretToken === "must-survive");
+  }
+  h.check("devin success: fake captured the preflight environment", existsSync(preflightEnvFile));
+  if (existsSync(preflightEnvFile)) {
+    const preflight = JSON.parse(readFileSync(preflightEnvFile, "utf8"));
+    h.check("devin success: preflight WINDSURF_API_KEY removed", preflight.windsurfApiKey === null);
+    h.check("devin success: preflight sentinel preserved", preflight.smokeSecretToken === "must-survive");
   }
 
   const readOnlyOutDir = join(h.scratch, "out-readonly-devin");

--- a/test/relay/index.mjs
+++ b/test/relay/index.mjs
@@ -20,6 +20,7 @@ import { runAider } from "./aider.mjs";
 import { runCopilot } from "./copilot.mjs";
 import { runCommandcode } from "./commandcode.mjs";
 import { runZcode } from "./zcode.mjs";
+import { runDevin } from "./devin.mjs";
 
 export const runners = [
   ["package-shape", runPackageShape],
@@ -43,5 +44,6 @@ export const runners = [
   ["timeout-tree", runTimeoutTree],
   ["abort", runAbort],
   ["zcode", runZcode],
+  ["devin", runDevin],
   ["delegate-setup", runDelegateSetup],
 ];

--- a/test/relay/timeout-tree.mjs
+++ b/test/relay/timeout-tree.mjs
@@ -18,6 +18,7 @@ const TIMEOUT_CASES = [
   { skill: "agy", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "aider", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
   { skill: "warp", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
+  { skill: "devin", flags: ["--timeout", "6s"], exitDeadline: 45_000 },
 ];
 async function driveTimeout({ skill, flags, exitDeadline }, mode, extraEnv, tag) {
   const outDir = join(h.scratch, `out-${tag}-${skill}`);


### PR DESCRIPTION
## Summary

Adds `devin-delegate`, the eighteenth implementer skill, delegating to the local Devin CLI (`devin`, Cognition's terminal agent — not Devin Cloud).

- `skills/devin-delegate/` — `SKILL.md`, `scripts/relay.mjs`, and the four references, modeled on `grok-delegate` (shared helpers kept byte-identical for `relay-parity`).
- Relay launches `devin --print --respect-workspace-trust false --permission-mode <mode> --export <out>/session.atif.json --prompt-file <brief>`:
  - default → `--permission-mode smart` (workspace edits auto; clearly-safe shell/fetch auto — the only write-capable mode that still gates installs/mutating-git/rm headlessly)
  - `--read-only` → `--permission-mode normal` (headless `normal` rejects writes *and* exec at the tool boundary — real enforcement, with the git tripwire still reported)
  - `--full-access` → `--permission-mode dangerous`; canonical names only (`autonomous`/`auto`/`yolo`/`bypass` rejected with reasons)
  - `--sandbox` is never passed: it forces `autonomous`, where edit/write tools still prompt — broken under `--print`.
  - Session id is parsed from the ATIF export's `session_id`; resume via `--resume-last` (`-c`) / `--session <id>` (`-r`). Plain stdout is the final report — no event stream.
- delegate-setup: `devin` registry entry (auth probe via `devin auth status`; `modelProbe`/`usageProbe` null — `sessions.db` is sqlite), `DEVIN_PERMISSION` dial set, `readOnly` → `permissionMode: normal` lane normalization.
- Registered in `skills.sh.json`, the smoke matrix (`SKILLS`/`EXTRA_ARGS`), `relay-parity` (incl. `READ_ONLY_TRIPWIRE_RELAYS`), `relay-isolated`, `test/relay/index.mjs`, `install-shim` (native `.exe` on Windows), plus `devin-success` fixtures in `fake-cli.cjs`/`.cs` and a `test/relay/devin.mjs` module (argv pins, mode mapping, validation rejections, 127 contract, preflight bounds).
- README table row + `[^devin]` footnote + verification line; AGENTS.md implementer list, count, vocabulary row, and native-binary sentence.

## Verification

Ran on macOS against `devin` 3000.10.21:

- `node test/relay-parity.mjs` — pass (all shared helpers byte-identical)
- `node test/relay-isolated.mjs` — pass (incl. `devin: isolated --help`)
- `npx skills add . --list` — pass, `devin-delegate` listed (19 skills)
- `node test/relay-smoke.mjs` — all `devin` checks pass, plus the shared matrix (timeout, abort, unavailable, package shape). One deterministic pre-existing failure reproduced on `upstream/master`: `commandcode snapshot abort` (also fails there); three abort-check flakes under full-suite load (`cursor`/`vibe`/`copilot` preflight abort) pass on isolated re-run.
- Live run: relay dispatch against a throwaway git repo wrote `probe.txt` (`status: completed`, `permissionMode: smart`, ATIF `sessionId` captured); a `--resume-last` delta brief resumed the same session and appended a line.

Not verified: native Windows (docs route Windows through WSL; noted in README/SKILL.md).
